### PR TITLE
Add profile option to time query generation and execution

### DIFF
--- a/defog/query_methods.py
+++ b/defog/query_methods.py
@@ -2,6 +2,7 @@ import requests
 from defog.query import execute_query
 from datetime import datetime
 
+
 def get_query(
     self,
     question: str,
@@ -33,7 +34,7 @@ def get_query(
         if schema != {}:
             data["schema"] = schema
             data["is_direct"] = True
-        
+
         t_start = datetime.now()
         r = requests.post(
             self.generate_query_url,
@@ -57,7 +58,7 @@ def get_query(
         }
         if profile:
             resp["time_taken"] = time_taken
-        
+
         return resp
     except Exception as e:
         if debug:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.63.4",
+    version="0.63.5",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
This adds a `generation_time_taken` and `execution_time_taken` parameter to the `run_query` and `get_query` methods. This will help Defog users understand if a given query is taken too long to execute and/or generate, and optimize instructions or their database accordingly.

To test this,

```python
from defog import Defog
defog = Defog()
defog.run_query("how many rows are in the table", profile=True)
```

The resulting dict option will have the keys `execution_time_taken`, and `generation_time_taken`