### PR TITLE
[CLI] defog vet metadata

### DIFF
--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -1,8 +1,6 @@
 import base64
 import json
 import os
-import requests
-import pandas as pd
 from importlib.metadata import version
 from defog import generate_schema, query_methods, admin_methods
 
@@ -35,6 +33,7 @@ class Defog:
         save_json: bool = True,
         base_url: str = "https://api.defog.ai",
         generate_query_url: str = "https://api.defog.ai/generate_query_chat",
+        verbose: bool = False,
     ):
         """
         Initializes the Defog class.
@@ -64,7 +63,10 @@ class Defog:
                 self.save_connection_json()
         elif os.path.exists(self.filepath):  # case 4 and 5
             # read connection details from filepath
-            print("Connection details found. Reading connection details from file...")
+            if verbose:
+                print(
+                    "Connection details found. Reading connection details from file..."
+                )
             if api_key == "":
                 with open(self.filepath, "r") as f:
                     data = json.load(f)
@@ -78,7 +80,8 @@ class Defog:
                             "generate_query_url",
                             "https://api.defog.ai/generate_query_chat",
                         )
-                        print(f"Connection details read from {self.filepath}.")
+                        if verbose:
+                            print(f"Connection details read from {self.filepath}.")
                     else:
                         raise KeyError(
                             f"Invalid file at {self.filepath}.\n"

--- a/defog/admin_methods.py
+++ b/defog/admin_methods.py
@@ -8,6 +8,14 @@ def update_db_schema(self, path_to_csv):
     Update the DB schema via a CSV
     """
     schema_df = pd.read_csv(path_to_csv).fillna("")
+    # check columns
+    if not all(
+        col in schema_df.columns
+        for col in ["table_name", "column_name", "data_type", "column_description"]
+    ):
+        raise ValueError(
+            "The CSV must contain the following columns: table_name, column_name, data_type, column_description"
+        )
     schema = {}
     for table_name in schema_df["table_name"].unique():
         schema[table_name] = schema_df[schema_df["table_name"] == table_name][

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.63.0",
+    version="0.63.1",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
Added a new command to our CLI: `defog vet metadata <csv_path>`
This will check each row and if the character length of the column description exceeds 100, it will send a request to our backend to propose a shortened version.
It will prompt the user with the shortened version to see if the user wants to accept it or not, and will only save it back to the csv if the user agrees (enters 'y').
The user can propose edits on the suggested description.
```sh
$ defog vet metadata defog_metadata.csv
Column description for username is > 100 characters.

Old description: Email of the user. Possible values are abc@gmail.com, def@microsoft.com, brickworks123@elevate.com, alan@sofi.com, kbdfans@neurips.org

Suggested description: Email of the user. Format: [username]@[domain].com

Do you want to save this description? Enter (Y/n) or your proposed edit: y
Would you like to save the changes back to defog_metadata.csv? Enter 'y' to save or anything else to
 exit without saving:y
Changes saved to defog_metadata.csv
```
