### PR TITLE
Tool Call Improvements

### DIFF
--- a/defog/llm/models.py
+++ b/defog/llm/models.py
@@ -1,12 +1,6 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from enum import Enum
-from typing import Optional, Union, Dict, Any
-
-
-class OpenAIToolChoice(Enum):
-    AUTO = "auto"  # default if not provided. calls 0, 1, or multiple functions
-    REQUIRED = "required"  # calls at least 1 function
-    NONE = "none"  # calls no functions
+from typing import Optional, Union, Dict, Any, Literal
 
 
 class OpenAIFunctionSpecs(BaseModel):
@@ -17,26 +11,9 @@ class OpenAIFunctionSpecs(BaseModel):
     )
 
 
-class OpenAIForcedFunction(BaseModel):
-    # a forced function call - forces a call to one specific function
-    type: str = "function"
-    function: OpenAIFunctionSpecs
-
-
-class AnthropicToolChoice(Enum):
-    AUTO = "auto"  # default if not provided. calls 0, 1, or multiple functions
-    REQUIRED = "required"  # calls at least 1 function
-
-
 class AnthropicFunctionSpecs(BaseModel):
     name: str  # name of the function to call
     description: Optional[str] = None  # description of the function
     input_schema: Optional[Union[str, Dict[str, Any]]] = (
         None  # parameters of the function
     )
-
-
-class AnthropicForcedFunction(BaseModel):
-    # a forced function call - forces a call to one specific function
-    type: str = "function"
-    function: AnthropicFunctionSpecs

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -532,6 +532,10 @@ def _build_openai_params(
         # not supported in o models
         if model in ["gpt-4o", "gpt-4o-mini"]:
             request_params["parallel_tool_calls"] = False
+    if tool_choice:
+        tool_names_list = [func.__name__ for func in tools]
+        tool_choice = convert_tool_choice(tool_choice, tool_names_list, model)
+        request_params["tool_choice"] = tool_choice
 
     # Some models do not allow temperature or response_format:
     if model.startswith("o") or model == "deepseek-reasoner":

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -127,7 +127,7 @@ def _build_anthropic_params(
             tool_choice = convert_tool_choice(tool_choice, tool_names_list, model)
             params["tool_choice"] = tool_choice
         else:
-            params["tool_choice"] = {"type" : "auto"}
+            params["tool_choice"] = {"type": "auto"}
 
     return params, messages  # returning updated messages in case we want them
 
@@ -230,9 +230,13 @@ async def _process_anthropic_response(
                         ],
                     }
                 )
-                
+
                 # Set tool_choice to "auto" so that the next message will be generated normally
-                request_params["tool_choice"] = {"type": "auto"} if request_params["tool_choice"] != "auto" else None
+                request_params["tool_choice"] = (
+                    {"type": "auto"}
+                    if request_params["tool_choice"] != "auto"
+                    else None
+                )
 
                 # Make next call
                 if is_async:
