### PR TITLE
Gemini tool support

### DIFF
--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -103,7 +103,7 @@ def _build_anthropic_params(
     stop: List[str],
     tools: List[Callable] = None,
     tool_choice: str = None,
-    timeout=100,
+    timeout: int = 100,
 ):
     """Create the parameter dict for Anthropic's .messages.create()."""
     if len(messages) >= 1 and messages[0].get("role") == "system":
@@ -137,10 +137,10 @@ def _build_anthropic_params(
 async def _process_anthropic_response(
     client,
     response,
-    request_params,
-    tools,
-    tool_dict,
-    is_async,
+    request_params: Dict[str, Any],
+    tools: List[Callable],
+    tool_dict: Dict[str, Callable],
+    is_async: bool,
     post_tool_function: Callable = None,
 ):
     """
@@ -280,7 +280,7 @@ def _process_anthropic_response_handler(
     request_params: Dict[str, Any],
     tools: List[Callable],
     tool_dict: Dict[str, Callable],
-    is_async=False,
+    is_async: bool = False,
     post_tool_function: Callable = None,
 ):
     """
@@ -508,11 +508,11 @@ def _build_openai_params(
     seed: int = 0,
     tools: List[Callable] = None,
     tool_choice: str = None,
-    prediction=None,
-    reasoning_effort=None,
-    store=True,
-    metadata=None,
-    timeout=100,
+    prediction: Dict[str, str] = None,
+    reasoning_effort: str = None,
+    store: bool = True,
+    metadata: Dict[str, str] = None,
+    timeout: int = 100,
 ):
     """
     Build the parameter dictionary for OpenAI's chat.completions.create().
@@ -1138,8 +1138,8 @@ def _build_gemini_params(
     stop: List[str],
     response_format=None,
     seed: int = 0,
-    tools=None,
-    tool_choice=None,
+    tools: List[Callable] = None,
+    tool_choice: str = None,
 ):
     """Construct parameters for Gemini's generate_content call."""
     if messages[0]["role"] == "system":
@@ -1188,13 +1188,14 @@ def _build_gemini_params(
 async def _process_gemini_response(
     client,
     response,
-    request_params,
-    messages,
-    tools,
-    tool_dict,
+    request_params: Dict[str, Any],
+    messages: List[Dict[str, str]],
+    tools: List[Callable],
+    tool_dict: Dict[str, Callable],
     response_format,
-    model,
-    is_async,
+    model: str,
+    is_async: bool,
+    post_tool_function: Callable = None,
 ):
     """Extract content (including any tool calls) and usage info from Gemini response.
     Handles chaining of tool calls.
@@ -1321,6 +1322,7 @@ def _process_gemini_response_handler(
     response_format,
     model: str,
     is_async=False,
+    post_tool_function: Callable = None,
 ):
     """
     Processes Gemini's response by determining whether to execute the response handling
@@ -1350,6 +1352,7 @@ def _process_gemini_response_handler(
                 response_format=response_format,
                 model=model,
                 is_async=is_async,
+                post_tool_function=post_tool_function,
             )  # Caller must await this
         else:
             return asyncio.run(
@@ -1363,6 +1366,7 @@ def _process_gemini_response_handler(
                     response_format=response_format,
                     model=model,
                     is_async=is_async,
+                    post_tool_function=post_tool_function,
                 )
             )
 
@@ -1378,8 +1382,8 @@ def chat_gemini(
     stop: List[str] = [],
     response_format=None,
     seed: int = 0,
-    tools=None,
-    tool_choice=None,
+    tools: List[Callable] = None,
+    tool_choice: str = None,
     post_tool_function: Callable = None,
 ):
     """
@@ -1449,6 +1453,7 @@ def chat_gemini(
             messages=messages,
             model=model,
             is_async=False,
+            post_tool_function=post_tool_function,
         )
     )
     return LLMResponse(
@@ -1470,8 +1475,8 @@ async def chat_gemini_async(
     stop: List[str] = [],
     response_format=None,
     seed: int = 0,
-    tools=None,
-    tool_choice=None,
+    tools: List[Callable] = None,
+    tool_choice: str = None,
     store=True,
     metadata=None,
     timeout=100,
@@ -1558,6 +1563,7 @@ async def chat_gemini_async(
             response_format=response_format,
             model=model,
             is_async=True,
+            post_tool_function=post_tool_function,
         )
     )
     return LLMResponse(

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -1208,8 +1208,12 @@ async def _process_gemini_response(
     # If we have tools, handle dynamic chaining:
     tools_used = []
     tool_outputs = []
+    total_input_tokens = 0
+    total_output_tokens = 0
     if tools and len(tools) > 0:
         while True:
+            total_input_tokens += response.usage_metadata.prompt_token_count
+            total_output_tokens += response.usage_metadata.candidates_token_count
             if response.function_calls:
                 tool_call = response.function_calls[0]
                 func_name = tool_call.name
@@ -1302,13 +1306,15 @@ async def _process_gemini_response(
         else:
             content = response.text.strip() if response.text else None
 
-    usage_meta = response.usage_metadata
+    usage = response.usage_metadata
+    total_input_tokens += usage.prompt_token_count
+    total_output_tokens += usage.candidates_token_count
     return (
         content,
         tools_used,
         tool_outputs,
-        usage_meta.prompt_token_count,
-        usage_meta.candidates_token_count,
+        total_input_tokens,
+        total_output_tokens,
     )
 
 

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -4,7 +4,6 @@ import json
 import traceback
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any, Union, Callable
-from google.genai import types
 
 from defog.llm.utils_function_calling import (
     get_function_specs,
@@ -1142,6 +1141,9 @@ def _build_gemini_params(
     tool_choice: str = None,
 ):
     """Construct parameters for Gemini's generate_content call."""
+
+    from google.genai import types
+
     if messages[0]["role"] == "system":
         system_msg = messages[0]["content"]
         messages = messages[1:]
@@ -1200,6 +1202,9 @@ async def _process_gemini_response(
     """Extract content (including any tool calls) and usage info from Gemini response.
     Handles chaining of tool calls.
     """
+
+    from google.genai import types
+
     if len(response.candidates) == 0:
         raise Exception("No response from Gemini.")
     if response.candidates[0].finish_reason == "MAX_TOKENS":
@@ -1324,7 +1329,7 @@ def _process_gemini_response_handler(
     client,
     response,
     request_params: Dict[str, Any],
-    messages: List[types.Content],
+    messages: List,
     tools: List[Callable],
     tool_dict: Dict[str, Callable],
     response_format,
@@ -1418,6 +1423,7 @@ def chat_gemini(
     - LLMResponse which contains the response content, input tokens, output tokens, tools used, and tool outputs
     """
     from google import genai
+    from google.genai import types
 
     if post_tool_function:
         verify_post_tool_function(post_tool_function)
@@ -1521,6 +1527,7 @@ async def chat_gemini_async(
     - LLMResponse which contains the response content, input tokens, output tokens, tools used, and tool outputs
     """
     from google import genai
+    from google.genai import types
 
     t = time.time()
     client = genai.Client(api_key=os.getenv("GEMINI_API_KEY", ""))

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -1144,7 +1144,9 @@ def _build_gemini_params(
             tool_names_list = [func.__name__ for func in tools]
             tool_choice = convert_tool_choice(tool_choice, tool_names_list, model)
         if tool_choice:
-            request_params["automatic_function_calling"] = types.AutomaticFunctionCallingConfig(disable=True)
+            request_params["automatic_function_calling"] = (
+                types.AutomaticFunctionCallingConfig(disable=True)
+            )
             request_params["tool_config"] = tool_choice
 
     if response_format:
@@ -1232,7 +1234,9 @@ async def _process_gemini_response(
                 )
 
                 # Set tool_choice to None so that the next message will be generated normally without required tool calls
-                request_params["automatic_function_calling"] = types.AutomaticFunctionCallingConfig(disable=False)
+                request_params["automatic_function_calling"] = (
+                    types.AutomaticFunctionCallingConfig(disable=False)
+                )
                 request_params["tool_config"] = None
 
                 # Make next call
@@ -1445,7 +1449,9 @@ async def chat_gemini_async(
             tool_names_list = [func.__name__ for func in tools]
             tool_choice = convert_tool_choice(tool_choice, tool_names_list, model)
         if tool_choice:
-            request_params["automatic_function_calling"] = types.AutomaticFunctionCallingConfig(disable=True)
+            request_params["automatic_function_calling"] = (
+                types.AutomaticFunctionCallingConfig(disable=True)
+            )
             request_params["tool_config"] = tool_choice
 
     try:

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -1276,11 +1276,13 @@ async def _process_gemini_response(
                     )
                 )
 
-                # Set tool_choice to None so that the next message will be generated normally without required tool calls
+                # Set tool_choice to AUTO so that the next message will be generated normally without required tool calls
                 request_params["automatic_function_calling"] = (
                     types.AutomaticFunctionCallingConfig(disable=False)
                 )
-                request_params["tool_config"] = None
+                request_params["tool_config"] = types.ToolConfig(
+                    function_calling_config=types.FunctionCallingConfig(mode="AUTO")
+                )
 
                 # Make next call
                 if is_async:

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -330,6 +330,7 @@ def chat_anthropic(
     seed: int = 0,
     tools: List[Callable] = None,
     tool_choice: str = None,
+    post_tool_function: Callable = None,
 ):
     """
     Synchronous Anthropic chat.
@@ -1111,8 +1112,6 @@ def _build_gemini_params(
     seed: int = 0,
     tools=None,
     tool_choice=None,
-    store=True,
-    metadata=None,
 ):
     """Construct parameters for Gemini's generate_content call."""
     if messages[0]["role"] == "system":
@@ -1342,11 +1341,30 @@ def chat_gemini(
     seed: int = 0,
     tools=None,
     tool_choice=None,
-    store=True,
-    metadata=None,
     post_tool_function: Callable = None,
 ):
-    """Synchronous Gemini chat."""
+    """
+    Synchronous Gemini chat.
+
+    Parameters:
+    - messages: The list of messages to send to the LLM.
+    - model: The Gemini model to use for the chat.
+    - max_completion_tokens: The maximum number of tokens to return in the response.
+    - temperature: Higher values will make the output more random, while lower values like will make it more focused and deterministic.
+        Between 0 to 2: gemini-1.5-flash, gemini-1.5-pro, gemini-1.0-pro-002, gemini-2.0-flash
+        Between 0 to 1: gemini-1.0-pro-vision, gemini-1.0-pro-001
+    - stop: List of strings that will stop the model from generating further tokens.
+    - response_format: The format that the model must output. See https://ai.google.dev/gemini-api/docs/structured-output?lang=python
+    - seed: NA
+    - tools: The list of tools the model may call.
+    - tool_choice: Controls which (if any) tool is called by the model.
+        "auto": calls 0, 1, or multiple functions,
+        "required": calls at least one function,
+        "<function_name>": calls only the specified function
+    
+    Returns:
+    - LLMResponse which contains the response content, input tokens, output tokens, tools used, and tool outputs
+    """
     from google import genai
 
     t = time.time()
@@ -1361,8 +1379,6 @@ def chat_gemini(
         seed=seed,
         tools=tools,
         tool_choice=tool_choice,
-        store=store,
-        metadata=metadata,
     )
 
     # Construct a tool dict if needed
@@ -1420,7 +1436,33 @@ async def chat_gemini_async(
     reasoning_effort=None,
     post_tool_function: Callable = None,
 ):
-    """Asynchronous Gemini chat."""
+    """
+    Asynchronous Gemini chat.
+    
+    Parameters:
+    - messages: The list of messages to send to the LLM.
+    - model: The Gemini model to use for the chat.
+    - max_completion_tokens: The maximum number of tokens to return in the response.
+    - temperature: Higher values will make the output more random, while lower values like will make it more focused and deterministic.
+        Between 0 to 2: gemini-1.5-flash, gemini-1.5-pro, gemini-1.0-pro-002, gemini-2.0-flash
+        Between 0 to 1: gemini-1.0-pro-vision, gemini-1.0-pro-001
+    - stop: List of strings that will stop the model from generating further tokens.
+    - response_format: The format that the model must output. See https://ai.google.dev/gemini-api/docs/structured-output?lang=python
+    - seed: NA
+    - tools: The list of tools the model may call.
+    - tool_choice: Controls which (if any) tool is called by the model.
+        "auto": calls 0, 1, or multiple functions,
+        "required": calls at least one function,
+        "<function_name>": calls only the specified function
+    - store: NA
+    - metadata: NA
+    - timeout: NA
+    - prediction: NA
+    - reasoning_effort: NA
+    
+    Returns:
+    - LLMResponse which contains the response content, input tokens, output tokens, tools used, and tool outputs
+    """
     from google import genai
 
     t = time.time()
@@ -1435,8 +1477,6 @@ async def chat_gemini_async(
         seed=seed,
         tools=tools,
         tool_choice=tool_choice,
-        store=store,
-        metadata=metadata,
     )
 
     # Construct a tool dict if needed

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -70,6 +70,10 @@ def get_function_specs(
                 }
             )
         elif model.startswith("gemini"):
+            # change all "type" values to uppercase
+            input_schema["type"] = input_schema["type"].upper()
+            for prop in input_schema["properties"].values():
+                prop["type"] = prop["type"].upper()
 
             func_spec = {
                 "name": func.__name__,

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -182,25 +182,17 @@ def verify_post_tool_function(function: Callable):
     Verify that the post_tool_function is a function that takes exactly 3 arguments: function_name, input_args, tool_result
     """
     if not inspect.isfunction(function):
-        raise ValueError(
-            f"post_tool_function must be a function, not {type(function)}"
-        )
+        raise ValueError(f"post_tool_function must be a function, not {type(function)}")
     sig = inspect.signature(function)
     if len(sig.parameters) != 3:
         raise ValueError(
-                "post_tool_function must have exactly three parameters: function_name, input_args, and tool_result"
-            )
+            "post_tool_function must have exactly three parameters: function_name, input_args, and tool_result"
+        )
     if sig.parameters.get("function_name") is None:
-        raise ValueError(
-            "post_tool_function must have parameter named `function_name`"
-        )
+        raise ValueError("post_tool_function must have parameter named `function_name`")
     if sig.parameters.get("input_args") is None:
-        raise ValueError(
-            "post_tool_function must have parameter named `input_args`"
-        )
+        raise ValueError("post_tool_function must have parameter named `input_args`")
     if sig.parameters.get("tool_result") is None:
-        raise ValueError(
-            "post_tool_function must have parameter named `tool_result`"
-        )
+        raise ValueError("post_tool_function must have parameter named `tool_result`")
 
     return function

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -117,12 +117,17 @@ def convert_tool_choice(tool_choice: str, tool_name_list: List[str], model: str)
         "gemini": {
             "prefixes": ["gemini"],
             "choices": {
-                "auto": None,
+                "auto": types.ToolConfig(
+                    function_calling_config=types.FunctionCallingConfig(mode="AUTO")
+                ),
                 "required": types.ToolConfig(
                     function_calling_config=types.FunctionCallingConfig(mode="ANY")
                 ),
                 "any": types.ToolConfig(
                     function_calling_config=types.FunctionCallingConfig(mode="ANY")
+                ),
+                "none": types.ToolConfig(
+                    function_calling_config=types.FunctionCallingConfig(mode="NONE")
                 ),
             },
             "custom": types.ToolConfig(

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -2,12 +2,11 @@ import inspect
 from typing import Callable, List, Dict, Any, Union
 from pydantic import BaseModel
 from defog.llm.models import OpenAIFunctionSpecs, AnthropicFunctionSpecs
-from google.genai import types
 
 
 def get_function_specs(
     functions: List[Callable], model: str
-) -> List[Union[OpenAIFunctionSpecs, AnthropicFunctionSpecs, types.Tool]]:
+) -> List[Union[OpenAIFunctionSpecs, AnthropicFunctionSpecs]]:
     """Return a list of dictionaries describing each function's name, docstring, and input schema."""
     function_specs = []
 
@@ -70,6 +69,8 @@ def get_function_specs(
                 }
             )
         elif model.startswith("gemini"):
+            from google.genai import types
+
             # change all "type" values to uppercase
             input_schema["type"] = input_schema["type"].upper()
             for prop in input_schema["properties"].values():

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -7,7 +7,7 @@ from google.genai import types
 
 def get_function_specs(
     functions: List[Callable], model: str
-) -> List[Union[OpenAIFunctionSpecs, AnthropicFunctionSpecs]]:
+) -> List[Union[OpenAIFunctionSpecs, AnthropicFunctionSpecs, types.Tool]]:
     """Return a list of dictionaries describing each function's name, docstring, and input schema."""
     function_specs = []
 
@@ -109,6 +109,23 @@ def convert_tool_choice(tool_choice: str, tool_name_list: List[str], model: str)
                 "any": {"type": "any"},
             },
             "custom": {"type": "tool", "name": tool_choice},
+        },
+        "gemini": {
+            "prefixes": ["gemini"],
+            "choices": {
+                "auto": None,
+                "required": types.ToolConfig(
+                    function_calling_config=types.FunctionCallingConfig(mode="ANY")
+                ),
+                "any": types.ToolConfig(
+                    function_calling_config=types.FunctionCallingConfig(mode="ANY")
+                ),
+            },
+            "custom": types.ToolConfig(
+                function_calling_config=types.FunctionCallingConfig(
+                    mode="ANY", allowed_function_names=[tool_choice]
+                )
+            ),
         },
     }
 

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -175,3 +175,19 @@ async def execute_tool_async(tool: Callable, inputs: Dict[str, Any]):
     model = model_class.model_validate(inputs)
     # Call the tool function with the Pydantic model
     return await tool(model)
+
+
+def verify_post_tool_function(function: Callable):
+    """
+    Verify that the post_tool_function is a function that takes exactly 3 arguments: function_name, input_args, tool_results
+    """
+    if not inspect.isfunction(function):
+        raise ValueError(
+            f"post_tool_function must be a function, not {type(function)}"
+        )
+    sig = inspect.signature(function)
+    if len(sig.parameters) != 3:
+        raise ValueError(
+                "post_tool_function must have exactly three parameters: function_name, input_args, and tool_results"
+            )
+    return function

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -115,32 +115,43 @@ def convert_tool_choice(tool_choice: str, tool_name_list: List[str], model: str)
             },
             "custom": {"type": "tool", "name": tool_choice},
         },
