### PR TITLE
Enable bigquery to determine table names if tables names are not provided

### DIFF
--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -447,7 +447,21 @@ def generate_bigquery_schema(
         raise Exception("google-cloud-bigquery not installed.")
 
     client = bigquery.Client.from_service_account_json(self.db_creds["json_key_path"])
+    project_id = [p.project_id for p in client.list_projects()][0]
+    datasets = [dataset.dataset_id for dataset in client.list_datasets()]
     schemas = {}
+
+    if len(tables) == 0:
+        # get all tables
+        tables = []
+        for dataset in datasets:
+            tables += [
+                f"{project_id}.{dataset}.{table.table_id}"
+                for table in client.list_tables(dataset=dataset)
+            ]
+
+    if return_tables_only:
+        return tables
 
     print("Getting the schema for each table that you selected...")
     # get the schema for each table

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.65.8",
+    version="0.65.9",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
To test

```python
from defog import Defog
defog = Defog(DEFOG_API_KEY, db_type="bigquery", db_creds={"json_key_path": "/path/to/bq.json"})
defog.generate_db_schema(tables=[], return_tables_only=True)
```