### PR TITLE
Remove SSL verification, add better support for postgres metadata generation with schemas

### DIFF
--- a/defog/admin_methods.py
+++ b/defog/admin_methods.py
@@ -316,7 +316,7 @@ def create_ddl_from_metadata(
     md_create = ""
     for table_name, columns in metadata.items():
         if "." in table_name:
-            table_name = table_name.split(".", 1)[1]
+            # table_name = table_name.split(".", 1)[1]
             schema_name = table_name.split(".")[0]
 
             md_create += f"CREATE SCHEMA IF NOT EXISTS {schema_name};\n"

--- a/defog/admin_methods.py
+++ b/defog/admin_methods.py
@@ -32,6 +32,7 @@ def update_db_schema(self, path_to_csv, dev=False, temp=False):
             "dev": dev,
             "temp": temp,
         },
+        verify=False,
     )
     resp = r.json()
     return resp
@@ -58,7 +59,7 @@ def update_glossary(
     }
     if customized_glossary:
         data["customized_glossary"] = customized_glossary
-    r = requests.post(f"{self.base_url}/update_glossary", json=data)
+    r = requests.post(f"{self.base_url}/update_glossary", json=data, verify=False)
     resp = r.json()
     return resp
 
@@ -73,7 +74,7 @@ def delete_glossary(self, user_type=None, dev=False):
     }
     if user_type:
         data["key"] = user_type
-    r = requests.post(f"{self.base_url}/delete_glossary", json=data)
+    r = requests.post(f"{self.base_url}/delete_glossary", json=data, verify=False)
     if r.status_code == 200:
         print("Glossary deleted successfully.")
     else:
@@ -88,6 +89,7 @@ def get_glossary(self, mode="general", dev=False):
     r = requests.post(
         f"{self.base_url}/get_metadata",
         json={"api_key": self.api_key, "dev": dev},
+        verify=False,
     )
     resp = r.json()
     if mode == "general":
@@ -103,6 +105,7 @@ def get_metadata(self, format="markdown", export_path=None, dev=False):
     r = requests.post(
         f"{self.base_url}/get_metadata",
         json={"api_key": self.api_key, "dev": dev},
+        verify=False,
     )
     resp = r.json()
     items = []
@@ -131,8 +134,7 @@ def get_feedback(self, n_rows: int = 50, start_from: int = 0):
     Gets the feedback on the defog servers.
     """
     r = requests.post(
-        f"{self.base_url}/get_feedback",
-        json={"api_key": self.api_key},
+        f"{self.base_url}/get_feedback", json={"api_key": self.api_key}, verify=False
     )
     resp = r.json()
     df = pd.DataFrame(resp["data"], columns=resp["columns"])
@@ -149,8 +151,7 @@ def get_quota(self) -> Optional[Dict]:
     """
     api_key = self.api_key
     response = requests.post(
-        f"{self.base_url}/check_api_usage",
-        json={"api_key": api_key},
+        f"{self.base_url}/check_api_usage", json={"api_key": api_key}, verify=False
     )
     # get status code and return None if not 200
     if response.status_code != 200:
@@ -187,6 +188,7 @@ def update_golden_queries(
             "scrub": scrub,
             "dev": dev,
         },
+        verify=False,
     )
     resp = r.json()
     print(
@@ -220,6 +222,7 @@ def delete_golden_queries(
         r = requests.post(
             f"{self.base_url}/delete_golden_queries",
             json={"api_key": self.api_key, "all": True, "dev": dev},
+            verify=False,
         )
         resp = r.json()
         print("All golden queries have now been deleted.")
@@ -235,6 +238,7 @@ def delete_golden_queries(
                 "api_key": self.api_key,
                 "golden_queries": golden_queries,
             },
+            verify=False,
         )
         resp = r.json()
     return resp
@@ -252,6 +256,7 @@ def get_golden_queries(
             "api_key": self.api_key,
             "dev": dev,
         },
+        verify=False,
     )
     resp = r.json()
     golden_queries = resp["golden_queries"]

--- a/defog/async_admin_methods.py
+++ b/defog/async_admin_methods.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional
 from defog.util import make_async_post_request
 import pandas as pd
 import asyncio
-import aiofiles
 
 
 async def update_db_schema(self, path_to_csv, dev=False, temp=False):
