### PR TITLE
Rishabh/dx fixes

### DIFF
--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -70,7 +70,10 @@ class Defog:
                         self.api_key = data["api_key"]
                         self.db_type = data["db_type"]
                         self.db_creds = data["db_creds"]
-                        self.generate_query_url = data.get("generate_query_url", "https://api.defog.ai/generate_query_chat")
+                        self.generate_query_url = data.get(
+                            "generate_query_url",
+                            "https://api.defog.ai/generate_query_chat",
+                        )
                         print(f"Connection details read from {self.filepath}.")
                     else:
                         raise KeyError(
@@ -83,7 +86,7 @@ class Defog:
                     self.api_key = api_key
                 if db_type != "":
                     self.db_type = db_type
-                
+
                 self.generate_query_url = generate_query_url
                 self.db_creds = db_creds
                 self.check_db_creds(self.db_type, self.db_creds)
@@ -102,7 +105,7 @@ class Defog:
                     "api_key": self.api_key,
                     "db_type": self.db_type,
                     "db_creds": self.db_creds,
-                    "generate_query_url": self.generate_query_url
+                    "generate_query_url": self.generate_query_url,
                 },
                 f,
                 indent=4,

--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -43,8 +43,6 @@ class Defog:
         4) config file present, no params -> read params from config file
         5) config file present, some/all params -> ignore existing config file, save new params to config file
         """
-        self.generate_query_url = generate_query_url
-
         if base64creds != "":
             self.from_base64_creds(base64creds)
             return
@@ -57,7 +55,7 @@ class Defog:
             self.api_key = api_key
             self.db_type = db_type
             self.db_creds = db_creds
-            data = {"api_key": api_key, "db_type": db_type, "db_creds": db_creds}
+            self.generate_query_url = generate_query_url
             # write to filepath and print confirmation
             if save_json:
                 self.save_connection_json()
@@ -72,6 +70,7 @@ class Defog:
                         self.api_key = data["api_key"]
                         self.db_type = data["db_type"]
                         self.db_creds = data["db_creds"]
+                        self.generate_query_url = data.get("generate_query_url", "https://api.defog.ai/generate_query_chat")
                         print(f"Connection details read from {self.filepath}.")
                     else:
                         raise KeyError(
@@ -84,6 +83,8 @@ class Defog:
                     self.api_key = api_key
                 if db_type != "":
                     self.db_type = db_type
+                
+                self.generate_query_url = generate_query_url
                 self.db_creds = db_creds
                 self.check_db_creds(self.db_type, self.db_creds)
                 if save_json:
@@ -101,6 +102,7 @@ class Defog:
                     "api_key": self.api_key,
                     "db_type": self.db_type,
                     "db_creds": self.db_creds,
+                    "generate_query_url": self.generate_query_url
                 },
                 f,
                 indent=4,

--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -217,7 +217,9 @@ class Defog:
             print(message)
             return True
 
-    def generate_postgres_schema(self, tables: list, upload: bool = True, return_format: str = "gsheets") -> str:
+    def generate_postgres_schema(
+        self, tables: list, upload: bool = True, return_format: str = "gsheets"
+    ) -> str:
         # when upload is True, we send the schema to the defog servers and generate a Google Sheet
         # when its false, we return the schema as a dict
         try:
@@ -336,7 +338,9 @@ class Defog:
         else:
             return schemas
 
-    def generate_redshift_schema(self, tables: list, upload: bool = True, return_format: str = "gsheets") -> str:
+    def generate_redshift_schema(
+        self, tables: list, upload: bool = True, return_format: str = "gsheets"
+    ) -> str:
         # when upload is True, we send the schema to the defog servers and generate a Google Sheet
         # when its false, we return the schema as a dict
         try:
@@ -465,7 +469,9 @@ class Defog:
         else:
             return schemas
 
-    def generate_mysql_schema(self, tables: list, upload: bool = True, return_format: str = "gsheets") -> str:
+    def generate_mysql_schema(
+        self, tables: list, upload: bool = True, return_format: str = "gsheets"
+    ) -> str:
         try:
             import mysql.connector
         except:
@@ -535,7 +541,9 @@ class Defog:
         else:
             return schemas
 
-    def generate_snowflake_schema(self, tables: list, upload: bool = True, return_format: str = "gsheets") -> str:
+    def generate_snowflake_schema(
+        self, tables: list, upload: bool = True, return_format: str = "gsheets"
+    ) -> str:
         try:
             import snowflake.connector
         except:
@@ -620,7 +628,9 @@ class Defog:
         else:
             return schemas
 
-    def generate_bigquery_schema(self, tables: list, upload: bool = True, return_format: str = "gsheets") -> str:
+    def generate_bigquery_schema(
+        self, tables: list, upload: bool = True, return_format: str = "gsheets"
+    ) -> str:
         try:
             from google.cloud import bigquery
         except:

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -197,7 +197,7 @@ def init():
         print(f"\033[1m{filename}\033[0m\n")
 
     print(
-        "You can give us more context about your schema at the above link. Once you're done, you can just hit enter to upload the data in this URL to Defog. If you would like to exit instead, just enter `exit`."
+        "You can give us more context about your schema by editing the CSV above. Once you're done, you can just hit enter to upload the data in the spreadsheet to Defog. If you would like to exit instead, just enter `exit`."
     )
     upload_option = prompt()
     if upload_option == "exit":
@@ -257,12 +257,14 @@ def gen():
         table_name_list = re.split(r"\s+", table_names.strip())
     else:
         table_name_list = sys.argv[2:]
-    gsheets_url = df.generate_db_schema(table_name_list)
-    print("Your schema has been generated and is available at:\n")
-    print(f"\033[1m{gsheets_url}\033[0m\n")
+    filename = df.generate_db_schema(table_name_list)
+    print(
+        "Your schema has been generated and is available at the following CSV file in this folder:\n"
+    )
+    print(f"\033[1m{filename}\033[0m\n")
 
     print("We are now uploading this auto-generated schema to Defog.")
-    df.update_db_schema(gsheets_url)
+    df.update_db_schema_csv(filename)
 
     print(
         "If you modify the auto-generated schema, please run `defog update <csv_filename>` again to refresh the schema on Defog's servers."

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -258,8 +258,12 @@ def gen():
     gsheets_url = df.generate_db_schema(table_name_list)
     print("Your schema has been generated and is available at:\n")
     print(f"\033[1m{gsheets_url}\033[0m\n")
+
+    print("We are now uploading this auto-generated schema to Defog.")
+    df.update_db_schema(gsheets_url)
+
     print(
-        "If you do modify the schema in the link provided, please run `defog update <url>` to update the updated schema."
+        "If you modify the auto-generated schema, please run `defog update <url>` again to refresh the schema on Defog's servers."
     )
 
 
@@ -363,16 +367,23 @@ def query():
             user_question = query
             resp = df.run_query(query, retries=3)
             if not resp["ran_successfully"]:
-                print("Defog generated the following query to answer your question:\n")
-                print(f"\033[1m{resp['query_generated']}\033[0m\n")
+                if "query_generated" in resp:
+                    print(
+                        "Defog generated the following query to answer your question:\n"
+                    )
+                    print(f"\033[1m{resp['query_generated']}\033[0m\n")
 
-                print(
-                    f"However, your query did not run successfully. The error message generated while running the query on your database was\n\n\033[1m{resp['error_message']}\033[0m\n."
-                )
+                    print(
+                        f"However, your query did not run successfully. The error message generated while running the query on your database was\n\n\033[1m{resp['error_message']}\033[0m\n."
+                    )
 
-                print(
-                    f"If you continue to get these errors, please consider updating the metadata in your schema by editing the google sheet generated and running `defog update <url>`, or by updating your glossary.\n"
-                )
+                    print(
+                        f"If you continue to get these errors, please consider updating the metadata in your schema by editing the google sheet generated and running `defog update <url>`, or by updating your glossary.\n"
+                    )
+                else:
+                    print(
+                        f"Defog was unable to generate a query for your question. The error message generated while running the query on your database was\n\n\033[1m{resp.get('error_message')}\033[0m\n."
+                    )
                 query = prompt("Enter another query, or type 'e' to exit: ")
             else:
                 sql_generated = resp.get("query_generated")

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -191,7 +191,7 @@ def init():
     else:
         df = defog.Defog(api_key=api_key, db_type=db_type, db_creds=db_creds)
         filename = df.generate_db_schema(table_name_list)
-        print("Your schema has been generated and is available at:\n")
+        print("Your schema has been generated and is available as a CSV file in this folder at:\n")
         print(f"\033[1m{filename}\033[0m\n")
 
     print(

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -191,7 +191,9 @@ def init():
     else:
         df = defog.Defog(api_key=api_key, db_type=db_type, db_creds=db_creds)
         filename = df.generate_db_schema(table_name_list)
-        print("Your schema has been generated and is available as a CSV file in this folder at:\n")
+        print(
+            "Your schema has been generated and is available as a CSV file in this folder at:\n"
+        )
         print(f"\033[1m{filename}\033[0m\n")
 
     print(

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -190,9 +190,9 @@ def init():
         sys.exit(0)
     else:
         df = defog.Defog(api_key=api_key, db_type=db_type, db_creds=db_creds)
-        gsheets_url = df.generate_db_schema(table_name_list)
+        filename = df.generate_db_schema(table_name_list)
         print("Your schema has been generated and is available at:\n")
-        print(f"\033[1m{gsheets_url}\033[0m\n")
+        print(f"\033[1m{filename}\033[0m\n")
 
     print(
         "You can give us more context about your schema at the above link. Once you're done, you can just hit enter to upload the data in this URL to Defog. If you would like to exit instead, just enter `exit`."
@@ -202,7 +202,7 @@ def init():
         print("Exiting.")
         sys.exit(0)
     else:
-        resp = df.update_db_schema(gsheets_url)
+        resp = df.update_db_schema_csv(filename)
         if resp["status"] == "success":
             print("Your schema has been updated. You're ready to start querying!")
         else:
@@ -263,7 +263,7 @@ def gen():
     df.update_db_schema(gsheets_url)
 
     print(
-        "If you modify the auto-generated schema, please run `defog update <url>` again to refresh the schema on Defog's servers."
+        "If you modify the auto-generated schema, please run `defog update <csv_filename>` again to refresh the schema on Defog's servers."
     )
 
 

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -278,15 +278,15 @@ def update():
     # check for 3rd arg (url), if not there, prompt user for url
     if len(sys.argv) < 3:
         print(
-            "defog update requires a google sheets url. Please enter the url of the google sheets document you would like to update:"
+            "defog update requires a CSV that contains your Database metadata. Please enter the path to the CSV you would like to update:"
         )
-        gsheets_url = prompt()
+        filename = prompt()
     else:
-        gsheets_url = sys.argv[2]
+        filename = sys.argv[2]
     # load config from .defog/connection.json
     df = defog.Defog()
     # upload schema to defog
-    resp = df.update_db_schema(gsheets_url)
+    resp = df.update_db_schema_csv(filename)
     if resp["status"] == "success":
         print("Your schema has been updated. You're ready to start querying!")
     else:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"]},
-    version="0.52.0",
+    version="0.52.2",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
This PR does 3 things:
1. instead of generating the initial schema in google sheets, we now generate it locally and save it as a CSV
2. the initial schema generated is now saved to Defog's servers by default – instead of a user having to manually upload it using the `defog update` method
3. if a user (like an enterprise user) is has a custom `generate_query_url`, it is now persisted in connection.json