### PR TITLE
Add crud for golden queries in cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ ipython_config.py
 
 *.DS_Store
 local_test.py
+
+defog_metadata.csv
+golden_queries.csv
+golden_queries.json

--- a/defog/admin_methods.py
+++ b/defog/admin_methods.py
@@ -1,3 +1,4 @@
+import json
 import requests
 import pandas as pd
 
@@ -177,6 +178,7 @@ def delete_golden_queries(
             },
         )
         resp = r.json()
+        print("All golden queries have now been deleted.")
     else:
         if golden_queries is None:
             golden_queries = (
@@ -191,7 +193,6 @@ def delete_golden_queries(
             },
         )
         resp = r.json()
-    print("All golden queries have now been deleted.")
     return resp
 
 
@@ -204,13 +205,19 @@ def get_golden_queries(self, format="csv", export_path=None):
         json={"api_key": self.api_key},
     )
     resp = r.json()
+    golden_queries = resp["golden_queries"]
     if format == "csv":
         if export_path is None:
             export_path = "golden_queries.csv"
-        pd.DataFrame(resp["golden_queries"]).to_csv(export_path, index=False)
-        print(f"Golden queries exported to {export_path}")
-        return True
+        pd.DataFrame(golden_queries).to_csv(export_path, index=False)
+        print(f"{len(golden_queries)} golden queries exported to {export_path}")
+        return golden_queries
     elif format == "json":
-        return resp["golden_queries"]
+        if export_path is None:
+            export_path = "golden_queries.json"
+        with open(export_path, "w") as f:
+            json.dump(resp, f, indent=4)
+        print(f"{len(golden_queries)} golden queries exported to {export_path}")
+        return golden_queries
     else:
         raise ValueError("format must be either 'csv' or 'json'.")


### PR DESCRIPTION
Add ability to "get", "add", "delete" golden queries using the cli.
Updated the admin methods to consistently export to a default path regardless of format, and to always return the golden queries object.

Usage tests:
```
# add golden queries
$ defog golden add golden_queries.json
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
Golden queries have been received by the system, and will be processed shortly...
Once that is done, you should be able to see improved results for your questions.

# get golden queries
$ defog golden get json
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
Getting golden queries...
2 golden queries exported to golden_queries.json

You have 2 golden queries:

Question:
How many customers do we have
SQL:
SELECT COUNT(c.customer_id) FROM customers c;

Question:
how many accounts does customer_id=PERSON ID have
SQL:
SELECT COUNT(account_id) AS num_accounts FROM accounts WHERE customer_id=PERSON ID

# delete golden queries
$ defog golden delete
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
defog golden delete requires either a path to a JSON or CSV file containing golden queries for deletion, or 'all' to delete all golden queries.
all
All golden queries have now been deleted.

# verify nothing left
$ defog golden get json
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
Getting golden queries...
0 golden queries exported to golden_queries.json