### PR TITLE
Checks for likely categorical variables in databases 

### DIFF
--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -6,7 +6,7 @@ import pandas as pd
 from defog.query import execute_query
 from importlib.metadata import version
 from io import StringIO
-from util import identify_categorical_columns
+from defog.util import identify_categorical_columns
 
 try:
     __version__ = version("defog")

--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -208,6 +208,26 @@ class Defog:
             rows = cur.fetchall()
             rows = [row for row in rows]
             rows = [{"column_name": i[0], "data_type": i[1]} for i in rows]
+
+            # loop through each column, look at whether it is a string column, and then determine if it might be a categorical variable
+            # if it is a categorical variable, then we want to get the distinct values and their counts
+            # we will then send this to the defog servers so that we can generate a column description
+            # for each categorical variable
+            for idx, row in enumerate(rows):
+                if row["data_type"] in ["character varying", "text", "character"]:
+                    # get the total number of rows and number of distinct values in the table for this column
+                    cur.execute(f"SELECT COUNT({row['column_name']}) as tot_count, COUNT(DISTINCT {row['column_name']}) AS unique_count FROM {table_name};")
+                    total_rows, num_distinct_values = cur.fetchone()
+
+                    if num_distinct_values <= 10:
+                        # get the top 10 distinct values
+                        cur.execute(
+                            f"SELECT {row['column_name']}, COUNT({row['column_name']}) AS col_count FROM {table_name} GROUP BY {row['column_name']} ORDER BY col_count DESC LIMIT 10;"
+                        )
+                        top_values = cur.fetchall()
+                        top_values = [i[0] for i in top_values if i[0] is not None]
+                        rows[idx]["top_values"] = top_values
+            
             schemas[table_name] = rows
 
         # get foreign key relationships

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -1,6 +1,6 @@
 import datetime
 import decimal
-import getpass
+import pwinput
 import json
 import os
 import re
@@ -121,7 +121,7 @@ def init():
         database = prompt().strip()
         print("Please enter your database user:")
         user = prompt().strip()
