### PR TITLE
Update token usage and cost, taking tool use into account

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.67.3",
+    version="0.67.4",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
The `input_tokens`, `output_tokens`, and `cost_in_cents` previously only reflected values for a single message.

This was fine when we had not incorporated tool use into this library. But with tool use, there are multiple messages sent to the LLM.

This PR amends the way we were calculated these to take multiple messages into account.