### PR TITLE
Add glossary actions in cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ local_test.py
 defog_metadata.csv
 golden_queries.csv
 golden_queries.json
+glossary.txt

--- a/defog/admin_methods.py
+++ b/defog/admin_methods.py
@@ -31,16 +31,32 @@ def update_glossary(self, glossary: str = "", customized_glossary: dict = None):
     Updates the glossary on the defog servers.
     :param glossary: The glossary to be used.
     """
-    r = requests.post(
-        f"{self.base_url}/update_glossary",
-        json={
-            "api_key": self.api_key,
-            "glossary": glossary,
-            "customized_glossary": customized_glossary,
-        },
-    )
+    data = {
+        "api_key": self.api_key,
+        "glossary": glossary,
+    }
+    if customized_glossary:
+        data["customized_glossary"] = customized_glossary
+    r = requests.post(f"{self.base_url}/update_glossary", json=data)
     resp = r.json()
     return resp
+
+
+def delete_glossary(self, user_type=None):
+    """
+    Deletes the glossary on the defog servers.
+    """
+    data = {
+        "api_key": self.api_key,
+    }
+    if user_type:
+        data["key"] = user_type
+    r = requests.post(f"{self.base_url}/delete_glossary", json=data)
+    if r.status_code == 200:
+        print("Glossary deleted successfully.")
+    else:
+        error_message = r.json().get("message", "")
+        print(f"Glossary deletion failed.\nError message: {error_message}")
 
 
 def get_glossary(self, mode="general"):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.62.7",
+    version="0.63.0",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
Add glossary actions in cli. We now support getting, updating, and deleting glossaries from the cli:
- defog glossary get
- defog glossary update (will prompt for path next)
- defog glossary delete

Tests below:
```
$ defog glossary get
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
You don't have a glossary yet.
$ cat glossary.txt
customer_id can be used to join accounts and customers table%
$ defog glossary update
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
defog glossary update requires a path to a .txt file containing your glossary:
glossary.txt
Your glossary has been updated.
$ defog glossary get
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
Your glossary is:
customer_id can be used to join accounts and customers table
Enter the file path to save the glossary to, or just hit enter for default (glossary.txt):

Your glossary has been saved to glossary.txt.
$ defog glossary delete
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
Glossary deleted successfully.
$ defog glossary get
Connection details found. Reading connection details from file...
Connection details read from /Users/jp/.defog/connection.json.
You don't have a glossary yet.
```