### PR TITLE
[Bug Fix] Fixed issue when getting excessively long column values with unexpected characters.

### DIFF
--- a/defog/util.py
+++ b/defog/util.py
@@ -53,21 +53,50 @@ def write_logs(msg: str) -> None:
         pass
 
 
+def is_str_type(data_type: str) -> bool:
+    """
+    Check if the given data_type is a string type.
+
+    Args:
+        data_type (str): The data_type to check.
+
+    Returns:
+        bool: True if the data_type is a string type, False otherwise.
+    """
+    return data_type.lower().strip() in {
+        "character varying",
+        "text",
+        "character",
+        "varchar",
+        "char",
+        "string",
+    }
+
+
 def identify_categorical_columns(
     cur,  # a cursor object for any database
     table_name: str,
     rows: list,
+    distinct_threshold: int = 10,
+    character_length_threshold: int = 50,
 ):
     """
-    Identify categorical columns in the table and return the top 10 distinct values for each column.
+    Identify categorical columns in the table and return the top distinct values for each column.
 
     Args:
-        cur (cursor): A cursor object for any database.
+        cur (cursor): A cursor object for any database. This cursor should support the following methods:
+            - execute(sql, params)
+            - fetchone()
+            - fetchall()
         table_name (str): The name of the table.
-        rows (list): A list of dictionaries containing the column names and data types.
+        rows (list): A list of dictionaries containing the column names and data types.a
+        distinct_threshold (int): The threshold for the number of distinct values in a column to be considered categorical.
+        character_length_threshold (int): The threshold for the maximum length of a string column to be considered categorical.
+          This is a heuristic for pruning columns that might contain arbitrarily long strings like json / configs.
 
     Returns:
-        rows (list): The updated list of dictionaries containing the column names, data types and top 10 distinct values.
+        rows (list): The updated list of dictionaries containing the column names, data types and top distinct values.
+          The list is modified in-place.
     """
     # loop through each column, look at whether it is a string column, and then determine if it might be a categorical variable
     # if it is a categorical variable, then we want to get the distinct values and their counts
@@ -77,33 +106,28 @@ def identify_categorical_columns(
         f"Identifying categorical columns in {table_name}. This might take a while if you have many rows in your table."
     )
     for idx, row in enumerate(rows):
-        if row["data_type"].lower().strip() in [
-            "character varying",
-            "text",
-            "character",
-            "varchar",
-            "char",
-            "string",
-        ]:
+        if is_str_type(row["data_type"]):
             # get the total number of rows and number of distinct values in the table for this column
+            column_name = row["column_name"]
             cur.execute(
-                f"SELECT COUNT(DISTINCT {row['column_name']}) AS unique_count FROM {table_name};"
+                f"""SELECT COUNT(DISTINCT {column_name}) AS unique_count FROM {table_name} WHERE LENGTH({column_name}) < %s;""",
+                (character_length_threshold,),
             )
             try:
                 num_distinct_values = cur.fetchone()[0]
-            except:
+            except Exception as e:
                 num_distinct_values = 0
-
-            if num_distinct_values <= 10 and num_distinct_values > 0:
-                # get the top 10 distinct values
+            if num_distinct_values <= distinct_threshold and num_distinct_values > 0:
+                # get the top distinct_threshold distinct values
                 cur.execute(
-                    f"SELECT {row['column_name']}, COUNT({row['column_name']}) AS col_count FROM {table_name} GROUP BY {row['column_name']} ORDER BY col_count DESC LIMIT 10;"
+                    f"""SELECT {column_name}, COUNT({column_name}) AS col_count FROM {table_name} GROUP BY {column_name} ORDER BY col_count DESC LIMIT %s;""",
+                    (distinct_threshold,),
                 )
                 top_values = cur.fetchall()
                 top_values = [i[0] for i in top_values if i[0] is not None]
-                rows[idx]["top_values"] = ",".join(top_values)
+                rows[idx]["top_values"] = ",".join(sorted(top_values))
                 print(
-                    f"Identified {row['column_name']} as a likely categorical column. The unique values are: {top_values}"
+                    f"Identified {column_name} as a likely categorical column. The unique values are: {top_values}"
                 )
     return rows
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.58.0",
+    version="0.60.0",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,7 +1,6 @@
 import unittest
-from unittest.mock import patch
-
-from defog.util import parse_update, get_feedback
+from unittest.mock import Mock, MagicMock, patch
+from defog.util import identify_categorical_columns, parse_update, get_feedback
 
 
 class TestParseUpdate(unittest.TestCase):
@@ -41,6 +40,69 @@ class TestParseUpdate(unittest.TestCase):
         self.assertEqual(
             parse_update(update_str, attributes_list, config), expected_output
         )