-        "gemini": {
-            "prefixes": ["gemini"],
-            "choices": {
-                "auto": types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(mode="AUTO")
-                ),
-                "required": types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(mode="ANY")
-                ),
-                "any": types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(mode="ANY")
-                ),
-                "none": types.ToolConfig(
-                    function_calling_config=types.FunctionCallingConfig(mode="NONE")
-                ),
-            },
-            "custom": types.ToolConfig(
-                function_calling_config=types.FunctionCallingConfig(
-                    mode="ANY", allowed_function_names=[tool_choice]
-                )
-            ),
-        },
+        "gemini": {"prefixes": ["gemini"]},
     }
 
     for model_type, config in model_map.items():
         if any(model.startswith(prefix) for prefix in config["prefixes"]):
+            if model_type == "gemini":
+                from google.genai import types
+
+                config = {
+                    "choices": {
+                        "auto": types.ToolConfig(
+                            function_calling_config=types.FunctionCallingConfig(
+                                mode="AUTO"
+                            )
+                        ),
+                        "required": types.ToolConfig(
+                            function_calling_config=types.FunctionCallingConfig(
+                                mode="ANY"
+                            )
+                        ),
+                        "any": types.ToolConfig(
+                            function_calling_config=types.FunctionCallingConfig(
+                                mode="ANY"
+                            )
+                        ),
+                        "none": types.ToolConfig(
+                            function_calling_config=types.FunctionCallingConfig(
+                                mode="NONE"
+                            )
+                        ),
+                    },
+                    "custom": types.ToolConfig(
+                        function_calling_config=types.FunctionCallingConfig(
+                            mode="ANY", allowed_function_names=[tool_choice]
+                        )
+                    ),
+                }
             if tool_choice not in config["choices"]:
                 # Validate custom tool_choice
                 if tool_choice not in tool_name_list:

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -179,7 +179,7 @@ async def execute_tool_async(tool: Callable, inputs: Dict[str, Any]):
 
 def verify_post_tool_function(function: Callable):
     """
-    Verify that the post_tool_function is a function that takes exactly 3 arguments: function_name, input_args, tool_results
+    Verify that the post_tool_function is a function that takes exactly 3 arguments: function_name, input_args, tool_result
     """
     if not inspect.isfunction(function):
         raise ValueError(
@@ -188,6 +188,19 @@ def verify_post_tool_function(function: Callable):
     sig = inspect.signature(function)
     if len(sig.parameters) != 3:
         raise ValueError(
-                "post_tool_function must have exactly three parameters: function_name, input_args, and tool_results"
+                "post_tool_function must have exactly three parameters: function_name, input_args, and tool_result"
             )
+    if sig.parameters.get("function_name") is None:
+        raise ValueError(
+            "post_tool_function must have parameter named `function_name`"
+        )
+    if sig.parameters.get("input_args") is None:
+        raise ValueError(
+            "post_tool_function must have parameter named `input_args`"
+        )
+    if sig.parameters.get("tool_result") is None:
+        raise ValueError(
+            "post_tool_function must have parameter named `tool_result`"
+        )
+
     return function

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -14,15 +14,15 @@ import json
 IO_STREAM = StringIO()
 
 
-def log_to_file(function_name, args, result):
+def log_to_file(function_name, input_args, tool_result):
     """
     Simple function to test logging to a StringIO object.
     Used in test_post_tool_calls_openai and test_post_tool_calls_anthropic
     """
     message = {
         "function_name": function_name,
-        "args": args,
-        "result": result,
+        "args": input_args,
+        "result": tool_result,
     }
     message = json.dumps(message, indent=4)
     IO_STREAM.write(message + "\n")

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -83,19 +83,14 @@ class TestGetFunctionSpecs(unittest.TestCase):
                     "parameters": {
                         "properties": {
                             "latitude": {
-                                "default": 0.0,
                                 "description": "The latitude of the location",
-                                "title": "Latitude",
                                 "type": "number",
                             },
                             "longitude": {
-                                "default": 0.0,
                                 "description": "The longitude of the location",
-                                "title": "Longitude",
                                 "type": "number",
                             },
                         },
-                        "title": "WeatherInput",
                         "type": "object",
                     },
                 },