@@ -258,7 +257,7 @@ async def get_golden_queries(
         if export_path is None:
             export_path = "golden_queries.json"
         # Writing JSON asynchronously
-        async with aiofiles.open(export_path, "w") as f:
+        async with open(export_path, "w") as f:
             await f.write(json.dumps(resp, indent=4))
         print(f"{len(golden_queries)} golden queries exported to {export_path}")
         return golden_queries

--- a/defog/async_admin_methods.py
+++ b/defog/async_admin_methods.py
@@ -310,7 +310,7 @@ async def create_ddl_from_metadata(
     md_create = ""
     for table_name, columns in metadata.items():
         if "." in table_name:
-            table_name = table_name.split(".", 1)[1]
+            # table_name = table_name.split(".", 1)[1]
             schema_name = table_name.split(".")[0]
 
             md_create += f"CREATE SCHEMA IF NOT EXISTS {schema_name};\n"

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -368,6 +368,7 @@ def vet_metadata():
                     "column_name": column_name,
                     "column_description": column_description,
                 },
+                verify=False,
             )
             resp = r.json()
             new_column_description = resp["column_description"]

--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -66,27 +66,28 @@ def generate_postgres_schema(
     table_columns = {}
 
     # get the columns for each table
-    for schema in schemas:
-        for table_name in tables:
-            if "." in table_name:
-                _, table_name = table_name.split(".", 1)
-            cur.execute(
-                "SELECT CAST(column_name AS TEXT), CAST(data_type AS TEXT) FROM information_schema.columns WHERE table_name::text = %s AND table_schema = %s;",
-                (
-                    table_name,
-                    schema,
-                ),
-            )
-            rows = cur.fetchall()
-            rows = [row for row in rows]
-            rows = [{"column_name": i[0], "data_type": i[1]} for i in rows]
-            if len(rows) > 0:
-                if scan:
-                    rows = identify_categorical_columns(cur, table_name, rows)
-                if schema == "public":
-                    table_columns[table_name] = rows
-                else:
-                    table_columns[schema + "." + table_name] = rows
+    for table_name in tables:
+        if "." in table_name:
+            schema, table_name = table_name.split(".", 1)
+        else:
+            schema = "public"
+        cur.execute(
+            "SELECT CAST(column_name AS TEXT), CAST(data_type AS TEXT) FROM information_schema.columns WHERE table_name::text = %s AND table_schema = %s;",
+            (
+                table_name,
+                schema,
+            ),
+        )
+        rows = cur.fetchall()
+        rows = [row for row in rows]
+        rows = [{"column_name": i[0], "data_type": i[1]} for i in rows]
+        if len(rows) > 0:
+            if scan:
+                rows = identify_categorical_columns(cur, table_name, rows)
+            if schema == "public":
+                table_columns[table_name] = rows
+            else:
+                table_columns[schema + "." + table_name] = rows
     conn.close()
 
     print(

--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -100,6 +100,7 @@ def generate_postgres_schema(
                 "api_key": self.api_key,
                 "schemas": table_columns,
             },
+            verify=False,
         )
         resp = r.json()
         if "csv" in resp:
@@ -193,6 +194,7 @@ def generate_redshift_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
+            verify=False,
         )
         resp = r.json()
         if "csv" in resp:
@@ -268,6 +270,7 @@ def generate_mysql_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
+            verify=False,
         )
         resp = r.json()
         if "csv" in resp:
@@ -342,6 +345,7 @@ def generate_databricks_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
+            verify=False,
         )
         resp = r.json()
         if "csv" in resp:
@@ -435,6 +439,7 @@ def generate_snowflake_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
+            verify=False,
         )
         resp = r.json()
         if "csv" in resp:
@@ -508,6 +513,7 @@ def generate_bigquery_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
+            verify=False,
         )
         resp = r.json()
         if "csv" in resp:
@@ -589,6 +595,7 @@ def generate_sqlserver_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
+            verify=False,
         )
         resp = r.json()
         if "csv" in resp:

--- a/defog/health_methods.py
+++ b/defog/health_methods.py
@@ -9,6 +9,7 @@ def check_golden_queries_coverage(self, dev: bool = False):
         r = requests.post(
             f"{self.base_url}/get_golden_queries_coverage",
             json={"api_key": self.api_key, "dev": dev},
+            verify=False,
         )
         resp = r.json()
         return resp
@@ -24,6 +25,7 @@ def check_md_valid(self, dev: bool = False):
         r = requests.post(
             f"{self.base_url}/check_md_valid",
             json={"api_key": self.api_key, "db_type": self.db_type, "dev": dev},
+            verify=False,
         )
         resp = r.json()
         return resp
@@ -38,6 +40,7 @@ def check_gold_queries_valid(self, dev: bool = False):
     r = requests.post(
         f"{self.base_url}/check_gold_queries_valid",
         json={"api_key": self.api_key, "db_type": self.db_type, "dev": dev},
+        verify=False,
     )
     resp = r.json()
     return resp