@@ -323,8 +327,8 @@ def chat_anthropic(
     - seed: NA
     - tools: The list of tools the model may call.
     - tool_choice: Controls which (if any) tool is called by the model.
-        "auto": calls 0, 1, or multiple functions, 
-        "required": calls at least one function, 
+        "auto": calls 0, 1, or multiple functions,
+        "required": calls at least one function,
         "<function_name>": calls only the specified function
 
     Returns:
@@ -401,8 +405,8 @@ async def chat_anthropic_async(
     - seed: NA
     - tools: The list of tools the model may call.
     - tool_choice: Controls which (if any) tool is called by the model.
-        "auto": calls 0, 1, or multiple functions, 
-        "required": calls at least one function, 
+        "auto": calls 0, 1, or multiple functions,
+        "required": calls at least one function,
         "<function_name>": calls only the specified function
     - store: NA
     - metadata: NA
@@ -641,7 +645,9 @@ async def _process_openai_response(
                 )
 
                 # Set tool_choice to "auto" so that the next message will be generated normally
-                request_params["tool_choice"] = "auto" if request_params["tool_choice"] != "auto" else None
+                request_params["tool_choice"] = (
+                    "auto" if request_params["tool_choice"] != "auto" else None
+                )
 
                 # Make next call
                 if is_async:
@@ -737,7 +743,7 @@ def chat_openai(
     tool_choice: str = None,
     base_url: str = "https://api.openai.com/v1/",
     api_key: str = os.environ.get("OPENAI_API_KEY", ""),
-    prediction: Dict[str, str] =None,
+    prediction: Dict[str, str] = None,
     reasoning_effort: str = None,
     store: bool = True,
     metadata: Dict[str, str] = None,
@@ -745,7 +751,7 @@ def chat_openai(
 ):
     """
     Synchronous OpenAI chat.
-    
+
     Parameters:
     - messages: The list of messages to send to the LLM.
     - model: The OpenAI model to use for the chat.
@@ -756,11 +762,11 @@ def chat_openai(
     - seed: If specified, OpenAI will try their best to sample deterministically
     - tools: The list of tools the model may call.
     - tool_choice: Controls which (if any) tool is called by the model.
-        "auto": calls 0, 1, or multiple functions, 
-        "required": calls at least one function, 
+        "auto": calls 0, 1, or multiple functions,
+        "required": calls at least one function,
         "<function_name>": calls only the specified function
     - base_url: The base URL to use for the chat.
-    - api_key: The OpenAI API key 
+    - api_key: The OpenAI API key
     - prediction: Configuration for a Predicted Output.
     - reasoning_effort: "low", "medium", or "high". Only for o1 and o3 models
     - store: Whether or not to store the output of this chat completion request for use in model distillation or evals products.
@@ -849,7 +855,7 @@ async def chat_openai_async(
 ):
     """
     Asynchronous OpenAI chat.
-    
+
     Parameters:
     - messages: The list of messages to send to the LLM.
     - model: The OpenAI model to use for the chat.
@@ -860,11 +866,11 @@ async def chat_openai_async(
     - seed: If specified, OpenAI will try their best to sample deterministically
     - tools: The list of tools the model may call.
     - tool_choice: Controls which (if any) tool is called by the model.
-        "auto": calls 0, 1, or multiple functions, 
-        "required": calls at least one function, 
+        "auto": calls 0, 1, or multiple functions,
+        "required": calls at least one function,
         "<function_name>": calls only the specified function
     - base_url: The base URL to use for the chat.
-    - api_key: The OpenAI API key 
+    - api_key: The OpenAI API key
     - prediction: Configuration for a Predicted Output.
     - reasoning_effort: "low", "medium", or "high". Only for o1 and o3 models
     - store: Whether or not to store the output of this chat completion request for use in model distillation or evals products.

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -194,6 +194,10 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
 
         self.arithmetic_qn = "What is the product of 31283 and 2323, added to 5? Return only the final answer, nothing else."
         self.arithmetic_answer = "72670414"
+        self.arithmetic_expected_tool_outputs = [
+            {"name": "numprod", "args": {"a": 31283, "b": 2323}, "result": 72670409},
+            {"name": "numsum", "args": {"a": 72670409, "b": 5}, "result": 72670414},
+        ]
 
     @pytest.mark.asyncio
     async def test_tool_use_arithmetic_async_openai(self):
@@ -210,6 +214,12 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=tools,
         )
         self.assertEqual(result.content, self.arithmetic_answer)
+        for expected, actual in zip(
+            self.arithmetic_expected_tool_outputs, result.tool_outputs
+        ):
+            self.assertEqual(expected["name"], actual["name"])
+            self.assertEqual(expected["args"], actual["args"])
+            self.assertEqual(expected["result"], actual["result"])
         self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
 
     @pytest.mark.asyncio
@@ -227,6 +237,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_retries=1,
         )
         self.assertSetEqual(set(result.tools_used), {"search"})
+        self.assertEqual(result.tool_outputs[0]["name"], "search")
         self.assertIn(self.search_answer, result.content.lower())
 
     @pytest.mark.asyncio
@@ -244,6 +255,12 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=tools,
         )
         self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        for expected, actual in zip(
+            self.arithmetic_expected_tool_outputs, result.tool_outputs
+        ):
+            self.assertEqual(expected["name"], actual["name"])
+            self.assertEqual(expected["args"], actual["args"])
+            self.assertEqual(expected["result"], actual["result"])
         self.assertEqual(result.content, self.arithmetic_answer)
 
     @pytest.mark.asyncio
@@ -261,6 +278,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_retries=1,
         )
         self.assertSetEqual(set(result.tools_used), {"search"})