@@ -107,10 +102,9 @@ class TestGetFunctionSpecs(unittest.TestCase):
                     "description": "This function returns the sum of two numbers",
                     "parameters": {
                         "properties": {
-                            "a": {"default": 0, "title": "A", "type": "integer"},
-                            "b": {"default": 0, "title": "B", "type": "integer"},
+                            "a": {"type": "integer"},
+                            "b": {"type": "integer"},
                         },
-                        "title": "Numbers",
                         "type": "object",
                     },
                 },
@@ -122,10 +116,9 @@ class TestGetFunctionSpecs(unittest.TestCase):
                     "description": "This function returns the product of two numbers",
                     "parameters": {
                         "properties": {
-                            "a": {"default": 0, "title": "A", "type": "integer"},
-                            "b": {"default": 0, "title": "B", "type": "integer"},
+                            "a": {"type": "integer"},
+                            "b": {"type": "integer"},
                         },
-                        "title": "Numbers",
                         "type": "object",
                     },
                 },
@@ -138,19 +131,14 @@ class TestGetFunctionSpecs(unittest.TestCase):
                 "input_schema": {
                     "properties": {
                         "latitude": {
-                            "default": 0.0,
                             "description": "The latitude of the location",
-                            "title": "Latitude",
                             "type": "number",
                         },
                         "longitude": {
-                            "default": 0.0,
                             "description": "The longitude of the location",
-                            "title": "Longitude",
                             "type": "number",
                         },
                     },
-                    "title": "WeatherInput",
                     "type": "object",
                 },
             },
