### PR TITLE
Ensure that the `execute_query` method uses a base_url parameter

### DIFF
--- a/defog/query_methods.py
+++ b/defog/query_methods.py
@@ -139,15 +139,16 @@ def run_query(
             print("Query generated, now running it on your database...")
             tstart = datetime.now()
             colnames, result, executed_query = execute_query(
-                query["query_generated"],
-                self.api_key,
-                self.db_type,
-                self.db_creds,
-                question,
-                hard_filters,
-                retries,
+                query=query["query_generated"],
+                api_key=self.api_key,
+                db_type=self.db_type,
+                db_creds=self.db_creds,
+                question=question,
+                hard_filters=hard_filters,
+                retries=retries,
                 dev=dev,
                 temp=temp,
+                base_url=self.base_url,
             )
             tend = datetime.now()
             time_taken = (tend - tstart).total_seconds()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.65.9",
+    version="0.65.10",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
This ensures that the `/feedback` and `/retry_query_with_error` functions utilize the base url