+
+
+class TestIdentifyCategoricalColumns(unittest.TestCase):
+    def setUp(self):
+        self.cur = Mock()
+        self.cur.execute = MagicMock()
+        self.cur.fetchone = MagicMock()
+        self.cur.fetchall = MagicMock()
+
+    def test_identify_categorical_columns_succeed(self):
+        # Mock 2 distinct values each with their respective occurence counts of 3, 30
+        self.cur.fetchone.return_value = (2,)
+        self.cur.fetchall.return_value = [("value1", 3), ("value2", 30)]
+        rows = [
+            {"column_name": "test_column", "data_type": "varchar"},
+            {"column_name": "test_column_int", "data_type": "bigint"},
+        ]
+
+        # Call the function
+        result = identify_categorical_columns(self.cur, "test_table", rows)
+
+        # Assert the results
+        self.assertEqual(len(result), len(rows))
+        self.assertEqual(result[0]["top_values"], "value1,value2")
+
+    def test_identify_categorical_columns_exceed_threshold(self):
+        # Mock 20 distinct values each with their respective occurence counts of 1
+        self.cur.fetchone.return_value = (20,)
+        self.cur.fetchall.return_value = [(f"value{i}", 1) for i in range(20)]
+        rows = [{"column_name": "test_column", "data_type": "varchar"}]
+
+        # Call the function
+        result = identify_categorical_columns(
+            self.cur, "test_table", rows, distinct_threshold=10
+        )
+
+        # Assert results is still the same as rows (not modified)
+        self.assertEqual(result, rows)
+        self.assertIn("column_name", result[0])
+        self.assertIn("data_type", result[0])
+        self.assertNotIn("top_values", result[0])
+
+    def test_identify_categorical_columns_within_modified_threshold(self):
+        # Mock 20 distinct values each with their respective occurence counts of 1
+        self.cur.fetchone.return_value = (20,)
+        self.cur.fetchall.return_value = [(f"value{i}", 1) for i in range(20)]
+        rows = [{"column_name": "test_column", "data_type": "varchar"}]
+
+        # Call the function
+        result = identify_categorical_columns(
+            self.cur, "test_table", rows, distinct_threshold=20
+        )
+
+        # Assert that we get 20 distinct values as required
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["top_values"],
+            "value0,value1,value10,value11,value12,value13,value14,value15,value16,value17,value18,value19,value2,value3,value4,value5,value6,value7,value8,value9",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()
 
 
 class TestGetFeedback(unittest.TestCase):


### PR DESCRIPTION
### Problem
Formatting of excessively long values with non-standard characters broke the table metadata csv conversion. Eg:
```
$ defog gen
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
defog gen requires a list of tables to generate. Please enter the names of the tables whose schema you would like to generate, separated by a space:
<redacted_table_name>
Do you want to automatically scan these tables to determine which column might be categorical? The distinct values in each column likely to be a categorical column will be sent to our server. (y/n)
y
Getting schema for each table that you selected...
Identifying categorical columns in <redacted_table_name>. This might take a while if you have many rows in your table.
Identified <redacted_column_name> as a likely categorical column. The unique values are: ['...<redacted>...']
Getting foreign keys for each table that you selected...
Getting indexes for each table that you selected...
Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes...
We got an error!
Error message: Something went wrong. Please try again later.
Please feel free to open a github issue at https://github.com/defog-ai/defog-python if this a generic library issue, or email support@defog.ai.
Your schema has been generated and is available at the following CSV file in this folder:

/Users/jp/workspace/defog-python/None

We are now uploading this auto-generated schema to Defog.
Traceback (most recent call last):
  File "/Users/jp/workspace/miniconda3/bin/defog", line 33, in <module>
    sys.exit(load_entry_point('defog', 'console_scripts', 'defog')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jp/workspace/defog-python/defog/cli.py", line 41, in main
    gen()
  File "/Users/jp/workspace/defog-python/defog/cli.py", line 308, in gen
    df.update_db_schema(filename)
  File "/Users/jp/workspace/defog-python/defog/admin_methods.py", line 9, in update_db_schema
    schema_df = pd.read_csv(path_to_csv).fillna("")
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/pandas/io/parsers/readers.py", line 912, in read_csv
    return _read(filepath_or_buffer, kwds)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/pandas/io/parsers/readers.py", line 577, in _read
    parser = TextFileReader(filepath_or_buffer, **kwds)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/pandas/io/parsers/readers.py", line 1407, in __init__
    self._engine = self._make_engine(f, self.engine)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/pandas/io/parsers/readers.py", line 1661, in _make_engine
    self.handles = get_handle(
                   ^^^^^^^^^^^
  File "/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/pandas/io/common.py", line 716, in get_handle
    ioargs = _get_filepath_or_buffer(
             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jp/workspace/miniconda3/lib/python3.11/site-packages/pandas/io/common.py", line 456, in _get_filepath_or_buffer
    raise ValueError(msg)
ValueError: Invalid file path or buffer object type: <class 'NoneType'>
```

### Fix
We fix this via 2 ways:
- Refactored SQL queries in `identify_categorical_columns` according to https://www.psycopg.org/docs/sql.html#module-psycopg2.sql to avoid potential SQL injections / custom characters breaking our query
  - wrap column and table names in psycopg2.sql.Identifier
  - wrap main SQL query in psycopg2.sql.SQL
  - pass column values as a param tuple in `cur.execute` instead of formatting them directly in the string
- Added character limit for possible values as a heuristic for avoiding things that could potentially be sparse but large unstructured data like json, text configs etc. This heuristic will also reduce the latency on the backend LLM inference since we're also trimming the metadata length. We allow the user of the function to customize the character limit and number of distinct values according to their needs as well, since they would know which character limit / number of distinct values would suit their needs better.

### Testing
We've also added unit tests, and have verified that we can re-run the above command successfully:
```
$ defog gen <redacted_table_name>
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
Do you want to automatically scan these tables to determine which column might be categorical? The distinct values in each column likely to be a categorical column will be sent to our server. (y/n)
y
Getting schema for each table that you selected...
Identifying categorical columns in <redacted_table_name>. This might take a while if you have many rows in your table.
Identified <redacted_column_name> as a likely categorical column. The unique values are: ['...<redacted>...']
Getting foreign keys for each table that you selected...
Getting indexes for each table that you selected...
Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes...
Your schema has been generated and is available at the following CSV file in this folder:

/Users/jp/workspace/defog-python/defog_metadata.csv

We are now uploading this auto-generated schema to Defog.
If you modify the auto-generated schema, please run `defog update <csv_filename>` again to refresh the schema on Defog's servers.
```