@@ -159,10 +147,9 @@ class TestGetFunctionSpecs(unittest.TestCase):
                 "description": "This function returns the sum of two numbers",
                 "input_schema": {
                     "properties": {
-                        "a": {"default": 0, "title": "A", "type": "integer"},
-                        "b": {"default": 0, "title": "B", "type": "integer"},
+                        "a": {"type": "integer"},
+                        "b": {"type": "integer"},
                     },
-                    "title": "Numbers",
                     "type": "object",
                 },
             },
@@ -171,10 +158,9 @@ class TestGetFunctionSpecs(unittest.TestCase):
                 "description": "This function returns the product of two numbers",
                 "input_schema": {
                     "properties": {
-                        "a": {"default": 0, "title": "A", "type": "integer"},
-                        "b": {"default": 0, "title": "B", "type": "integer"},
+                        "a": {"type": "integer"},
+                        "b": {"type": "integer"},
                     },
-                    "title": "Numbers",
                     "type": "object",
                 },
             },


### PR DESCRIPTION
## Gemini changes
- `chat_gemini_async` and `chat_gemini` now both support function calling.
- Note that in `get_function_specs`, we now remove `default` and `title` keys from the input_schema as these extra fields are not accepted in gemini and are not required in OpenAI/Anthropic models.
- For gemini, all "type" values in the input_schema have to be in uppercase.
- Removed unused `store` and `metadata` params for gemini.
- New tool use tests for gemini 
- Update token usage for gemini in line with #73 
- Added `post_tool_function` for gemini chats in line with #72 

## Other changes
- added missing `post_tool_function` param to `chat_anthropic`
- added more constraints in new `verify_post_tool_function` to check that `post_tool_function` has the right parameters

## Minor changes in tests
- rephrased arithmetic question slightly as gemini tends to do simple calculations without the use of tools
- sorted keys in `log_to_file` post tool function because gemini orders them differently