+        self.assertEqual(result.tool_outputs[0]["name"], "search")
         self.assertIn(self.search_answer, result.content.lower())
 
     def test_async_tool_in_sync_function_openai(self):
@@ -276,6 +294,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=tools,
         )
         self.assertSetEqual(set(result_openai.tools_used), {"search"})
+        self.assertEqual(result_openai.tool_outputs[0]["name"], "search")
         self.assertIn(self.search_answer, result_openai.content.lower())
 
     def test_async_tool_in_sync_function_anthropic(self):
@@ -291,4 +310,5 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=tools,
         )
         self.assertSetEqual(set(result_anthropic.tools_used), {"search"})
+        self.assertEqual(result_anthropic.tool_outputs[0]["name"], "search")
         self.assertIn(self.search_answer, result_anthropic.content.lower())

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -386,7 +386,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         self.assertSetEqual(set(result.tools_used), {"numprod"})
         self.assertEqual(result.tool_outputs[0]["name"], "numprod")
         self.assertEqual(result.tool_outputs[0]["result"], 204)
-        self.assertIn("204", result.content.lower())
 
     def test_invalid_forced_tool_choice_openai(self):
         """

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -310,3 +310,38 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         self.assertSetEqual(set(result.tools_used), {"search"})
         self.assertEqual(result.tool_outputs[0]["name"], "search")
         self.assertIn(self.search_answer, result.content.lower())
+
+    def test_required_tool_choice_openai(self):
+        result = chat_openai(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Give me the result of 102 + 2",
+                },
+            ],
+            tools=self.tools,
+            tool_choice="required",
+        )
+        print(result)
+        self.assertSetEqual(set(result.tools_used), {"numsum"})
+        self.assertEqual(result.tool_outputs[0]["name"], "numsum")
+        self.assertIn("104", result.content.lower())
+
+    def test_required_tool_choice_anthropic(self):
+        result = chat_anthropic(
+            model="claude-3-haiku-20240307",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Give me the result of 102 + 2",
+                },
+            ],
+            tools=self.tools,
+            tool_choice="required",
+            max_completion_tokens=1000,
+        )
+        print(result)
+        self.assertSetEqual(set(result.tools_used), {"numsum"})
+        self.assertEqual(result.tool_outputs[0]["name"], "numsum")
+        self.assertIn("104", result.content.lower())

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -1,76 +1,294 @@
 import unittest
 import pytest
-from defog.llm.utils import chat_async
-from pydantic import BaseModel
-import aiohttp
+from defog.llm.utils import chat_async, chat_openai, chat_anthropic
+from defog.llm.utils_function_calling import get_function_specs
+from pydantic import BaseModel, Field
+import httpx
+import os
+from bs4 import BeautifulSoup
+
+DEFOG_API_KEY = os.environ.get("DEFOG_API_KEY")
+
+if DEFOG_API_KEY is None:
+    raise ValueError("DEFOG_API_KEY is not set, the search test cannot be run")
+
+# ==================================================================================================
+# Functions for function calling
+# ==================================================================================================
 
 
-class WeatherInput(BaseModel):
-    latitude: float
-    longitude: float
-
-
-async def get_weather(input: WeatherInput):
+def clean_html_text(html_text):
     """
