### PR TITLE
generate_query_url now uses base_url by default, instead of being hard-coded to api.defog.ai

### DIFF
--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -78,7 +78,7 @@ class Defog:
                         self.base_url = data.get("base_url", "https://api.defog.ai")
                         self.generate_query_url = data.get(
                             "generate_query_url",
-                            "https://api.defog.ai/generate_query_chat",
+                            f"{self.base_url}/generate_query_chat",
                         )
                         if verbose:
                             print(f"Connection details read from {self.filepath}.")

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.63.2",
+    version="0.63.3",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
1 liner PR