### PR TITLE
AsyncDefog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ defog_metadata.csv
 golden_queries.csv
 golden_queries.json
 glossary.txt
+
+# Ignore virtual environment directories
+.virtual/
+myenv/
+venv/

--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -2,7 +2,16 @@ import base64
 import json
 import os
 from importlib.metadata import version
-from defog import generate_schema, query_methods, admin_methods, health_methods
+from defog import (
+    generate_schema,
+    async_generate_schema,
+    query_methods,
+    async_query_methods,
+    admin_methods,
+    async_admin_methods,
+    health_methods,
+    async_health_methods,
+)
 
 try:
     __version__ = version("defog")
@@ -20,9 +29,9 @@ SUPPORTED_DB_TYPES = [
 ]
 
 
-class Defog:
+class BaseDefog:
     """
-    The main class for Defog
+    The base class for Defog and AsyncDefog
     """
 
     def __init__(
@@ -37,7 +46,7 @@ class Defog:
         verbose: bool = False,
     ):
         """
-        Initializes the Defog class.
+        Initializes the Base Defog class.
         We have the possible scenarios detailed below:
         1) no config file, no/incomplete params -> success if only db_creds missing, error otherwise
         2) no config file, wrong params -> error
@@ -204,12 +213,77 @@ class Defog:
         self.db_creds = creds["db_creds"]
 
 
+class Defog(BaseDefog):
+    """
+    The main class for Defog (Synchronous)
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        db_type: str = "",
+        db_creds: dict = {},
+        base64creds: str = "",
+        save_json: bool = True,
+        base_url: str = "https://api.defog.ai",
+        generate_query_url: str = "https://api.defog.ai/generate_query_chat",
+        verbose: bool = False,
+    ):
+        """Initializes the synchronous version of the Defog class"""
+        super().__init__(
+            api_key=api_key,
+            db_type=db_type,
+            db_creds=db_creds,
+            base64creds=base64creds,
+            save_json=save_json,
+            base_url=base_url,
+            generate_query_url=generate_query_url,
+            verbose=verbose,
+        )
+
+
+class AsyncDefog(BaseDefog):
+    """
+    The main class for Defog (Asynchronous)
+    """
+
+    def __init__(
+        self,
+        api_key: str = "",
+        db_type: str = "",
+        db_creds: dict = {},
+        base64creds: str = "",
+        save_json: bool = True,
+        base_url: str = "https://api.defog.ai",
+        generate_query_url: str = "https://api.defog.ai/generate_query_chat",
+        verbose: bool = False,
+    ):
+        """Initializes the asynchronous version of the Defog class"""
+        super().__init__(
+            api_key=api_key,
+            db_type=db_type,
+            db_creds=db_creds,
+            base64creds=base64creds,
+            save_json=save_json,
+            base_url=base_url,
+            generate_query_url=generate_query_url,
+            verbose=verbose,
+        )
+
+
 # Add all methods from generate_schema to Defog
 for name in dir(generate_schema):
     attr = getattr(generate_schema, name)
     if callable(attr):
         # Add the method to Defog
         setattr(Defog, name, attr)
+
+# Add all methods from async_generate_schema to AsyncDefog
+for name in dir(async_generate_schema):
+    attr = getattr(async_generate_schema, name)
+    if callable(attr):
+        # Add the method to AsyncDefog
+        setattr(AsyncDefog, name, attr)
 
 # Add all methods from query_methods to Defog
 for name in dir(query_methods):
@@ -218,6 +292,13 @@ for name in dir(query_methods):
         # Add the method to Defog
         setattr(Defog, name, attr)
 
+# Add all methods from async_query_methods to AsyncDefog
+for name in dir(async_query_methods):
+    attr = getattr(async_query_methods, name)
+    if callable(attr):
+        # Add the method to AsyncDefog
+        setattr(AsyncDefog, name, attr)
+
 # Add all methods from admin_methods to Defog
 for name in dir(admin_methods):
     attr = getattr(admin_methods, name)
@@ -225,9 +306,23 @@ for name in dir(admin_methods):
         # Add the method to Defog
         setattr(Defog, name, attr)
 
+# Add all methods from async_admin_methods to AsyncDefog
+for name in dir(async_admin_methods):
+    attr = getattr(async_admin_methods, name)
+    if callable(attr):
+        # Add the method to AsyncDefog
+        setattr(AsyncDefog, name, attr)
+
 # Add all methods from health_methods to Defog
 for name in dir(health_methods):
     attr = getattr(health_methods, name)
     if callable(attr):
         # Add the method to Defog
         setattr(Defog, name, attr)
+
+# Add all methods from async_health_methods to AsyncDefog
+for name in dir(async_health_methods):
+    attr = getattr(async_health_methods, name)
+    if callable(attr):
+        # Add the method to AsyncDefog
+        setattr(AsyncDefog, name, attr)