-        password = getpass.getpass(prompt="Please enter your database password:")
+        password = pwinput.pwinput(prompt="Please enter your database password. This won't be displayed as you're typing for privacy reasons")
         db_creds = {
             "host": host,
             "port": port,
@@ -138,7 +138,7 @@ def init():
         print("Please enter your database user:")
         user = prompt().strip()
         print("Please enter your database password:")
-        password = getpass.getpass(prompt="Please enter your database password:")
+        password = pwinput.pwinput(prompt="Please enter your database password:")
         db_creds = {
             "host": host,
             "database": database,
@@ -153,7 +153,7 @@ def init():
         print("Please enter your database user:")
         user = prompt().strip()
         print("Please enter your database password:")
-        password = getpass.getpass(prompt="Please enter your database password:")
+        password = pwinput.pwinput(prompt="Please enter your database password:")
         db_creds = {
             "account": account,
             "warehouse": warehouse,
@@ -163,7 +163,7 @@ def init():
     elif db_type == "databricks":
         print("Please enter your databricks host:")
         host = prompt().strip()
-        token = getpass.getpass(prompt="Please enter your databricks token:")
+        token = pwinput.pwinput(prompt="Please enter your databricks token:")
         print("Please add your http_path:")
         http_path = prompt().strip()
         print("Please enter your schema name (this is usually 'default'):")

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -94,9 +94,9 @@ def init():
         )
         api_key = os.environ.get("DEFOG_API_KEY")
     else:
-        api_key = getpass.getpass(
-            prompt="Please enter your DEFOG_API_KEY. You can get it from https://defog.ai/accounts/dashboard/ and creating an account:"
-        )
+        print("Please enter your DEFOG_API_KEY. You can get it from https://defog.ai/accounts/dashboard/ and creating an account:")
+        api_key = prompt()
+        
     # prompt user for db_type
     print(
         "What database are you using? Available options are: "

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -159,7 +159,6 @@ def init():
         warehouse = prompt().strip()
         print("Please enter your database user:")
         user = prompt().strip()
-        print("Please enter your database password:")
         password = pwinput.pwinput(prompt="Please enter your database password:")
         db_creds = {
             "account": account,

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -212,13 +212,14 @@ def init():
         print(f"\033[1m{filename}\033[0m\n")
 
     print(
-        "You can give us more context about your schema by editing the CSV above. Once you're done, you can just hit enter to upload the data in the spreadsheet to Defog. If you would like to exit instead, just enter `exit`."
+        "You can give us more context about your schema by editing the CSV above. Refer to our cookbook on how to do this here: https://defog.notion.site/Cookbook-for-schema-definitions-1650a6855ea447fdb0be75d39975571b#2ba1d37e243e4da3b8f17590b4a3e4e3.\n\nOnce you're done, you can just hit enter to upload the data in the spreadsheet to Defog. If you would like to exit instead, just enter `exit`."
     )
     upload_option = prompt().strip()
     if upload_option == "exit":
         print("Exiting.")
         sys.exit(0)
     else:
+        print("We are now uploading this schema to Defog. This might take up to 30 seconds...")
         resp = df.update_db_schema_csv(filename)
         if resp["status"] == "success":
             print("Your schema has been updated. You're ready to start querying!")

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -94,9 +94,11 @@ def init():
         )
         api_key = os.environ.get("DEFOG_API_KEY")
     else:
-        print("Please enter your DEFOG_API_KEY. You can get it from https://defog.ai/accounts/dashboard/ and creating an account:")
+        print(
+            "Please enter your DEFOG_API_KEY. You can get it from https://defog.ai/accounts/dashboard/ and creating an account:"
+        )
         api_key = prompt().strip()
-        
+
     # prompt user for db_type
     print(
         "What database are you using? Available options are: "
@@ -124,7 +126,9 @@ def init():
         database = prompt().strip()
         print("Please enter your database user:")
         user = prompt().strip()
-        password = pwinput.pwinput(prompt="Please enter your database password. This won't be displayed as you're typing for privacy reasons")
+        password = pwinput.pwinput(
+            prompt="Please enter your database password. This won't be displayed as you're typing for privacy reasons"
+        )
         db_creds = {
             "host": host,
             "port": port,
@@ -219,7 +223,9 @@ def init():
         print("Exiting.")
         sys.exit(0)
     else:
-        print("We are now uploading this schema to Defog. This might take up to 30 seconds...")
+        print(
+            "We are now uploading this schema to Defog. This might take up to 30 seconds..."
+        )
         resp = df.update_db_schema_csv(filename)
         if resp["status"] == "success":
             print("Your schema has been updated. You're ready to start querying!")

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -115,6 +115,9 @@ def init():
     if db_type == "postgres" or db_type == "redshift":
         print("Please enter your database host:")
         host = prompt().strip()
+        # check if host has http:// or https:// and remove it if it does
+        if host.startswith("http://") or host.startswith("https://"):
+            host = host.split("://")[1]
         print("Please enter your database port:")
         port = prompt().strip()
         print("Please enter your database name:")

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -76,7 +76,7 @@ def init():
         print(
             "It looks like you've already initialized defog. Do you want to overwrite your existing configuration? (y/n)"
         )
-        overwrite = prompt()
+        overwrite = prompt().strip()
         if overwrite.lower() != "y":
             print("We'll keep your existing config. No changes were made.")
             sys.exit(0)
@@ -95,32 +95,32 @@ def init():
         api_key = os.environ.get("DEFOG_API_KEY")
     else:
         print("Please enter your DEFOG_API_KEY. You can get it from https://defog.ai/accounts/dashboard/ and creating an account:")
-        api_key = prompt()
+        api_key = prompt().strip()
         
     # prompt user for db_type
     print(
         "What database are you using? Available options are: "
         + ", ".join(defog.SUPPORTED_DB_TYPES)
     )
-    db_type = prompt()
+    db_type = prompt().strip()
     db_type = db_type.lower()
     while db_type not in defog.SUPPORTED_DB_TYPES:
         print(
             "Sorry, we don't support that database yet. Available options are: "
             + ", ".join(defog.SUPPORTED_DB_TYPES)
         )
-        db_type = prompt()
+        db_type = prompt().strip()
         db_type = db_type.lower()
     # depending on db_type, prompt user for appropriate db_creds
     if db_type == "postgres" or db_type == "redshift":
         print("Please enter your database host:")
-        host = prompt()
+        host = prompt().strip()
         print("Please enter your database port:")
-        port = prompt()
+        port = prompt().strip()
         print("Please enter your database name:")
-        database = prompt()
+        database = prompt().strip()
         print("Please enter your database user:")
-        user = prompt()
+        user = prompt().strip()
         password = getpass.getpass(prompt="Please enter your database password:")
         db_creds = {
             "host": host,
@@ -132,11 +132,11 @@ def init():
 
     elif db_type == "mysql":
         print("Please enter your database host:")
-        host = prompt()
+        host = prompt().strip()
         print("Please enter your database name:")
-        database = prompt()
+        database = prompt().strip()
         print("Please enter your database user:")
-        user = prompt()
+        user = prompt().strip()
         print("Please enter your database password:")
         password = getpass.getpass(prompt="Please enter your database password:")
         db_creds = {
@@ -147,11 +147,11 @@ def init():
         }
     elif db_type == "snowflake":
         print("Please enter your database account:")
-        account = prompt()
+        account = prompt().strip()
         print("Please enter your database warehouse:")
-        warehouse = prompt()
+        warehouse = prompt().strip()
         print("Please enter your database user:")
-        user = prompt()
+        user = prompt().strip()
         print("Please enter your database password:")
         password = getpass.getpass(prompt="Please enter your database password:")
         db_creds = {
@@ -162,12 +162,12 @@ def init():
         }
     elif db_type == "databricks":
         print("Please enter your databricks host:")
-        host = prompt()
+        host = prompt().strip()
         token = getpass.getpass(prompt="Please enter your databricks token:")
         print("Please add your http_path:")
-        http_path = prompt()
+        http_path = prompt().strip()
         print("Please enter your schema name (this is usually 'default'):")
-        schema = prompt()
+        schema = prompt().strip()
         db_creds = {
             "server_hostname": host,
             "access_token": token,
@@ -176,7 +176,7 @@ def init():
         }
     elif db_type == "bigquery":
         print("Please enter your bigquery json key's path:")
-        json_key_path = prompt()
+        json_key_path = prompt().strip()
         db_creds = {
             "json_key_path": json_key_path,
         }
@@ -194,7 +194,7 @@ def init():
     print(
         "Please enter the names of the tables you would like to register, separated by a space:"
     )
-    table_names = prompt()
+    table_names = prompt().strip()
     table_name_list = re.split(r"\s+", table_names.strip())
     # if input is empty, exit
     if table_name_list == [""]:
@@ -211,7 +211,7 @@ def init():
     print(
         "You can give us more context about your schema by editing the CSV above. Once you're done, you can just hit enter to upload the data in the spreadsheet to Defog. If you would like to exit instead, just enter `exit`."
     )
-    upload_option = prompt()
+    upload_option = prompt().strip()
     if upload_option == "exit":
         print("Exiting.")
         sys.exit(0)
@@ -265,7 +265,7 @@ def gen():
         print(
             "If you would like to index all of your tables, just leave this blank and hit enter (Supported for postgres + redshift only)."
         )
-        table_names = prompt()
+        table_names = prompt().strip()
         table_name_list = re.split(r"\s+", table_names.strip())
     else:
         table_name_list = sys.argv[2:]
@@ -292,7 +292,7 @@ def update():
         print(
             "defog update requires a CSV that contains your Database metadata. Please enter the path to the CSV you would like to update:"
         )
-        filename = prompt()
+        filename = prompt().strip()
     else:
         filename = sys.argv[2]
     # load config from .defog/connection.json
@@ -314,7 +314,7 @@ def query():
     df = defog.Defog()  # load config from .defog/connection.json
     if len(sys.argv) < 3:
         print("defog query requires a query. Please enter your query:")
-        query = prompt()
+        query = prompt().strip()
     else:
         query = sys.argv[2]
 
@@ -432,7 +432,7 @@ def deploy():
     # check args for gcp or aws
     if len(sys.argv) < 3:
         print("defog deploy requires a cloud provider. Please enter 'gcp' or 'aws':")
-        cloud_provider = prompt().lower()
+        cloud_provider = prompt().strip().lower()
     else:
         cloud_provider = sys.argv[2].lower()
 

--- a/defog/util.py
+++ b/defog/util.py
@@ -69,8 +69,9 @@ def identify_categorical_columns(
     # if it is a categorical variable, then we want to get the distinct values and their counts
     # we will then send this to the defog servers so that we can generate a column description
     # for each categorical variable
+    print(f"Identifying categorical columns in {table_name}...")
     for idx, row in enumerate(rows):
-        if row["data_type"] in ["character varying", "text", "character"]:
+        if row["data_type"].lower() in ["character varying", "text", "character", "varchar", "char"]:
             # get the total number of rows and number of distinct values in the table for this column
             cur.execute(f"SELECT COUNT({row['column_name']}) as tot_count, COUNT(DISTINCT {row['column_name']}) AS unique_count FROM {table_name};")
             total_rows, num_distinct_values = cur.fetchone()

--- a/defog/util.py
+++ b/defog/util.py
@@ -49,11 +49,12 @@ def write_logs(msg: str) -> None:
     except Exception as e:
         pass
 
+
 def identify_categorical_columns(
-        cur, # a cursor object for any database
-        table_name: str,
-        rows: list,
-    ):
+    cur,  # a cursor object for any database
+    table_name: str,
+    rows: list,
+):
     """
     Identify categorical columns in the table and return the top 10 distinct values for each column.
 
@@ -61,7 +62,7 @@ def identify_categorical_columns(
         cur (cursor): A cursor object for any database.
         table_name (str): The name of the table.
         rows (list): A list of dictionaries containing the column names and data types.
-    
+
     Returns:
         rows (list): The updated list of dictionaries containing the column names, data types and top 10 distinct values.
     """
@@ -71,9 +72,17 @@ def identify_categorical_columns(
     # for each categorical variable
     print(f"Identifying categorical columns in {table_name}...")
     for idx, row in enumerate(rows):
-        if row["data_type"].lower() in ["character varying", "text", "character", "varchar", "char"]:
+        if row["data_type"].lower() in [
+            "character varying",
+            "text",
+            "character",
+            "varchar",
+            "char",
+        ]:
             # get the total number of rows and number of distinct values in the table for this column
-            cur.execute(f"SELECT COUNT({row['column_name']}) as tot_count, COUNT(DISTINCT {row['column_name']}) AS unique_count FROM {table_name};")
+            cur.execute(
+                f"SELECT COUNT({row['column_name']}) as tot_count, COUNT(DISTINCT {row['column_name']}) AS unique_count FROM {table_name};"
+            )
             total_rows, num_distinct_values = cur.fetchone()
 
             if num_distinct_values <= 10:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests>=2.28.2
 psycopg2-binary>=2.9.5
 pandas
 tabulate
+pwinput

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.54.6",
+    version="0.55.1",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
**Motivation**:  While we have specific instructions in the metadata cookbook for users to enumerate categorical variables in the generated schema, in reality, few users manually made these changes. This would lead to errors when users later generated queries. 

**Changes made**: 
To make this process smoother, we can automatically highlight any columns that are likely to be categorical variables and enumerate possible values in the column descriptions. To do this:

1. We define indicators that a column has categorical variables. We looked at two approaches: 
(a) whether the ratio of unique values to total values in a column is below a certain cutoff (eg, 2%). While this works for a smaller number of rows, it did not make sense for larger numbers of rows. For eg, a column with 10000 total values and 200 unique values would be classified as categorical value. In reality, this is unlikely to be the case. 

(b) whether the number of unique values in a column is below a certain cutoff (eg, 10). This works reasonably well across smaller and larger numbers of rows.

Hence, we went with approach (b).

2. We extract the values of these categorical variables so they can be appended to the column description in the generated schema.

**Future improvement**:
A future improvement could be to use approach (a) for fewer rows and (b) for larger number of rows - with the cutoff for number of rows to be determined.