### PR TITLE
Return table names in postgres for non 'public' schemas, too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.65.10",
+    version="0.65.11",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
Previously, Defog we would not show tables/views that were not part of the default schema. 

From a customer's email:

> Currently, in the select tables dropdown Defog is only able to detect the tables/views that are a part of the default schema. If I want to add tables from a schema, I would need to manually paste it in like so: <schema_name>.<table_name> 

With this PR, this is now fixed. A corresponding fix in defog-self-hosted is coming up