@@ -50,6 +53,7 @@ def check_glossary_valid(self, dev: bool = False):
     r = requests.post(
         f"{self.base_url}/check_glossary_valid",
         json={"api_key": self.api_key, "dev": dev},
+        verify=False,
     )
     resp = r.json()
     return resp
@@ -62,6 +66,7 @@ def check_glossary_consistency(self, dev: bool = False):
     r = requests.post(
         f"{self.base_url}/check_glossary_consistency",
         json={"api_key": self.api_key, "dev": dev},
+        verify=False,
     )
     resp = r.json()
     return resp

--- a/defog/query.py
+++ b/defog/query.py
@@ -339,6 +339,7 @@ def execute_query(
                     "temp": temp,
                 },
                 timeout=1,
+                verify=False,
             )
         except:
             pass
@@ -364,6 +365,7 @@ def execute_query(
                 r = requests.post(
                     f"{base_url}/retry_query_after_error",
                     json=retry,
+                    verify=False,
                 )
                 response = r.json()
                 new_query = response["new_query"]

--- a/defog/query.py
+++ b/defog/query.py
@@ -1,7 +1,7 @@
 import json
 import re
 import requests
-from defog.util import write_logs, async_write_logs, make_async_post_request
+from defog.util import write_logs, make_async_post_request
 import asyncio
 import os
 
@@ -433,10 +433,10 @@ async def async_execute_query(
         except:
             pass
         # log locally
-        await async_write_logs(str(e))
+        write_logs(str(e))
         # retry with adaptive learning
         while retries > 0:
-            await async_write_logs(f"Retries left: {retries}")
+            write_logs(f"Retries left: {retries}")
             try:
                 retry = {
                     "api_key": api_key,
@@ -451,14 +451,14 @@ async def async_execute_query(
                 if schema is not None:
                     retry["schema"] = schema
 
-                await async_write_logs(json.dumps(retry))
+                write_logs(json.dumps(retry))
 
                 response = await make_async_post_request(
                     url=f"{base_url}/retry_query_after_error",
                     payload=retry,
                 )
                 new_query = response["new_query"]
-                await async_write_logs(f"New query: \n{new_query}")
+                write_logs(f"New query: \n{new_query}")
                 return await async_execute_query_once(db_type, db_creds, new_query) + (
                     new_query,
                 )

--- a/defog/query_methods.py
+++ b/defog/query_methods.py
@@ -56,6 +56,7 @@ def get_query(
             self.generate_query_url,
             json=data,
             timeout=300,
+            verify=False,
         )
         resp = r.json()
         t_end = datetime.now()

--- a/defog/util.py
+++ b/defog/util.py
@@ -443,7 +443,7 @@ def get_feedback(
 
 
 async def make_async_post_request(
-    url: str, payload: dict, timeout=None, return_response_object=False
+    url: str, payload: dict, timeout=300, return_response_object=False
 ):
     """
     Helper function to make async POST requests and defaults to return the JSON response. Optionally allows returning the response object itself.

--- a/defog/util.py
+++ b/defog/util.py
@@ -5,7 +5,6 @@ from prompt_toolkit import prompt
 import requests
 
 import aiohttp
-import aiofiles
 import asyncio
 
 
@@ -70,7 +69,7 @@ async def async_write_logs(msg: str) -> None:
     try:
         if not os.path.exists(log_file_path):
             os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
-        async with aiofiles.open(log_file_path, "a") as file:
+        async with open(log_file_path, "a") as file:
             await file.write(msg + "\n")
     except Exception as e:
         pass

--- a/defog/util.py
+++ b/defog/util.py
@@ -56,25 +56,6 @@ def write_logs(msg: str) -> None:
         pass
 
 
-async def async_write_logs(msg: str) -> None:
-    """
-    Asynchronously write out log messages to ~/.defog/logs to avoid bloating cli output,
-    while still preserving more verbose error messages when debugging.
-
-    Args:
-        msg (str): The message to write.
-    """
-    log_file_path = os.path.expanduser("~/.defog/logs")
-
-    try:
-        if not os.path.exists(log_file_path):
-            os.makedirs(os.path.dirname(log_file_path), exist_ok=True)
-        async with open(log_file_path, "a") as file:
-            await file.write(msg + "\n")
-    except Exception as e:
-        pass
-
-
 def is_str_type(data_type: str) -> bool:
     """
     Check if the given data_type is a string type.

--- a/defog/util.py
+++ b/defog/util.py
@@ -273,6 +273,7 @@ def get_feedback(
             f"{base_url}/feedback",
             json=data,
             timeout=1,
+            verify=False,
         )
         if feedback == "y":
             print("Thank you for the feedback!")
@@ -289,6 +290,7 @@ def get_feedback(
             response = requests.post(
                 f"{base_url}/reflect_on_error",
                 json=data,
+                verify=False,
             )
 
             if response.status_code == 200:
@@ -309,6 +311,7 @@ def get_feedback(
                         md_resp = requests.post(
                             f"{base_url}/get_metadata",
                             json={"api_key": api_key},
+                            verify=False,
                         )
                         md_resp_dict = md_resp.json()
                         glossary_current = md_resp_dict.get("glossary", "")
@@ -319,12 +322,14 @@ def get_feedback(
                                 "api_key": api_key,
                                 "glossary": glossary_updated,
                             },
+                            verify=False,
                         )
                         print("Glossary updated successfully.\n")
                     elif add_to_glossary != "n":
                         md_resp = requests.post(
                             f"{base_url}/get_metadata",
                             json={"api_key": api_key},
+                            verify=False,
                         )
                         md_resp_dict = md_resp.json()
                         glossary_current = md_resp_dict.get("glossary", "")
@@ -335,6 +340,7 @@ def get_feedback(
                                 "api_key": api_key,
                                 "glossary": glossary_updated,
                             },
+                            verify=False,
                         )
                         print("Glossary updated successfully.\n")
                     else:
@@ -350,6 +356,7 @@ def get_feedback(
                     r = requests.post(
                         f"{base_url}/get_metadata",
                         json={"api_key": api_key},
+                        verify=False,
                     )
                     resp = r.json()
                     md = resp.get("table_metadata", {})
@@ -392,6 +399,7 @@ def get_feedback(
                                 "table_metadata": new_column_description,
                                 "db_type": db_type,
                             },
+                            verify=False,
                         )
                         print("Metadata updated successfully.\n")
                     else:
@@ -423,6 +431,7 @@ def get_feedback(
                                 "golden_queries": reference_queries_to_add,
                                 "scrub": True,
                             },
+                            verify=False,
                         )
                         if r.status_code == 200:
                             print(

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ aioodbc
 pwinput
 requests>=2.28.2
 aiohttp
-aiofiles
 tabulate
 uvicorn
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.65.13",
+    version="0.65.14",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",
@@ -38,6 +38,7 @@ setup(
         "uvicorn",
         "tqdm",
         "pwinput",
+        "aiohttp",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.65.11",
+    version="0.65.13",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.65.14",
+    version="0.65.16",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -363,7 +363,7 @@ class ExecuteAsyncQueryOnceTestCase(unittest.IsolatedAsyncioTestCase):
 
         # Assert aiohttp post was called with the correct arguments
         mock_aiohttp_post.assert_called_with(
-            "https://api.defog.ai/retry_query_after_error", json=json_req, timeout=None
+            "https://api.defog.ai/retry_query_after_error", json=json_req, timeout=300
         )
 
         # check that error logs are populated

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -363,10 +363,7 @@ class ExecuteAsyncQueryOnceTestCase(unittest.IsolatedAsyncioTestCase):
 
         # Assert aiohttp post was called with the correct arguments
         mock_aiohttp_post.assert_called_with(
-            "https://api.defog.ai/retry_query_after_error",
-            json=json_req,
-            timeout=None,
-            verify=False,
+            "https://api.defog.ai/retry_query_after_error", json=json_req, timeout=None
         )
 
         # check that error logs are populated

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -171,6 +171,7 @@ class ExecuteQueryOnceTestCase(unittest.TestCase):
         mock_requests_post.assert_called_with(
             "https://api.defog.ai/retry_query_after_error",
             json=json_req,
+            verify=False,
         )
 
         # check that err logs are populated
@@ -365,6 +366,7 @@ class ExecuteAsyncQueryOnceTestCase(unittest.IsolatedAsyncioTestCase):
             "https://api.defog.ai/retry_query_after_error",
             json=json_req,
             timeout=None,
+            verify=False,
         )
 
         # check that error logs are populated


### PR DESCRIPTION
This PR primarily does 2 things:

1. Adds `verify=False` to all HTTP requests. This ensures that the python library can run on machines that do not have a way to verify server side SSL certificates
2. Fixes the logic for generating metadata in postgres databases when querying from non default schemas

This has been pushed to pypi and has been tested in `defog-self-hosted`, so merging for now to minimize distractions for everyone else.