-    This function returns the current temperature (in celsius) for the given latitude and longitude.
+    Remove HTML tags from the given HTML text and return plain text.
+
+    Args:
+        html_text (str): A string containing HTML content.
+
+    Returns:
+        str: A string with the HTML tags removed.
     """
-    async with aiohttp.ClientSession() as client:
-        r = await client.get(
-            f"https://api.open-meteo.com/v1/forecast?latitude={input.latitude}&longitude={input.longitude}&current=temperature_2m,wind_speed_10m&hourly=temperature_2m,relative_humidity_2m,wind_speed_10m",
+    # Parse the HTML content
+    soup = BeautifulSoup(html_text, "html.parser")
+
+    # Extract text from the parsed HTML
+    # The separator parameter defines what string to insert between text blocks.
+    # strip=True removes leading and trailing whitespace from each piece of text.
+    cleaned_text = soup.get_text(separator=" ", strip=True)
+
+    return cleaned_text
+
+
+class SearchInput(BaseModel):
+    query: str = Field(default="", description="The query to search for")
+
+
+async def search(input: SearchInput):
+    """
+    This function searches Google for the given query. It then visits the first result page, and returns the HTML content of the page.
+    """
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            "https://api.defog.ai/unstructured_data/search",
+            json={"api_key": DEFOG_API_KEY, "user_question": input.query},
         )
-        return_object = await r.json()
-        return return_object["current"]["temperature_2m"]
+        first_result_link = r.json()["organic"][0]["link"]
+        r = await client.get(first_result_link)
+    return clean_html_text(r.text)
+
+
+class Numbers(BaseModel):
+    a: int = 0
+    b: int = 0
+
+
+def numsum(input: Numbers):
+    """
+    This function returns the sum of two numbers
+    """
+    return input.a + input.b
+
+
+def numprod(input: Numbers):
+    """
+    This function returns the product of two numbers
+    """
+    return input.a * input.b
+
+
+# ==================================================================================================
+# Tests
+# ==================================================================================================
+class TestGetFunctionSpecs(unittest.TestCase):
+    def setUp(self):
+        self.openai_model = "gpt-4o"
+        self.anthropic_model = "claude-3-haiku-20240307"
+        self.tools = [search, numsum, numprod]
+        self.maxDiff = None
+        self.openai_specs = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "search",
+                    "description": "This function searches Google for the given query. It then visits the first result page, and returns the HTML content of the page.",
+                    "parameters": {
+                        "properties": {
+                            "query": {
+                                "default": "",
+                                "description": "The query to search for",
+                                "title": "Query",
+                                "type": "string",
+                            }
+                        },
+                        "title": "SearchInput",
+                        "type": "object",
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "numsum",
+                    "description": "This function returns the sum of two numbers",
+                    "parameters": {
+                        "properties": {
+                            "a": {"default": 0, "title": "A", "type": "integer"},
+                            "b": {"default": 0, "title": "B", "type": "integer"},
+                        },
+                        "title": "Numbers",
+                        "type": "object",
+                    },
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "numprod",
+                    "description": "This function returns the product of two numbers",
+                    "parameters": {
+                        "properties": {
+                            "a": {"default": 0, "title": "A", "type": "integer"},
+                            "b": {"default": 0, "title": "B", "type": "integer"},
+                        },
+                        "title": "Numbers",
+                        "type": "object",
+                    },
+                },
+            },
+        ]
+        self.anthropic_specs = [
+            {
+                "name": "search",
+                "description": "This function searches Google for the given query. It then visits the first result page, and returns the HTML content of the page.",
+                "input_schema": {
+                    "properties": {
+                        "query": {
+                            "default": "",
+                            "description": "The query to search for",
+                            "title": "Query",
+                            "type": "string",
+                        }
+                    },
+                    "title": "SearchInput",
+                    "type": "object",
+                },
+            },
+            {
+                "name": "numsum",
+                "description": "This function returns the sum of two numbers",
+                "input_schema": {
+                    "properties": {
+                        "a": {"default": 0, "title": "A", "type": "integer"},
+                        "b": {"default": 0, "title": "B", "type": "integer"},
+                    },
+                    "title": "Numbers",
+                    "type": "object",
+                },
+            },
+            {
+                "name": "numprod",
+                "description": "This function returns the product of two numbers",
+                "input_schema": {
+                    "properties": {
+                        "a": {"default": 0, "title": "A", "type": "integer"},
+                        "b": {"default": 0, "title": "B", "type": "integer"},
+                    },
+                    "title": "Numbers",
+                    "type": "object",
+                },
+            },
+        ]
+
+    def test_get_function_specs(self):
+        openai_specs = get_function_specs(self.tools, self.openai_model)
+        anthropic_specs = get_function_specs(self.tools, self.anthropic_model)
+
+        self.assertEqual(openai_specs, self.openai_specs)
+        self.assertEqual(anthropic_specs, self.anthropic_specs)
 
 
 class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
-    @pytest.mark.asyncio
-    async def test_tool_use_arithmetic(self):
-        class Numbers(BaseModel):
-            a: int = 0
-            b: int = 0
+    def setUp(self):
+        self.tools = [search, numsum, numprod]
+        self.search_qn = "Who is the Prime Minister of Singapore right now (in 2025)? Recall that the current year is 2025. Return your answer as a single phrase."
+        self.search_answer = "lawrence wong"
 
-        def numsum(input: Numbers):
-            """
-            This function return the sum of two numbers
-            """
-            return input.a + input.b
-
-        def numprod(input: Numbers):
-            """
-            This function return the product of two numbers
-            """
-            return input.a * input.b
-
-        tools = [numsum, numprod]
-
-        for model in ["gpt-4o", "claude-3-5-sonnet-latest"]:
-            result = await chat_async(
-                model=model,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": "What is the product of 31283 and 2323, added to 5? Return only the final answer, nothing else.",
-                    },
-                ],
-                tools=tools,
-            )
-            self.assertEqual(result.content, "72670414")
+        self.arithmetic_qn = "What is the product of 31283 and 2323, added to 5? Return only the final answer, nothing else."
+        self.arithmetic_answer = "72670414"
 
     @pytest.mark.asyncio
-    async def test_tool_use_async_weather(self):
-        tools = [get_weather]
-        for model in ["gpt-4o", "claude-3-5-sonnet-latest"]:
-            result = await chat_async(
-                model=model,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": "What is the current temperature in Singapore? Return the answer as just a number.",
-                    },
-                ],
-                tools=tools,
-                max_retries=1,
-            )
-            # assert that the temperature is between 21 and 38
-            self.assertGreaterEqual(float(result.content), 21)
-            self.assertLessEqual(float(result.content), 38)
+    async def test_tool_use_arithmetic_async_openai(self):
+        tools = self.tools
+
+        result = await chat_async(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.arithmetic_qn,
+                },
+            ],
+            tools=tools,
+        )
+        self.assertEqual(result.content, self.arithmetic_answer)
+        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+
+    @pytest.mark.asyncio
+    async def test_tool_use_search_async_openai(self):
+        tools = self.tools
+        result = await chat_async(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.search_qn,
+                },
+            ],
+            tools=tools,
+            max_retries=1,
+        )
+        self.assertSetEqual(set(result.tools_used), {"search"})
+        self.assertIn(self.search_answer, result.content.lower())
+
+    @pytest.mark.asyncio
+    async def test_tool_use_arithmetic_async_anthropic(self):
+        tools = self.tools
+
+        result = await chat_async(
+            model="claude-3-haiku-20240307",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.arithmetic_qn,
+                },
+            ],
+            tools=tools,
+        )
+        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        self.assertEqual(result.content, self.arithmetic_answer)
+
+    @pytest.mark.asyncio
+    async def test_tool_use_search_async_anthropic(self):
+        tools = self.tools
+        result = await chat_async(
+            model="claude-3-haiku-20240307",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.search_qn,
+                },
+            ],
+            tools=tools,
+            max_retries=1,
+        )
+        self.assertSetEqual(set(result.tools_used), {"search"})
+        self.assertIn(self.search_answer, result.content.lower())
+
+    def test_async_tool_in_sync_function_openai(self):
+        tools = self.tools
+        result_openai = chat_openai(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.search_qn,
+                },
+            ],
+            tools=tools,
+        )
+        self.assertSetEqual(set(result_openai.tools_used), {"search"})
+        self.assertIn(self.search_answer, result_openai.content.lower())
+
+    def test_async_tool_in_sync_function_anthropic(self):
+        tools = self.tools
+        result_anthropic = chat_anthropic(
+            model="claude-3-5-sonnet-20241022",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.search_qn,
+                },
+            ],
+            tools=tools,
+        )
+        self.assertSetEqual(set(result_anthropic.tools_used), {"search"})
+        self.assertIn(self.search_answer, result_anthropic.content.lower())

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -201,8 +201,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_tool_use_arithmetic_async_openai(self):
-        tools = self.tools
-
         result = await chat_async(
             model="gpt-4o",
             messages=[
@@ -211,8 +209,9 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
                     "content": self.arithmetic_qn,
                 },
             ],
-            tools=tools,
+            tools=self.tools,
         )
+        print(result)
         self.assertEqual(result.content, self.arithmetic_answer)
         for expected, actual in zip(
             self.arithmetic_expected_tool_outputs, result.tool_outputs
@@ -224,7 +223,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_tool_use_search_async_openai(self):
-        tools = self.tools
         result = await chat_async(
             model="gpt-4o",
             messages=[
@@ -233,17 +231,16 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
                     "content": self.search_qn,
                 },
             ],
-            tools=tools,
+            tools=self.tools,
             max_retries=1,
         )
+        print(result)
         self.assertSetEqual(set(result.tools_used), {"search"})
         self.assertEqual(result.tool_outputs[0]["name"], "search")
         self.assertIn(self.search_answer, result.content.lower())
 
     @pytest.mark.asyncio
     async def test_tool_use_arithmetic_async_anthropic(self):
-        tools = self.tools
-
         result = await chat_async(
             model="claude-3-haiku-20240307",
             messages=[
@@ -252,8 +249,9 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
                     "content": self.arithmetic_qn,
                 },
             ],
-            tools=tools,
+            tools=self.tools,
         )
+        print(result)
         self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
         for expected, actual in zip(
             self.arithmetic_expected_tool_outputs, result.tool_outputs
@@ -265,7 +263,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
 
     @pytest.mark.asyncio
     async def test_tool_use_search_async_anthropic(self):
-        tools = self.tools
         result = await chat_async(
             model="claude-3-haiku-20240307",
             messages=[
@@ -274,16 +271,16 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
                     "content": self.search_qn,
                 },
             ],
-            tools=tools,
+            tools=self.tools,
             max_retries=1,
         )
+        print(result)
         self.assertSetEqual(set(result.tools_used), {"search"})
         self.assertEqual(result.tool_outputs[0]["name"], "search")
         self.assertIn(self.search_answer, result.content.lower())
 
     def test_async_tool_in_sync_function_openai(self):
-        tools = self.tools
-        result_openai = chat_openai(
+        result = chat_openai(
             model="gpt-4o",
             messages=[
                 {
@@ -291,15 +288,15 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
                     "content": self.search_qn,
                 },
             ],
-            tools=tools,
+            tools=self.tools,
         )
-        self.assertSetEqual(set(result_openai.tools_used), {"search"})
-        self.assertEqual(result_openai.tool_outputs[0]["name"], "search")
-        self.assertIn(self.search_answer, result_openai.content.lower())
+        print(result)
+        self.assertSetEqual(set(result.tools_used), {"search"})
+        self.assertEqual(result.tool_outputs[0]["name"], "search")
+        self.assertIn(self.search_answer, result.content.lower())
 
     def test_async_tool_in_sync_function_anthropic(self):
-        tools = self.tools
-        result_anthropic = chat_anthropic(
+        result = chat_anthropic(
             model="claude-3-5-sonnet-20241022",
             messages=[
                 {
@@ -307,8 +304,9 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
                     "content": self.search_qn,
                 },
             ],
-            tools=tools,
+            tools=self.tools,
         )
-        self.assertSetEqual(set(result_anthropic.tools_used), {"search"})
-        self.assertEqual(result_anthropic.tool_outputs[0]["name"], "search")
-        self.assertIn(self.search_answer, result_anthropic.content.lower())
+        print(result)
+        self.assertSetEqual(set(result.tools_used), {"search"})
+        self.assertEqual(result.tool_outputs[0]["name"], "search")
+        self.assertIn(self.search_answer, result.content.lower())

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -345,3 +345,88 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         self.assertSetEqual(set(result.tools_used), {"numsum"})
         self.assertEqual(result.tool_outputs[0]["name"], "numsum")
         self.assertIn("104", result.content.lower())
+
+    def test_forced_tool_choice_openai(self):
+        """
+        This test forces the use of numprod even though the user question asks for addition.
+        """
+        result = chat_openai(
+            model="gpt-4o",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Give me the result of 102 + 2",
+                },
+            ],
+            tools=self.tools,
+            tool_choice="numprod",
+        )
+        print(result)
+        self.assertSetEqual(set(result.tools_used), {"numprod"})
+        self.assertEqual(result.tool_outputs[0]["name"], "numprod")
+        self.assertEqual(result.tool_outputs[0]["result"], 204)
+
+    def test_forced_tool_choice_anthropic(self):
+        """
+        This test forces the use of numprod even though the user question asks for addition.
+        """
+        result = chat_anthropic(
+            model="claude-3-haiku-20240307",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Give me the result of 102 + 2",
+                },
+            ],
+            tools=self.tools,
+            tool_choice="numprod",
+            max_completion_tokens=1000,
+        )
+        print(result)
+        self.assertSetEqual(set(result.tools_used), {"numprod"})
+        self.assertEqual(result.tool_outputs[0]["name"], "numprod")
+        self.assertEqual(result.tool_outputs[0]["result"], 204)
+        self.assertIn("204", result.content.lower())
+
+    def test_invalid_forced_tool_choice_openai(self):
+        """
+        This test forces the use of an invalid tool `sum` and checks that an error is raised
+        """
+        with self.assertRaises(ValueError) as context:
+            result = chat_openai(
+                model="gpt-4o",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": self.arithmetic_qn,
+                    },
+                ],
+                tools=self.tools,
+                tool_choice="sum",
+            )
+        self.assertEqual(
+            str(context.exception),
+            "Forced function `sum` is not in the list of provided tools",
+        )
+
+    def test_invalid_forced_tool_choice_anthropic(self):
+        """
+        This test forces the use of an invalid tool `sum` and checks that an error is raised
+        """
+        with self.assertRaises(ValueError) as context:
+            result = chat_anthropic(
+                model="claude-3-haiku-20240307",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": self.arithmetic_qn,
+                    },
+                ],
+                tools=self.tools,
+                tool_choice="sum",
+                max_completion_tokens=1000,
+            )
+        self.assertEqual(
+            str(context.exception),
+            "Forced function `sum` is not in the list of provided tools",
+        )

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -245,7 +245,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.content, self.arithmetic_answer)
 
     @pytest.mark.asyncio
-    async def test_tool_weather_async_anthropic(self):
+    async def test_tool_use_weather_async_anthropic(self):
         result = await chat_async(
             model="claude-3-5-sonnet-20241022",
             messages=[


### PR DESCRIPTION
## Changes

### 1. tool_choice schema
Removed pydantic schema for `tool_choice`. OpenAI and Anthropic have very different inputs for this parameter. 

| Feature                      | OpenAI                                      | Anthropic                                  |
|------------------------------|---------------------------------------------|--------------------------------------------|
| Zero or more tools called    | `auto`                                      | `{"type": "auto"}`                        |
| At least one tool must be called | `required`                               | `{"type": "any"}`                         |
| Specific tool called         | `{"type": "function", "function": {"name": function_name}}` | `{"type": "tool", "name": function_name}` |

We hence simplify things by allowing the input to the chat functions to be simple strings like "auto", "required", "function_name". `convert_tool_choice` function will then map these to the right formats above for the different models. Also if `tools` are listed but `tool_choice` is not set, we default to "auto".

### 2. Avoid looping with `required` tool_choice
Previously if `tool_choice` was set to `required`, tool chaining would force the model to use a tool in each round. This will continue indefinitely and would not end with a message. We fix this by setting `tool_choice` to be `auto` after the first tool call.

### 3. tool_outputs in LLMResponse
We output the intermediate tool outputs during tool chaining so that we can inspect the steps the model has taken.

### 4. New tests
We port the tests for tool calls from defog_utils. However, we retain `get_weather` tests and do away with the `web_search` tests so that we do not require a defog API key. Other tests have also been added to cases where tool_choice is `required` or a forced function. Anthropic tests now also use sonnet instead of haiku as it's more reliable.