--- a/defog/async_admin_methods.py
+++ b/defog/async_admin_methods.py
@@ -266,7 +266,7 @@ async def get_golden_queries(
         raise ValueError("format must be either 'csv' or 'json'.")
 
 
-def create_table_ddl(
+async def create_table_ddl(
     table_name: str, columns: List[Dict[str, str]], add_exists=True
 ) -> str:
     """
@@ -296,7 +296,7 @@ def create_table_ddl(
     return md_create
 
 
-def create_ddl_from_metadata(
+async def create_ddl_from_metadata(
     metadata: Dict[str, List[Dict[str, str]]], add_exists=True
 ) -> str:
     """

--- a/defog/async_admin_methods.py
+++ b/defog/async_admin_methods.py
@@ -1,10 +1,12 @@
 import json
 from typing import Dict, List, Optional
-import requests
+from defog.util import make_async_post_request
 import pandas as pd
+import asyncio
+import aiofiles
 
 
-def update_db_schema(self, path_to_csv, dev=False, temp=False):
+async def update_db_schema(self, path_to_csv, dev=False, temp=False):
     """
     Update the DB schema via a CSV
     """
@@ -23,21 +25,21 @@ def update_db_schema(self, path_to_csv, dev=False, temp=False):
             ["column_name", "data_type", "column_description"]
         ].to_dict(orient="records")
 
-    r = requests.post(
-        f"{self.base_url}/update_metadata",
-        json={
-            "api_key": self.api_key,
-            "table_metadata": schema,
-            "db_type": self.db_type,
-            "dev": dev,
-            "temp": temp,
-        },
+    payload = {
+        "api_key": self.api_key,
+        "table_metadata": schema,
+        "db_type": self.db_type,
+        "dev": dev,
+        "temp": temp,
+    }
+
+    resp = await make_async_post_request(
+        url=f"{self.base_url}/update_metadata", payload=payload
     )
-    resp = r.json()
     return resp
 
 
-def update_glossary(
+async def update_glossary(
     self,
     glossary: str = "",
     customized_glossary: dict = None,
@@ -58,12 +60,13 @@ def update_glossary(
     }
     if customized_glossary:
         data["customized_glossary"] = customized_glossary
-    r = requests.post(f"{self.base_url}/update_glossary", json=data)
-    resp = r.json()
+    resp = await make_async_post_request(
+        url=f"{self.base_url}/update_glossary", payload=data
+    )
     return resp
 
 
-def delete_glossary(self, user_type=None, dev=False):
+async def delete_glossary(self, user_type=None, dev=False):
     """
     Deletes the glossary on the defog servers.
     """
@@ -73,7 +76,11 @@ def delete_glossary(self, user_type=None, dev=False):
     }
     if user_type:
         data["key"] = user_type
-    r = requests.post(f"{self.base_url}/delete_glossary", json=data)
+    r = await make_async_post_request(
+        url=f"{self.base_url}/delete_glossary",
+        payload=data,
+        return_response_object=True,
+    )
     if r.status_code == 200:
         print("Glossary deleted successfully.")
     else:
@@ -81,30 +88,28 @@ def delete_glossary(self, user_type=None, dev=False):
         print(f"Glossary deletion failed.\nError message: {error_message}")
 
 
-def get_glossary(self, mode="general", dev=False):
+async def get_glossary(self, mode="general", dev=False):
     """
     Gets the glossary on the defog servers.
     """
-    r = requests.post(
-        f"{self.base_url}/get_metadata",
-        json={"api_key": self.api_key, "dev": dev},
+    resp = await make_async_post_request(
+        url=f"{self.base_url}/get_glossary",
+        payload={"api_key": self.api_key, "dev": dev},
     )
-    resp = r.json()
     if mode == "general":
         return resp["glossary"]
     elif mode == "customized":
         return resp["customized_glossary"]
 
 
-def get_metadata(self, format="markdown", export_path=None, dev=False):
+async def get_metadata(self, format="markdown", export_path=None, dev=False):
     """
     Gets the metadata on the defog servers.
     """
-    r = requests.post(
-        f"{self.base_url}/get_metadata",
-        json={"api_key": self.api_key, "dev": dev},
+    resp = await make_async_post_request(
+        url=f"{self.base_url}/get_metadata",
+        payload={"api_key": self.api_key, "dev": dev},
     )
-    resp = r.json()
     items = []
     for table in resp["table_metadata"]:
         for item in resp["table_metadata"][table]:
@@ -126,15 +131,13 @@ def get_metadata(self, format="markdown", export_path=None, dev=False):
         return resp["table_metadata"]
 
 
-def get_feedback(self, n_rows: int = 50, start_from: int = 0):
+async def get_feedback(self, n_rows: int = 50, start_from: int = 0):
     """
     Gets the feedback on the defog servers.
     """
-    r = requests.post(
-        f"{self.base_url}/get_feedback",
-        json={"api_key": self.api_key},
+    resp = await make_async_post_request(
+        url=f"{self.base_url}/get_feedback", payload={"api_key": self.api_key}
     )
-    resp = r.json()
     df = pd.DataFrame(resp["data"], columns=resp["columns"])
     df["created_at"] = df["created_at"].apply(lambda x: x[:10])
     for col in ["query_generated", "feedback_text"]:
@@ -143,22 +146,23 @@ def get_feedback(self, n_rows: int = 50, start_from: int = 0):
     return df.iloc[start_from:].head(n_rows).to_markdown(index=False)
 
 
-def get_quota(self) -> Optional[Dict]:
+async def get_quota(self) -> Optional[Dict]:
     """
-    Get the quota for the API key.
+    Get the quota usage for the API key.
     """
     api_key = self.api_key
-    response = requests.post(
-        f"{self.base_url}/check_api_usage",
-        json={"api_key": api_key},
+    r = await make_async_post_request(
+        url=f"{self.base_url}/check_api_usage",
+        payload={"api_key": api_key},
+        return_response_object=True,
     )
     # get status code and return None if not 200
-    if response.status_code != 200:
+    if r.status_code != 200:
         return None
-    return response.json()
+    return r.json()
 
 
-def update_golden_queries(
+async def update_golden_queries(
     self,
     golden_queries: List[Dict] = None,
     golden_queries_path: str = None,
@@ -179,16 +183,15 @@ def update_golden_queries(
             pd.read_csv(golden_queries_path).fillna("").to_dict(orient="records")
         )
 
-    r = requests.post(
-        f"{self.base_url}/update_golden_queries",
-        json={
+    resp = await make_async_post_request(
+        url=f"{self.base_url}/update_golden_queries",
+        payload={
             "api_key": self.api_key,
             "golden_queries": golden_queries,
             "scrub": scrub,
             "dev": dev,
         },
     )
-    resp = r.json()
     print(
         "Golden queries have been received by the system, and will be processed shortly..."
     )
@@ -198,7 +201,7 @@ def update_golden_queries(
     return resp
 
 
-def delete_golden_queries(
+async def delete_golden_queries(
     self,
     golden_queries: dict = None,
     golden_queries_path: str = None,
@@ -217,43 +220,33 @@ def delete_golden_queries(
         )
 
     if all:
-        r = requests.post(
-            f"{self.base_url}/delete_golden_queries",
-            json={"api_key": self.api_key, "all": True, "dev": dev},
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/delete_golden_queries",
+            payload={"api_key": self.api_key, "all": True, "dev": dev},
         )
-        resp = r.json()
         print("All golden queries have now been deleted.")
     else:
         if golden_queries is None:
             golden_queries = (
                 pd.read_csv(golden_queries_path).fillna("").to_dict(orient="records")
             )
-
-        r = requests.post(
-            f"{self.base_url}/update_golden_queries",
-            json={
-                "api_key": self.api_key,
-                "golden_queries": golden_queries,
-            },
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/update_golden_queries",
+            payload={"api_key": self.api_key, "golden_queries": golden_queries},
         )
-        resp = r.json()
     return resp
 
 
-def get_golden_queries(
+async def get_golden_queries(
     self, format: str = "csv", export_path: str = None, dev: bool = False
 ):
     """
     Gets the golden queries on the defog servers.
     """
-    r = requests.post(
-        f"{self.base_url}/get_golden_queries",
-        json={
-            "api_key": self.api_key,
-            "dev": dev,
-        },
+    resp = await make_async_post_request(
+        url=f"{self.base_url}/get_golden_queries",
+        payload={"api_key": self.api_key, "dev": dev},
     )
-    resp = r.json()
     golden_queries = resp["golden_queries"]
     if format == "csv":
         if export_path is None:
@@ -264,8 +257,9 @@ def get_golden_queries(
     elif format == "json":
         if export_path is None:
             export_path = "golden_queries.json"
-        with open(export_path, "w") as f:
-            json.dump(resp, f, indent=4)
+        # Writing JSON asynchronously
+        async with aiofiles.open(export_path, "w") as f:
+            await f.write(json.dumps(resp, indent=4))
         print(f"{len(golden_queries)} golden queries exported to {export_path}")
         return golden_queries
     else:
@@ -324,7 +318,7 @@ def create_ddl_from_metadata(
     return md_create
 
 
-def create_empty_tables(self, dev: bool = False):
+async def create_empty_tables(self, dev: bool = False):
     """
     Create empty tables based on metadata
     """
@@ -336,61 +330,61 @@ def create_empty_tables(self, dev: bool = False):
 
     try:
         if self.db_type == "postgres" or self.db_type == "redshift":
-            import psycopg2
+            import asyncpg
 
-            conn = psycopg2.connect(**self.db_creds)
-            cur = conn.cursor()
-            cur.execute(ddl)
-            conn.commit()
-            conn.close()
+            conn = await asyncpg.connect(**self.db_creds)
+            await conn.execute(ddl)
+            await conn.close()
             return True
 
         elif self.db_type == "mysql":
-            import mysql.connector
+            import aiomysql
 
-            conn = mysql.connector.connect(**self.db_creds)
-            cur = conn.cursor()
-            for statement in ddl.split(";"):
-                cur.execute(statement)
-            conn.commit()
-            conn.close()
+            conn = await aiomysql.connect(**self.db_creds)
+            async with conn.cursor() as cur:
+                for statement in ddl.split(";"):
+                    await cur.execute(statement)
+            await conn.commit()
+            await conn.ensure_closed()
             return True
 
         elif self.db_type == "databricks":
             from databricks import sql
 
-            con = sql.connect(**self.db_creds)
-            con.execute(ddl)
-            conn.commit()
-            conn.close()
+            conn = await asyncio.to_thread(sql.connect, **self.db_creds)
+            await asyncio.to_thread(conn.execute, ddl)
+            await asyncio.to_thread(conn.commit)
+            await asyncio.to_thread(conn.close)
             return True
 
         elif self.db_type == "snowflake":
             import snowflake.connector
 
-            conn = snowflake.connector.connect(
+            conn = await asyncio.to_thread(
+                snowflake.connector.connect,
                 user=self.db_creds["user"],
                 password=self.db_creds["password"],
                 account=self.db_creds["account"],
             )
-            cur = conn.cursor()
-            cur.execute(
-                f"USE WAREHOUSE {self.db_creds['warehouse']}"
-            )  # set the warehouse
+            cur = await asyncio.to_thread(conn.cursor)
+            await asyncio.to_thread(
+                cur.execute, f"USE WAREHOUSE {self.db_creds['warehouse']}"
+            )
             for statement in ddl.split(";"):
-                cur.execute(statement)
-            conn.commit()
-            conn.close()
+                await asyncio.to_thread(cur.execute, statement)
+            await asyncio.to_thread(conn.commit)
+            await asyncio.to_thread(conn.close)
             return True
 
         elif self.db_type == "bigquery":
             from google.cloud import bigquery
 
-            client = bigquery.Client.from_service_account_json(
-                self.db_creds["json_key_path"]
+            client = await asyncio.to_thread(
+                bigquery.Client.from_service_account_json,
+                self.db_creds["json_key_path"],
             )
             for statement in ddl.split(";"):
-                client.query(statement)
+                await asyncio.to_thread(client.query, statement)
             return True
 
         elif self.db_type == "sqlserver":
@@ -400,13 +394,14 @@ def create_empty_tables(self, dev: bool = False):
                 connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};DATABASE={self.db_creds['database']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
             else:
                 connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
-            conn = pyodbc.connect(connection_string)
-            cur = conn.cursor()
+            conn = await asyncio.to_thread(pyodbc.connect, connection_string)
+            cur = await asyncio.to_thread(conn.cursor)
             for statement in ddl.split(";"):
-                cur.execute(statement)
-            conn.commit()
-            conn.close()
+                await asyncio.to_thread(cur.execute, statement)
+            await asyncio.to_thread(conn.commit)
+            await asyncio.to_thread(conn.close)
             return True
+
         else:
             raise ValueError(f"Unsupported DB type: {self.db_type}")
     except Exception as e:

--- a/defog/async_generate_schema.py
+++ b/defog/async_generate_schema.py
@@ -353,7 +353,6 @@ async def generate_databricks_schema(
         return schemas
 
 
-
 async def generate_snowflake_schema(
     self,
     tables: list,
@@ -384,8 +383,8 @@ async def generate_snowflake_schema(
     if len(tables) == 0:
         cur = conn.cursor()
         # get all tables from Snowflake database
-        cur.execute_async("SHOW TERSE TABLES;") # execute asynchrnously
-        query_id = cur.sfqid # get the query id to check the status
+        cur.execute_async("SHOW TERSE TABLES;")  # execute asynchrnously
+        query_id = cur.sfqid  # get the query id to check the status
         while conn.is_still_running(conn.get_query_status(query_id)):
             await asyncio.sleep(1)
         res = cur.fetchall()
@@ -536,6 +535,7 @@ async def generate_bigquery_schema(
     else:
         return schemas
 
+
 async def generate_sqlserver_schema(
     self,
     tables: list,
@@ -553,7 +553,7 @@ async def generate_sqlserver_schema(
         connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};DATABASE={self.db_creds['database']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
     else:
         connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
-    
+
     conn = await aioodbc.connect(dsn=connection_string)
     cur = await conn.cursor()
     schemas = {}
@@ -569,7 +569,7 @@ async def generate_sqlserver_schema(
             tables = [row[0] for row in await cur.fetchall()]
         else:
             tables = [schema + "." + row[0] for row in await cur.fetchall()]
-    
+
     if return_tables_only:
         await conn.close()
         return tables

--- a/defog/async_generate_schema.py
+++ b/defog/async_generate_schema.py
@@ -1,12 +1,12 @@
-import requests
-from defog.util import identify_categorical_columns
+from defog.util import async_identify_categorical_columns, make_async_post_request
+import asyncio
 from io import StringIO
 import pandas as pd
 import json
 from typing import List
 
 
-def generate_postgres_schema(
+async def generate_postgres_schema(
     self,
     tables: list,
     upload: bool = True,
@@ -18,30 +18,31 @@ def generate_postgres_schema(
     # when upload is True, we send the schema to the defog servers and generate a CSV
     # when its false, we return the schema as a dict
     try:
-        import psycopg2
+        import asyncpg
     except ImportError:
         raise ImportError(
-            "psycopg2 not installed. Please install it with `pip install psycopg2-binary`."
+            "asyncpg not installed. Please install it with `pip install psycopg2-binary`."
         )
 
-    conn = psycopg2.connect(**self.db_creds)
-    cur = conn.cursor()
+    conn = await asyncpg.connect(**self.db_creds)
     schemas = tuple(schemas)
 
     if len(tables) == 0:
         # get all tables
         for schema in schemas:
-            cur.execute(
-                "SELECT table_name FROM information_schema.tables WHERE table_schema = %s;",
-                (schema,),
-            )
+            query = """
+                SELECT table_name 
+                FROM information_schema.tables 
+                WHERE table_schema = $1;
+            """
+            rows = await conn.fetch(query, schema)
             if schema == "public":
-                tables += [row[0] for row in cur.fetchall()]
+                tables += [row[0] for row in rows]
             else:
-                tables += [schema + "." + row[0] for row in cur.fetchall()]
+                tables += [schema + "." + row[0] for row in rows]
 
     if return_tables_only:
-        conn.close()
+        await conn.close()
         return tables
 
     print("Getting schema for each table that you selected...")
@@ -53,38 +54,37 @@ def generate_postgres_schema(
         for table_name in tables:
             if "." in table_name:
                 _, table_name = table_name.split(".", 1)
-            cur.execute(
-                "SELECT CAST(column_name AS TEXT), CAST(data_type AS TEXT) FROM information_schema.columns WHERE table_name::text = %s AND table_schema = %s;",
-                (
-                    table_name,
-                    schema,
-                ),
-            )
-            rows = cur.fetchall()
+            query = """
+                SELECT CAST(column_name AS TEXT), CAST(data_type AS TEXT)
+                FROM information_schema.columns
+                WHERE table_name = $1 AND table_schema = $2;
+            """
+            rows = await conn.fetch(query, table_name, schema)
             rows = [row for row in rows]
-            rows = [{"column_name": i[0], "data_type": i[1]} for i in rows]
+            rows = [{"column_name": row[0], "data_type": row[1]} for row in rows]
             if len(rows) > 0:
                 if scan:
-                    rows = identify_categorical_columns(cur, table_name, rows)
+                    rows = await async_identify_categorical_columns(
+                        conn=conn, cur=None, table_name=table_name, rows=rows
+                    )
                 if schema == "public":
                     table_columns[table_name] = rows
                 else:
                     table_columns[schema + "." + table_name] = rows
-    conn.close()
+    await conn.close()
 
     print(
         "Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes..."
     )
     if upload:
         # send the schemas dict to the defog servers
-        r = requests.post(
-            f"{self.base_url}/get_schema_csv",
-            json={
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/get_schema_csv",
+            payload={
                 "api_key": self.api_key,
                 "schemas": table_columns,
             },
         )
-        resp = r.json()
         if "csv" in resp:
             csv = resp["csv"]
             if return_format == "csv":
@@ -103,7 +103,7 @@ def generate_postgres_schema(
         return table_columns
 
 
-def generate_redshift_schema(
+async def generate_redshift_schema(
     self,
     tables: list,
     upload: bool = True,
@@ -114,70 +114,65 @@ def generate_redshift_schema(
     # when upload is True, we send the schema to the defog servers and generate a CSV
     # when its false, we return the schema as a dict
     try:
-        import psycopg2
+        import asyncpg
     except ImportError:
         raise ImportError(
-            "psycopg2 not installed. Please install it with `pip install psycopg2-binary`."
+            "asyncpg not installed. Please install it with `pip install psycopg2-binary`."
         )
 
     if "schema" not in self.db_creds:
         schema = "public"
-        conn = psycopg2.connect(**self.db_creds)
+        conn = await asyncpg.connect(**self.db_creds)
     else:
         schema = self.db_creds["schema"]
         del self.db_creds["schema"]
-        conn = psycopg2.connect(**self.db_creds)
-    cur = conn.cursor()
+        conn = await asyncpg.connect(**self.db_creds)
 
     schemas = {}
 
     if len(tables) == 0:
-        # get all tables
-        cur.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s;",
-            (schema,),
+        table_names_query = (
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = $1;"
         )
-        tables = [row[0] for row in cur.fetchall()]
+        results = await conn.fetch(table_names_query, schema)
+        tables = [row[0] for row in results]
 
     if return_tables_only:
-        conn.close()
+        await conn.close()
         return tables
 
     print("Getting schema for each table that you selected...")
     # get the schema for each table
     for table_name in tables:
-        cur.execute(
-            "SELECT CAST(column_name AS TEXT), CAST(data_type AS TEXT) FROM information_schema.columns WHERE table_name::text = %s AND table_schema= %s;",
-            (
-                table_name,
-                schema,
-            ),
-        )
-        rows = cur.fetchall()
+        table_schema_query = "SELECT CAST(column_name AS TEXT), CAST(data_type AS TEXT) FROM information_schema.columns WHERE table_name::text = $1 AND table_schema= $2;"
+        rows = await conn.fetch(table_schema_query, table_name, schema)
         rows = [row for row in rows]
         rows = [{"column_name": i[0], "data_type": i[1]} for i in rows]
         if len(rows) > 0:
             if scan:
-                cur.execute(f"SET search_path TO {schema}")
-                rows = identify_categorical_columns(cur, table_name, rows)
-                cur.close()
+                await conn.execute(f"SET search_path TO {schema}")
+                rows = await async_identify_categorical_columns(
+                    conn=conn, cur=None, table_name=table_name, rows=rows
+                )
+
             schemas[table_name] = rows
+
+    await conn.close()
 
     if upload:
         print(
             "Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes..."
         )
         # send the schemas dict to the defog servers
-        r = requests.post(
-            f"{self.base_url}/get_schema_csv",
-            json={
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/get_schema_csv",
+            payload={
                 "api_key": self.api_key,
                 "schemas": schemas,
                 "foreign_keys": [],
                 "indexes": [],
             },
         )
-        resp = r.json()
         if "csv" in resp:
             csv = resp["csv"]
             if return_format == "csv":
@@ -196,7 +191,7 @@ def generate_redshift_schema(
         return schemas
 
 
-def generate_mysql_schema(
+async def generate_mysql_schema(
     self,
     tables: list,
     upload: bool = True,
@@ -205,54 +200,59 @@ def generate_mysql_schema(
     return_tables_only: bool = False,
 ) -> str:
     try:
-        import mysql.connector
+        import aiomysql
     except:
-        raise Exception("mysql-connector not installed.")
+        raise Exception("aiomysql not installed.")
 
-    conn = mysql.connector.connect(**self.db_creds)
-    cur = conn.cursor()
+    conn = await aiomysql.connect(**self.db_creds)
+    cur = await conn.cursor()
     schemas = {}
 
     if len(tables) == 0:
         # get all tables
         db_name = self.db_creds.get("database", "")
-        cur.execute(
+        await cur.execute(
             f"SELECT table_name FROM information_schema.tables WHERE table_schema = '{db_name}';"
         )
-        tables = [row[0] for row in cur.fetchall()]
+        tables = [row[0] for row in await cur.fetchall()]
 
     if return_tables_only:
-        conn.close()
+        await conn.close()
         return tables
 
     print("Getting schema for the relevant table in your database...")
     # get the schema for each table
     for table_name in tables:
-        cur.execute(
+        await cur.execute(
             "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = %s;",
             (table_name,),
         )
-        rows = cur.fetchall()
+        rows = await cur.fetchall()
         rows = [row for row in rows]
         rows = [{"column_name": i[0], "data_type": i[1]} for i in rows]
         if scan:
-            rows = identify_categorical_columns(cur, table_name, rows)
+            rows = await async_identify_categorical_columns(
+                conn=None,
+                cur=cur,
+                table_name=table_name,
+                rows=rows,
+                is_cursor_async=True,
+            )
         if len(rows) > 0:
             schemas[table_name] = rows
 
-    conn.close()
+    await conn.ensure_closed()
 
     if upload:
-        r = requests.post(
-            f"{self.base_url}/get_schema_csv",
-            json={
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/get_schema_csv",
+            payload={
                 "api_key": self.api_key,
                 "schemas": schemas,
                 "foreign_keys": [],
                 "indexes": [],
             },
         )
-        resp = r.json()
         if "csv" in resp:
             csv = resp["csv"]
             if return_format == "csv":
@@ -271,7 +271,7 @@ def generate_mysql_schema(
         return schemas
 
 
-def generate_databricks_schema(
+async def generate_databricks_schema(
     self,
     tables: list,
     upload: bool = True,
@@ -284,49 +284,57 @@ def generate_databricks_schema(
     except:
         raise Exception("databricks-sql-connector not installed.")
 
-    conn = sql.connect(**self.db_creds)
+    conn = await asyncio.to_thread(sql.connect, **self.db_creds)
     schemas = {}
-    with conn.cursor() as cur:
+    async with await asyncio.to_thread(conn.cursor) as cur:
         print("Getting schema for each table that you selected...")
         # get the schema for each table
 
         if len(tables) == 0:
             # get all tables from databricks
-            cur.tables(schema_name=self.db_creds.get("schema", "default"))
-            tables = [row.TABLE_NAME for row in cur.fetchall()]
+            await asyncio.to_thread(
+                cur.tables, schema_name=self.db_creds.get("schema", "default")
+            )
+            tables = [row.TABLE_NAME for row in await asyncio.to_thread(cur.fetchall())]
 
         if return_tables_only:
-            conn.close()
+            await asyncio.to_thread(conn.close)
             return tables
 
         for table_name in tables:
-            cur.columns(
+            await asyncio.to_thread(
+                cur.columns,
                 schema_name=self.db_creds.get("schema", "default"),
                 table_name=table_name,
             )
-            rows = cur.fetchall()
+            rows = await asyncio.to_thread(cur.fetchall)
             rows = [row for row in rows]
             rows = [
                 {"column_name": i.COLUMN_NAME, "data_type": i.TYPE_NAME} for i in rows
             ]
             if scan:
-                rows = identify_categorical_columns(cur, table_name, rows)
+                rows = await async_identify_categorical_columns(
+                    conn=None,
+                    cur=cur,
+                    table_name=table_name,
+                    rows=rows,
+                    is_cursor_async=False,
+                )
             if len(rows) > 0:
                 schemas[table_name] = rows
 
-    conn.close()
+    await asyncio.to_thread(conn.close)
 
     if upload:
-        r = requests.post(
-            f"{self.base_url}/get_schema_csv",
-            json={
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/get_schema_csv",
+            payload={
                 "api_key": self.api_key,
                 "schemas": schemas,
                 "foreign_keys": [],
                 "indexes": [],
             },
         )
-        resp = r.json()
         if "csv" in resp:
             csv = resp["csv"]
             if return_format == "csv":
@@ -345,7 +353,7 @@ def generate_databricks_schema(
         return schemas
 
 
-def generate_snowflake_schema(
+async def generate_snowflake_schema(
     self,
     tables: list,
     upload: bool = True,
@@ -358,13 +366,15 @@ def generate_snowflake_schema(
     except:
         raise Exception("snowflake-connector not installed.")
 
-    conn = snowflake.connector.connect(
+    conn = await asyncio.to_thread(
+        snowflake.connector.connect,
         user=self.db_creds["user"],
         password=self.db_creds["password"],
         account=self.db_creds["account"],
     )
-    conn.cursor().execute(
-        f"USE WAREHOUSE {self.db_creds['warehouse']}"
+
+    await asyncio.to_thread(
+        conn.cursor().execute, f"USE WAREHOUSE {self.db_creds['warehouse']}"
     )  # set the warehouse
 
     schemas = {}
@@ -373,16 +383,21 @@ def generate_snowflake_schema(
     # get the schema for each table
     if len(tables) == 0:
         # get all tables from Snowflake database
-        cur = conn.cursor().execute("SHOW TERSE TABLES;")
-        res = cur.fetchall()
+        cur = await asyncio.to_thread(conn.cursor().execute, "SHOW TERSE TABLES;")
+        res = await asyncio.to_thread(cur.fetchall)
         tables = [f"{row[3]}.{row[4]}.{row[1]}" for row in res]
 
     if return_tables_only:
+        await asyncio.to_thread(conn.close)
         return tables
 
     for table_name in tables:
         rows = []
-        for row in conn.cursor().execute(f"SHOW COLUMNS IN {table_name};"):
+        cur = await asyncio.to_thread(conn.cursor)
+        fetched_rows = await asyncio.to_thread(
+            cur.execute, f"SHOW COLUMNS IN {table_name};"
+        )
+        for row in fetched_rows:
             rows.append(row)
         rows = [
             {
@@ -396,29 +411,35 @@ def generate_snowflake_schema(
             if row["data_type"] in alt_types:
                 row["data_type"] = alt_types[row["data_type"]]
             rows[idx] = row
-        cur = conn.cursor()
+
+        cur = await asyncio.to_thread(conn.cursor)
         if scan:
-            rows = identify_categorical_columns(cur, table_name, rows)
-        cur.close()
+            rows = await async_identify_categorical_columns(
+                conn=None,
+                cur=cur,
+                table_name=table_name,
+                rows=rows,
+                is_cursor_async=False,
+            )
+        await asyncio.to_thread(cur.close)
         if len(rows) > 0:
             schemas[table_name] = rows
 
-    conn.close()
+    await asyncio.to_thread(conn.close)
 
     if upload:
         print(
             "Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes..."
         )
-        r = requests.post(
-            f"{self.base_url}/get_schema_csv",
-            json={
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/get_schema_csv",
+            payload={
                 "api_key": self.api_key,
                 "schemas": schemas,
                 "foreign_keys": [],
                 "indexes": [],
             },
         )
-        resp = r.json()
         if "csv" in resp:
             csv = resp["csv"]
             if return_format == "csv":
@@ -437,7 +458,7 @@ def generate_snowflake_schema(
         return schemas
 
 
-def generate_bigquery_schema(
+async def generate_bigquery_schema(
     self,
     tables: list,
     upload: bool = True,
@@ -450,48 +471,50 @@ def generate_bigquery_schema(
     except:
         raise Exception("google-cloud-bigquery not installed.")
 
-    client = bigquery.Client.from_service_account_json(self.db_creds["json_key_path"])
-    project_id = [p.project_id for p in client.list_projects()][0]
-    datasets = [dataset.dataset_id for dataset in client.list_datasets()]
+    client = await asyncio.to_thread(
+        bigquery.Client.from_service_account_json, self.db_creds["json_key_path"]
+    )
+    project_id = [p.project_id for p in await asyncio.to_thread(client.list_projects)][
+        0
+    ]
+    datasets = [
+        dataset.dataset_id for dataset in await asyncio.to_thread(client.list_datasets)
+    ]
     schemas = {}
 
     if len(tables) == 0:
         # get all tables
         tables = []
         for dataset in datasets:
+            table_list = await asyncio.to_thread(client.list_tables, dataset)
             tables += [
-                f"{project_id}.{dataset}.{table.table_id}"
-                for table in client.list_tables(dataset=dataset)
+                f"{project_id}.{dataset}.{table.table_id}" for table in table_list
             ]
-
-    if return_tables_only:
-        return tables
 
     print("Getting the schema for each table that you selected...")
     # get the schema for each table
     for table_name in tables:
-        table = client.get_table(table_name)
+        table = await asyncio.to_thread(client.get_table, table_name)
         rows = table.schema
         rows = [{"column_name": i.name, "data_type": i.field_type} for i in rows]
         if len(rows) > 0:
             schemas[table_name] = rows
 
-    client.close()
+    await asyncio.to_thread(client.close)
 
     if upload:
         print(
             "Sending the schema to Defog servers and generating column descriptions. This might take up to 2 minutes..."
         )
-        r = requests.post(
-            f"{self.base_url}/get_schema_csv",
-            json={
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/get_schema_csv",
+            payload={
                 "api_key": self.api_key,
                 "schemas": schemas,
                 "foreign_keys": [],
                 "indexes": [],
             },
         )
-        resp = r.json()
         if "csv" in resp:
             csv = resp["csv"]
             if return_format == "csv":
@@ -510,7 +533,7 @@ def generate_bigquery_schema(
         return schemas
 
 
-def generate_sqlserver_schema(
+async def generate_sqlserver_schema(
     self,
     tables: list,
     upload: bool = True,
@@ -526,52 +549,54 @@ def generate_sqlserver_schema(
         connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};DATABASE={self.db_creds['database']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
     else:
         connection_string = f"DRIVER={{ODBC Driver 18 for SQL Server}};SERVER={self.db_creds['server']};UID={self.db_creds['user']};PWD={self.db_creds['password']};TrustServerCertificate=yes;Connection Timeout=120;"
-    conn = pyodbc.connect(connection_string)
-    cur = conn.cursor()
+    conn = await asyncio.to_thread(pyodbc.connect, connection_string)
+    cur = await asyncio.to_thread(conn.cursor)
     schemas = {}
     schema = self.db_creds.get("schema", "dbo")
 
     if len(tables) == 0:
-        # get all tables
-        cur.execute(
-            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s;",
-            (schema,),
+        table_names_query = (
+            "SELECT table_name FROM information_schema.tables WHERE table_schema = %s;"
         )
+        await asyncio.to_thread(cur.execute, table_names_query, (schema,))
         if schema == "dbo":
-            tables += [row[0] for row in cur.fetchall()]
+            tables += [row[0] for row in await asyncio.to_thread(cur.fetchall)]
         else:
-            tables += [schema + "." + row[0] for row in cur.fetchall()]
+            tables += [
+                schema + "." + row[0] for row in await asyncio.to_thread(cur.fetchall)
+            ]
 
     if return_tables_only:
+        await asyncio.to_thread(conn.close)
         return tables
 
     print("Getting schema for each table in your database...")
     # get the schema for each table
     for table_name in tables:
-        cur.execute(
-            f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table_name}';"
+        await asyncio.to_thread(
+            cur.execute,
+            f"SELECT column_name, data_type FROM information_schema.columns WHERE table_name = '{table_name}';",
         )
-        rows = cur.fetchall()
+        rows = await asyncio.to_thread(cur.fetchall)
         rows = [row for row in rows]
         rows = [{"column_name": i[0], "data_type": i[1]} for i in rows]
         if len(rows) > 0:
             schemas[table_name] = rows
 
-    conn.close()
+    await asyncio.to_thread(conn.close)
     if upload:
         print(
             "Sending the schema to Defog servers and generating column descriptions. This might take up to 2 minutes..."
         )
-        r = requests.post(
-            f"{self.base_url}/get_schema_csv",
-            json={
+        resp = await make_async_post_request(
+            url=f"{self.base_url}/get_schema_csv",
+            payload={
                 "api_key": self.api_key,
                 "schemas": schemas,
                 "foreign_keys": [],
                 "indexes": [],
             },
         )
-        resp = r.json()
         if "csv" in resp:
             csv = resp["csv"]
             if return_format == "csv":
@@ -590,7 +615,7 @@ def generate_sqlserver_schema(
         return schemas
 
 
-def generate_db_schema(
+async def generate_db_schema(
     self,
     tables: list,
     scan: bool = True,
@@ -599,7 +624,7 @@ def generate_db_schema(
     return_format: str = "csv",
 ) -> str:
     if self.db_type == "postgres":
-        return self.generate_postgres_schema(
+        return await self.generate_postgres_schema(
             tables,
             return_format=return_format,
             scan=scan,
@@ -607,7 +632,7 @@ def generate_db_schema(
             return_tables_only=return_tables_only,
         )
     elif self.db_type == "mysql":
-        return self.generate_mysql_schema(
+        return await self.generate_mysql_schema(
             tables,
             return_format=return_format,
             scan=scan,
@@ -615,7 +640,7 @@ def generate_db_schema(
             return_tables_only=return_tables_only,
         )
     elif self.db_type == "bigquery":
-        return self.generate_bigquery_schema(
+        return await self.generate_bigquery_schema(
             tables,
             return_format=return_format,
             scan=scan,
@@ -623,7 +648,7 @@ def generate_db_schema(
             return_tables_only=return_tables_only,
         )
     elif self.db_type == "redshift":
-        return self.generate_redshift_schema(
+        return await self.generate_redshift_schema(
             tables,
             return_format=return_format,
             scan=scan,
@@ -631,7 +656,7 @@ def generate_db_schema(
             return_tables_only=return_tables_only,
         )
     elif self.db_type == "snowflake":
-        return self.generate_snowflake_schema(
+        return await self.generate_snowflake_schema(
             tables,
             return_format=return_format,
             scan=scan,
@@ -639,7 +664,7 @@ def generate_db_schema(
             return_tables_only=return_tables_only,
         )
     elif self.db_type == "databricks":
-        return self.generate_databricks_schema(
+        return await self.generate_databricks_schema(
             tables,
             return_format=return_format,
             scan=scan,
@@ -647,7 +672,7 @@ def generate_db_schema(
             return_tables_only=return_tables_only,
         )
     elif self.db_type == "sqlserver":
-        return self.generate_sqlserver_schema(
+        return await self.generate_sqlserver_schema(
             tables,
             return_format=return_format,
             upload=upload,

--- a/defog/async_health_methods.py
+++ b/defog/async_health_methods.py
@@ -1,0 +1,46 @@
+from defog.util import make_async_post_request
+
+
+async def check_golden_queries_coverage(self, dev: bool = False):
+    """
+    Check the number of tables and columns inside the metadata schema that are covered by the golden queries.
+    """
+    url = f"{self.base_url}/get_golden_queries_coverage"
+    payload = {"api_key": self.api_key, "dev": dev}
+    return await make_async_post_request(url, payload)
+
+
+async def check_md_valid(self, dev: bool = False):
+    """
+    Check if the metadata schema is valid.
+    """
+    url = f"{self.base_url}/check_md_valid"
+    payload = {"api_key": self.api_key, "db_type": self.db_type, "dev": dev}
+    return await make_async_post_request(url, payload)
+
+
+async def check_gold_queries_valid(self, dev: bool = False):
+    """
+    Check if the golden queries are valid and can be executed on a given database without errors.
+    """
+    url = f"{self.base_url}/check_gold_queries_valid"
+    payload = {"api_key": self.api_key, "db_type": self.db_type, "dev": dev}
+    return await make_async_post_request(url, payload)
+
+
+async def check_glossary_valid(self, dev: bool = False):
+    """
+    Check if the glossary is valid by verifying if all schema, table, and column names referenced are present in the metadata.
+    """
+    url = f"{self.base_url}/check_glossary_valid"
+    payload = {"api_key": self.api_key, "dev": dev}
+    return await make_async_post_request(url, payload)
+
+
+async def check_glossary_consistency(self, dev: bool = False):
+    """
+    Check if all logic in the glossary is consistent and coherent.
+    """
+    url = f"{self.base_url}/check_glossary_consistency"
+    payload = {"api_key": self.api_key, "dev": dev}
+    return await make_async_post_request(url, payload)

--- a/defog/async_query_methods.py
+++ b/defog/async_query_methods.py
@@ -1,0 +1,172 @@
+from defog.util import make_async_post_request
+from defog.query import execute_query
+from datetime import datetime
+
+
+async def get_query(
+    self,
+    question: str,
+    hard_filters: str = "",
+    previous_context: list = [],
+    glossary: str = "",
+    debug: bool = False,
+    dev: bool = False,
+    temp: bool = False,
+    profile: bool = False,
+    ignore_cache: bool = False,
+    model: str = "",
+    use_golden_queries: bool = True,
+    subtable_pruning: bool = False,
+    glossary_pruning: bool = False,
+    prune_max_tokens: int = 2000,
+    prune_bm25_num_columns: int = 10,
+    prune_glossary_max_tokens: int = 1000,
+    prune_glossary_num_cos_sim_units: int = 10,
+    prune_glossary_bm25_units: int = 10,
+):
+    """
+    Asynchronously sends the query to the defog servers, and return the response.
+    :param question: The question to be asked.
+    :return: The response from the defog server.
+    """
+    try:
+        data = {
+            "question": question,
+            "api_key": self.api_key,
+            "previous_context": previous_context,
+            "db_type": self.db_type if self.db_type != "databricks" else "postgres",
+            "glossary": glossary,
+            "hard_filters": hard_filters,
+            "dev": dev,
+            "temp": temp,
+            "ignore_cache": ignore_cache,
+            "model": model,
+            "use_golden_queries": use_golden_queries,
+            "subtable_pruning": subtable_pruning,
+            "glossary_pruning": glossary_pruning,
+            "prune_max_tokens": prune_max_tokens,
+            "prune_bm25_num_columns": prune_bm25_num_columns,
+            "prune_glossary_max_tokens": prune_glossary_max_tokens,
+            "prune_glossary_num_cos_sim_units": prune_glossary_num_cos_sim_units,
+            "prune_glossary_bm25_units": prune_glossary_bm25_units,
+        }
+
+        t_start = datetime.now()
+
+        resp = await make_async_post_request(
+            url=self.generate_query_url, payload=data, timeout=300
+        )
+
+        t_end = datetime.now()
+        time_taken = (t_end - t_start).total_seconds()
+        query_generated = resp.get("sql", resp.get("query_generated"))
+        ran_successfully = resp.get("ran_successfully")
+        error_message = resp.get("error_message")
+        query_db = self.db_type
+        resp = {
+            "query_generated": query_generated,
+            "ran_successfully": ran_successfully,
+            "error_message": error_message,
+            "query_db": query_db,
+            "previous_context": resp.get("previous_context"),
+            "reason_for_query": resp.get("reason_for_query"),
+        }
+        if profile:
+            resp["time_taken"] = time_taken
+
+        return resp
+    except Exception as e:
+        if debug:
+            print(e)
+        return {
+            "ran_successfully": False,
+            "error_message": "Sorry :( Our server is at capacity right now and we are unable to process your query. Please try again in a few minutes?",
+        }
+
+
+async def run_query(
+    self,
+    question: str,
+    hard_filters: str = "",
+    previous_context: list = [],
+    glossary: str = "",
+    query: dict = None,
+    retries: int = 3,
+    dev: bool = False,
+    temp: bool = False,
+    profile: bool = False,
+    ignore_cache: bool = False,
+    model: str = "",
+    use_golden_queries: bool = True,
+    subtable_pruning: bool = False,
+    glossary_pruning: bool = False,
+    prune_max_tokens: int = 2000,
+    prune_bm25_num_columns: int = 10,
+    prune_glossary_max_tokens: int = 1000,
+    prune_glossary_num_cos_sim_units: int = 10,
+    prune_glossary_bm25_units: int = 10,
+):
+    """
+    Asynchronously sends the question to the defog servers, executes the generated SQL,
+    and returns the response.
+    :param question: The question to be asked.
+    :return: The response from the defog server.
+    """
+    if query is None:
+        print(f"Generating the query for your question: {question}...")
+        query = await self.get_query(
+            question,
+            hard_filters,
+            previous_context,
+            glossary=glossary,
+            dev=dev,
+            temp=temp,
+            profile=profile,
+            model=model,
+            ignore_cache=ignore_cache,
+            use_golden_queries=use_golden_queries,
+            subtable_pruning=subtable_pruning,
+            glossary_pruning=glossary_pruning,
+            prune_max_tokens=prune_max_tokens,
+            prune_bm25_num_columns=prune_bm25_num_columns,
+            prune_glossary_max_tokens=prune_glossary_max_tokens,
+            prune_glossary_num_cos_sim_units=prune_glossary_num_cos_sim_units,
+            prune_glossary_bm25_units=prune_glossary_bm25_units,
+        )
+    if query["ran_successfully"]:
+        try:
+            print("Query generated, now running it on your database...")
+            tstart = datetime.now()
+            colnames, result, executed_query = await execute_query(
+                query=query["query_generated"],
+                api_key=self.api_key,
+                db_type=self.db_type,
+                db_creds=self.db_creds,
+                question=question,
+                hard_filters=hard_filters,
+                retries=retries,
+                dev=dev,
+                temp=temp,
+            )
+            tend = datetime.now()
+            time_taken = (tend - tstart).total_seconds()
+            resp = {
+                "columns": colnames,
+                "data": result,
+                "query_generated": executed_query,
+                "ran_successfully": True,
+                "reason_for_query": query.get("reason_for_query"),
+                "previous_context": query.get("previous_context"),
+            }
+            if profile:
+                resp["execution_time_taken"] = time_taken
+                resp["generation_time_taken"] = query.get("time_taken")
+            return resp
+        except Exception as e:
+            return {
+                "ran_successfully": False,
+                "error_message": str(e),
+                "query_generated": query["query_generated"],
+            }
+    else:
+        return {"ran_successfully": False, "error_message": query["error_message"]}

--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -378,6 +378,7 @@ def generate_snowflake_schema(
         tables = [f"{row[3]}.{row[4]}.{row[1]}" for row in res]
 
     if return_tables_only:
+        conn.close()
         return tables
 
     for table_name in tables:

--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -544,6 +544,7 @@ def generate_sqlserver_schema(
             tables += [schema + "." + row[0] for row in cur.fetchall()]
 
     if return_tables_only:
+        conn.close()
         return tables
 
     print("Getting schema for each table in your database...")

--- a/defog/query.py
+++ b/defog/query.py
@@ -5,6 +5,7 @@ from defog.util import write_logs, async_write_logs, make_async_post_request
 import asyncio
 import os
 
+
 # execute query for given db_type and return column names and data
 def execute_query_once(db_type: str, db_creds, query: str):
     """

--- a/defog/query.py
+++ b/defog/query.py
@@ -249,7 +249,7 @@ async def async_execute_query_once(db_type: str, db_creds, query: str):
         query_id = cur.sfqid
         while conn.is_still_running(conn.get_query_status(query_id)):
             await asyncio.sleep(1)
-        
+
         colnames = [desc[0] for desc in cur.description]
         rows = cur.fetchall()
         cur.close()

--- a/defog/util.py
+++ b/defog/util.py
@@ -156,7 +156,7 @@ def identify_categorical_columns(
 
 
 async def async_identify_categorical_columns(
-    conn=None,
+    conn=None,  # a connection object for any database
     cur=None,  # a cursor object for any database
     table_name: str = "",
     rows: list = [],
@@ -168,25 +168,22 @@ async def async_identify_categorical_columns(
     Identify categorical columns in the table and return the top distinct values for each column.
 
     Args:
-        conn (connection): A connection object for any database.
-        cur (cursor): A cursor object for any database. This cursor should support the following methods:
-            - execute(sql, params)
-            - fetchone()
-            - fetchall()
-        table_name (str): The name of the table.
-        rows (list): A list of dictionaries containing the column names and data types.a
-        distinct_threshold (int): The threshold for the number of distinct values in a column to be considered categorical.
-        character_length_threshold (int): The threshold for the maximum length of a string column to be considered categorical.
+        conn (optional): Async connection for databases (e.g., asyncpg).
+        cur (optional): Sync/async cursor object for database queries.
+        table_name (str): The name of the table to analyze.
+        rows (list): List of column info dictionaries (with keys like "column_name", "data_type").
+        is_cursor_async (bool): Set True if using an async cursor.
+        distinct_threshold (int): Max distinct values to classify a column as categorical.
+        character_length_threshold (int): Max length of a string column to be considered categorical.
         This is a heuristic for pruning columns that might contain arbitrarily long strings like json / configs.
+
+    Note:
+        - The function requires one of conn or cur to be provided.
 
     Returns:
         rows (list): The updated list of dictionaries containing the column names, data types and top distinct values.
         The list is modified in-place.
     """
-    # loop through each column, look at whether it is a string column, and then determine if it might be a categorical variable
-    # if it is a categorical variable, then we want to get the distinct values and their counts
-    # we will then send this to the defog servers so that we can generate a column description
-    # for each categorical variable
     print(
         f"Identifying categorical columns in {table_name}. This might take a while if you have many rows in your table."
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ prompt_toolkit
 psycopg2-binary>=2.9.5
 asyncpg
 aiomysql
+aioodbc
 pwinput
 requests>=2.28.2
 aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,13 @@
 pandas
 prompt_toolkit
 psycopg2-binary>=2.9.5
+asyncpg
+aiomysql
 pwinput
 requests>=2.28.2
+aiohttp
+aiofiles
 tabulate
 uvicorn
 tqdm
+setuptools

--- a/tests/test_async_defog.py
+++ b/tests/test_async_defog.py
@@ -1,0 +1,256 @@
+import shutil
+import unittest
+import asyncio
+from defog import AsyncDefog
+from defog.util import parse_update
+import os
+from unittest.mock import patch
+
+
+class TestAsyncDefog(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        # if connection.json exists, copy it to /tmp since we'll be overwriting it
+        home_dir = os.path.expanduser("~")
+        self.filepath = os.path.join(home_dir, ".defog", "connection.json")
+        self.tmp_dir = os.path.join("/tmp")
+        self.moved = False
+        if os.path.exists(self.filepath):
+            print("Moving connection.json to /tmp")
+            if os.path.exists(os.path.join(self.tmp_dir, "connection.json")):
+                os.remove(os.path.join(self.tmp_dir, "connection.json"))
+            shutil.move(self.filepath, self.tmp_dir)
+            self.moved = True
+
+    @classmethod
+    def tearDownClass(self):
+        # copy back the original after all tests have completed
+        if self.moved:
+            print("Moving connection.json back to ~/.defog")
+            shutil.move(os.path.join(self.tmp_dir, "connection.json"), self.filepath)
+
+    def tearDown(self):
+        # clean up connection.json created/saved after each test case
+        if os.path.exists(self.filepath):
+            print("Removing connection.json used for testing")
+            os.remove(self.filepath)
+
+    ### Case 1:
+    def test_async_defog_bad_init_no_params(self):
+        with self.assertRaises(ValueError):
+            print("Testing AsyncDefog with no params")
+            AsyncDefog()
+
+    # test initialization with partial params
+    def test_async_defog_good_init_no_db_creds(self):
+        df = AsyncDefog("test_api_key", "redis")
+        self.assertEqual(df.api_key, "test_api_key")
+        self.assertEqual(df.db_type, "redis")
+        self.assertEqual(df.db_creds, {})
+
+    ### Case 2:
+    # no connection file, no params
+    def test_async_defog_bad_init_no_connection_file(self):
+        with self.assertRaises(ValueError):
+            print("Testing AsyncDefog with no connection file, no params")
+            AsyncDefog()
+
+    # no connection file, incomplete db_creds
+    def test_async_defog_bad_init_incomplete_creds(self):
+        with self.assertRaises(KeyError):
+            AsyncDefog("test_api_key", "postgres", {"host": "some_host"})
+
+    ### Case 3:
+    def test_async_defog_good_init(self):
+        print("testing AsyncDefog with good params")
+        db_creds = {
+            "host": "some_host",
+            "port": "some_port",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        df = AsyncDefog("test_api_key", "postgres", db_creds)
+        self.assertEqual(df.api_key, "test_api_key")
+        self.assertEqual(df.db_type, "postgres")
+        self.assertEqual(df.db_creds, db_creds)
+
+    ### Case 4:
+    def test_async_defog_no_overwrite(self):
+        db_creds = {
+            "host": "host",
+            "port": "port",
+            "database": "database",
+            "user": "user",
+            "password": "password",
+        }
+        df1 = AsyncDefog("old_api_key", "postgres", db_creds)
+        self.assertEqual(df1.api_key, "old_api_key")
+        self.assertEqual(df1.db_type, "postgres")
+        self.assertEqual(df1.db_creds, db_creds)
+        self.assertTrue(os.path.exists(self.filepath))
+        del df1
+        df2 = AsyncDefog()  # should read connection.json
+        self.assertEqual(df2.api_key, "old_api_key")
+        self.assertEqual(df2.db_type, "postgres")
+        self.assertEqual(df2.db_creds, db_creds)
+
+    ### Case 5:
+    @patch("builtins.input", lambda *args: "y")
+    def test_async_defog_overwrite(self):
+        db_creds = {
+            "host": "host",
+            "port": "port",
+            "database": "database",
+            "user": "user",
+            "password": "password",
+        }
+        df = AsyncDefog("old_api_key", "postgres", db_creds)
+        self.assertEqual(df.api_key, "old_api_key")
+        self.assertEqual(df.db_type, "postgres")
+        self.assertEqual(df.db_creds, db_creds)
+        self.assertTrue(os.path.exists(self.filepath))
+        df = AsyncDefog("new_api_key", "redshift")
+        self.assertEqual(df.api_key, "new_api_key")
+        self.assertEqual(df.db_type, "redshift")
+        self.assertEqual(df.db_creds, {})
+
+    @patch("builtins.input", lambda *args: "n")
+    def test_async_defog_no_overwrite(self):
+        db_creds = {
+            "host": "host",
+            "port": "port",
+            "database": "database",
+            "user": "user",
+            "password": "password",
+        }
+        df = AsyncDefog("old_api_key", "postgres", db_creds)
+        self.assertEqual(df.api_key, "old_api_key")
+        self.assertEqual(df.db_type, "postgres")
+        self.assertEqual(df.db_creds, db_creds)
+        self.assertTrue(os.path.exists(self.filepath))
+        df = AsyncDefog("new_api_key", "redshift")
+        self.assertEqual(df.api_key, "new_api_key")
+        self.assertEqual(df.db_type, "redshift")
+        self.assertEqual(df.db_creds, {})
+
+    # test check_db_creds with all the different supported db types
+    def test_check_db_creds_postgres(self):
+        db_creds = {
+            "host": "some_host",
+            "port": "some_port",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        AsyncDefog.check_db_creds("postgres", db_creds)
+        AsyncDefog.check_db_creds("postgres", {})
+        with self.assertRaises(KeyError):
+            AsyncDefog.check_db_creds("postgres", {"host": "some_host"})
+
+    def test_check_db_creds_redshift(self):
+        db_creds = {
+            "host": "some_host",
+            "port": "some_port",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        AsyncDefog.check_db_creds("redshift", db_creds)
+        AsyncDefog.check_db_creds("redshift", {})
+        with self.assertRaises(KeyError):
+            AsyncDefog.check_db_creds("redshift", {"host": "some_host"})
+
+    def test_check_db_creds_mysql(self):
+        db_creds = {
+            "host": "some_host",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        AsyncDefog.check_db_creds("mysql", db_creds)
+        AsyncDefog.check_db_creds("mysql", {})
+        with self.assertRaises(KeyError):
+            AsyncDefog.check_db_creds("mysql", {"host": "some_host"})
+
+    async def test_check_db_creds_snowflake(self):
+        db_creds = {
+            "account": "some_account",
+            "warehouse": "some_warehouse",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        AsyncDefog.check_db_creds("snowflake", db_creds)
+        AsyncDefog.check_db_creds("snowflake", {})
+        with self.assertRaises(KeyError):
+            AsyncDefog.check_db_creds("snowflake", {"account": "some_account"})
+
+    def test_check_db_creds_mongo(self):
+        db_creds = {"connection_string": "some_connection_string"}
+        AsyncDefog.check_db_creds("mongo", db_creds)
+        AsyncDefog.check_db_creds("mongo", {})
+        with self.assertRaises(KeyError):
+            AsyncDefog.check_db_creds("mongo", {"account": "some_account"})
+
+    def test_check_db_creds_sqlserver(self):
+        db_creds = {
+            "server": "some_server",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        AsyncDefog.check_db_creds("sqlserver", db_creds)
+        AsyncDefog.check_db_creds("sqlserver", {})
+        with self.assertRaises(KeyError):
+            AsyncDefog.check_db_creds("sqlserver", {"account": "some_account"})
+
+    def test_check_db_creds_bigquery(self):
+        db_creds = {"json_key_path": "some_json_key_path"}
+        AsyncDefog.check_db_creds("bigquery", db_creds)
+        AsyncDefog.check_db_creds("bigquery", {})
+        with self.assertRaises(KeyError):
+            AsyncDefog.check_db_creds("bigquery", {"account": "some_account"})
+
+    def test_base64_encode_decode(self):
+        db_creds = {
+            "host": "some_host",
+            "port": "some_port",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        df1 = AsyncDefog("test_api_key", "postgres", db_creds)
+        df1_base64creds = df1.to_base64_creds()
+        df2 = AsyncDefog(base64creds=df1_base64creds)
+        self.assertEqual(df1.api_key, df2.api_key)
+        self.assertEqual(df1.api_key, "test_api_key")
+        self.assertEqual(df1.db_type, df2.db_type)
+        self.assertEqual(df1.db_type, "postgres")
+        self.assertEqual(df1.db_creds, df2.db_creds)
+        self.assertEqual(df1.db_creds, db_creds)
+
+    def test_save_json(self):
+        db_creds = {
+            "host": "some_host",
+            "port": "some_port",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        _ = AsyncDefog("test_api_key", "postgres", db_creds, save_json=True)
+        self.assertTrue(os.path.exists(self.filepath))
+
+    def test_no_save_json(self):
+        db_creds = {
+            "host": "some_host",
+            "port": "some_port",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
+        }
+        df_save = AsyncDefog("test_api_key", "postgres", db_creds, save_json=False)
+        self.assertTrue(not os.path.exists(self.filepath))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,7 +4,13 @@ import shutil
 import unittest
 from unittest import mock
 
-from defog.query import is_connection_error, execute_query_once, execute_query
+from defog.query import (
+    is_connection_error,
+    execute_query_once,
+    execute_query,
+    async_execute_query_once,
+    async_execute_query,
+)
 
 
 class ExecuteQueryOnceTestCase(unittest.TestCase):
@@ -168,6 +174,200 @@ class ExecuteQueryOnceTestCase(unittest.TestCase):
         )
 
         # check that err logs are populated
+        with open(self.logs_path, "r") as f:
+            lines = f.readlines()
+            self.assertEqual(len(lines), 5)
+            self.assertIn(err_msg, lines[0])
+            self.assertIn(f"Retries left: {retries}", lines[1])
+            self.assertIn(json.dumps(json_req), lines[2])
+
+
+class ExecuteAsyncQueryOnceTestCase(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(self):
+        # if connection.json exists, copy it to /tmp since we'll be overwriting it
+        home_dir = os.path.expanduser("~")
+        self.logs_path = os.path.join(home_dir, ".defog", "logs")
+        self.tmp_dir = os.path.join("/tmp")
+        self.moved = False
+        if os.path.exists(self.logs_path):
+            print("Moving logs to /tmp")
+            if os.path.exists(os.path.join(self.tmp_dir, "logs")):
+                os.remove(os.path.join(self.tmp_dir, "logs"))
+            shutil.move(self.logs_path, self.tmp_dir)
+            self.moved = True
+
+    @classmethod
+    def tearDownClass(self):
+        # copy back the original after all tests have completed
+        if self.moved:
+            print("Moving logs back to ~/.defog")
+            shutil.move(os.path.join(self.tmp_dir, "logs"), self.logs_path)
+
+    @mock.patch("asyncpg.connect")
+    async def test_async_execute_query_once_success(self, mock_connect):
+        # Mock the asyncpg.connect function
+        mock_cursor = mock_connect.return_value.fetch
+        mock_cursor.return_value = [
+            {"col1": "data1", "col2": "data2"},
+            {"col1": "data3", "col2": "data4"},
+        ]
+
+        db_type = "postgres"
+        db_creds = {
+            "host": "localhost",
+            "port": 5432,
+            "database": "test_db",
+            "user": "test_user",
+            "password": "test_password",
+        }
+        query = "SELECT * FROM table_name;"
+
+        colnames, results = await async_execute_query_once(db_type, db_creds, query)
+
+        # Add your assertions here to validate the results
+        self.assertEqual(colnames, ["col1", "col2"])
+        self.assertEqual(results, [["data1", "data2"], ["data3", "data4"]])
+        print("Postgres async query execution test passed!")
+
+    @mock.patch("aiohttp.ClientSession.post")
+    @mock.patch("defog.query.async_execute_query_once")
+    async def test_async_execute_query_success(
+        self, mock_execute_query_once, mock_aiohttp_post
+    ):
+        # Mock the execute_query_once function
+        db_type = "postgres"
+        db_creds = {
+            "host": "localhost",
+            "port": 5432,
+            "database": "test_db",
+            "user": "test_user",
+            "password": "test_password",
+        }
+        query1 = "SELECT * FROM table_name;"
+        query2 = "SELECT * FROM new_table_name;"
+        api_key = "your_api_key"
+        question = "your_question"
+        hard_filters = "your_hard_filters"
+        retries = 3
+
+        # Set up the mock responses
+        mock_execute_query_once.return_value = (
+            ["col1", "col2"],
+            [["data1", "data2"], ["data3", "data4"]],
+        )
+
+        # Mock the async aiohttp response
+        mock_response = mock.Mock()
+        mock_response.json = mock.AsyncMock(return_value={"new_query": query2})
+        mock_aiohttp_post.return_value.__aenter__.return_value = mock_response
+
+        # Call the function being tested
+        colnames, results, rcv_query = await async_execute_query(
+            query1, api_key, db_type, db_creds, question, hard_filters, retries
+        )
+
+        # Assert the expected behavior
+        mock_execute_query_once.assert_called_once_with(
+            db_type="postgres",  # Use keyword arguments for db_type
+            db_creds={
+                "host": "localhost",
+                "port": 5432,
+                "database": "test_db",
+                "user": "test_user",
+                "password": "test_password",
+            },  # Use keyword arguments for db_creds
+            query="SELECT * FROM table_name;",  # Use keyword arguments for query
+        )
+
+        # Since there should be no retry, aiohttp post should not be called
+        mock_aiohttp_post.assert_not_called()
+
+        self.assertEqual(colnames, ["col1", "col2"])
+        self.assertEqual(results, [["data1", "data2"], ["data3", "data4"]])
+        self.assertEqual(rcv_query, query1)  # should return the original query
+
+    @mock.patch("aiohttp.ClientSession.post")
+    @mock.patch("defog.query.async_execute_query_once")
+    async def test_execute_query_success_with_retry(
+        self, mock_execute_query_once, mock_aiohttp_post
+    ):
+        db_type = "postgres"
+        db_creds = {
+            "host": "localhost",
+            "port": 5432,
+            "database": "test_db",
+            "user": "test_user",
+            "password": "test_password",
+        }
+        query1 = "SELECT * FROM table_name;"
+        query2 = "SELECT * FROM table_name WHERE colour='blue';"
+        api_key = "your_api_key"
+        question = "your_question"
+        hard_filters = "your_hard_filters"
+        retries = 3
+        dev = False
+        temp = False
+        colnames = (["col1", "col2"],)
+        results = [("data1", "data2"), ("data3", "data4")]
+
+        # Mock the execute_query_once function to raise an exception the first
+        # time it is called and return the results the second time it is called
+        err_msg = "Test exception"
+
+        def side_effect(db_type, db_creds, query):
+            if query == query1:
+                raise Exception(err_msg)
+            else:
+                return colnames, results
+
+        mock_execute_query_once.side_effect = side_effect
+
+        # Mock the async aiohttp response for the retry query
+        mock_response = mock.Mock()
+        mock_response.json = mock.AsyncMock(return_value={"new_query": query2})
+        mock_aiohttp_post.return_value.__aenter__.return_value = mock_response
+
+        # remove logs if they exist
+        if os.path.exists(os.path.join(self.logs_path)):
+            os.remove(os.path.join(self.logs_path))
+
+        # Call the function being tested
+        ret = await async_execute_query(
+            query=query1,
+            api_key=api_key,
+            db_type=db_type,
+            db_creds=db_creds,
+            question=question,
+            hard_filters=hard_filters,
+            retries=retries,
+        )
+
+        # should return new query2 instead of query1
+        self.assertEqual(ret, (colnames, results, query2))
+
+        # Assert the mock function calls
+        mock_execute_query_once.assert_called_with(db_type, db_creds, query2)
+
+        json_req = {
+            "api_key": api_key,
+            "previous_query": query1,
+            "error": err_msg,
+            "db_type": db_type,
+            "hard_filters": hard_filters,
+            "question": question,
+            "dev": dev,
+            "temp": temp,
+        }
+
+        # Assert aiohttp post was called with the correct arguments
+        mock_aiohttp_post.assert_called_with(
+            "https://api.defog.ai/retry_query_after_error",
+            json=json_req,
+            timeout=None,
+        )
+
+        # check that error logs are populated
         with open(self.logs_path, "r") as f:
             lines = f.readlines()
             self.assertEqual(len(lines), 5)


### PR DESCRIPTION
For `postgres` and `redshift`, we have the asynchronous `asyncpg` to replace `psycopg2`
For `mysql`, we have `aiomysql` to replace `mysql.converter`
For `snowflake`, we use the same connector as it also offers a `cur.execute_async` method- we then poll the status of the query id to see if its done running otherwise just simulate an async sleep using `await asyncio.sleep(1) `.
For `sqlserver`, we use `aioodbc` which has the exact same signature as `pyodbc` but is asynchronous and must be awaited.

However, for `Databricks` and `BigQuery`, no native asynchronous alternatives were found. To mimic asynchronous behavior for these databases, we are using `asyncio.to_thread` to handle blocking operations in a non-blocking manner.


Methods of `AsyncDefog` have the exact same signature (name, params) but have to be `awaited`. The initial methods like `save_connection_json, check_db_creds, to_base64_creds, from_base64_creds` are kept as it is (not made async) but do let me know if those also need to be async and that will be a 3 mins fix (because it will just need a wrapper off its parent class's methods into an async function i.e `async def function(): return self.function()`).



`create_table_ddl` and `create_ddl_from_metadata` also made async under `async_admin_methods` for the sake of consistency even though they are not I/O bound or db intensive.

 