### PR TITLE
Enable multiple DBs on SQLServer

### DIFF
--- a/defog/admin_methods.py
+++ b/defog/admin_methods.py
@@ -388,7 +388,10 @@ def create_empty_tables(self, dev: bool = False):
         elif self.db_type == "sqlserver":
             import pyodbc
 
-            connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};DATABASE={self.db_creds['database']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
+            if self.db_creds["database"] != "":
+                connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};DATABASE={self.db_creds['database']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
+            else:
+                connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
             conn = pyodbc.connect(connection_string)
             cur = conn.cursor()
             for statement in ddl.split(";"):

--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -504,7 +504,10 @@ def generate_sqlserver_schema(
     except:
         raise Exception("pyodbc not installed.")
 
-    connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};DATABASE={self.db_creds['database']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
+    if self.db_creds["database"] != "":
+        connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};DATABASE={self.db_creds['database']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
+    else:
+        connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
     conn = pyodbc.connect(connection_string)
     cur = conn.cursor()
     schemas = {}

--- a/defog/query.py
+++ b/defog/query.py
@@ -119,7 +119,10 @@ def execute_query_once(db_type: str, db_creds, query: str):
         except:
             raise Exception("pyodbc not installed.")
 
-        connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={db_creds['server']};DATABASE={db_creds['database']};UID={db_creds['user']};PWD={db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
+        if db_creds["database"] != "":
+            connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={db_creds['server']};DATABASE={db_creds['database']};UID={db_creds['user']};PWD={db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
+        else:
+            connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={db_creds['server']};UID={db_creds['user']};PWD={db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
         conn = pyodbc.connect(connection_string)
         cur = conn.cursor()
         cur.execute(query)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.65.7",
+    version="0.65.8",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
If SQLServer users want to connect to multiple databases (and not be tied to just a single DB), they can now do so by specifying an empty string for database. 

A cleaner implementation + documentation for this coming soon. Will just leave your PR open until then.