### PR TITLE
Refactor tool use response

### DIFF
--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -379,7 +379,7 @@ def chat_anthropic(
         tool_dict = {tool.__name__: tool for tool in tools}
 
     response = client.messages.create(**request_params)
-    content, tools_used, tool_outputs, input_toks, output_toks = (
+    content, tool_outputs, input_toks, output_toks = (
         _process_anthropic_response_handler(
             client=client,
             response=response,
@@ -397,7 +397,6 @@ def chat_anthropic(
         time=round(time.time() - t, 3),
         input_tokens=input_toks,
         output_tokens=output_toks,
-        tools_used=tools_used,
         tool_outputs=tool_outputs,
     )
 
@@ -465,7 +464,7 @@ async def chat_anthropic_async(
         tool_dict = {tool.__name__: tool for tool in tools}
 
     response = await client.messages.create(**params)
-    content, tools_used, tool_outputs, input_toks, output_toks = (
+    content, tool_outputs, input_toks, output_toks = (
         await _process_anthropic_response_handler(
             client=client,
             response=response,
@@ -483,7 +482,6 @@ async def chat_anthropic_async(
         time=round(time.time() - t, 3),
         input_tokens=input_toks,
         output_tokens=output_toks,
-        tools_used=tools_used,
         tool_outputs=tool_outputs,
     )
 
@@ -864,7 +862,6 @@ def chat_openai(
 
     (
         content,
-        tools_used,
         tool_outputs,
         prompt_tokens,
         output_tokens,
@@ -888,7 +885,6 @@ def chat_openai(
         input_tokens=prompt_tokens,
         output_tokens=output_tokens,
         output_tokens_details=completion_token_details,
-        tools_used=tools_used,
         tool_outputs=tool_outputs,
     )
 
@@ -974,7 +970,6 @@ async def chat_openai_async(
 
     (
         content,
-        tools_used,
         tool_outputs,
         prompt_tokens,
         output_tokens,
@@ -998,7 +993,6 @@ async def chat_openai_async(
         input_tokens=prompt_tokens,
         output_tokens=output_tokens,
         output_tokens_details=completion_token_details,
-        tools_used=tools_used,
         tool_outputs=tool_outputs,
     )
 
@@ -1219,7 +1213,10 @@ async def _process_gemini_response(
                 tool_call = response.function_calls[0]
                 func_name = tool_call.name
                 args = tool_call.args
-                tool_id = tool_call.tool_id
+
+                # set tool_id to None, as Gemini models do not return a tool_id by default
+                # strangely, tool_call.id exists, but is always set to `None`
+                tool_id = None
 
                 try:
                     tool_to_call = tool_dict[func_name]
@@ -1452,7 +1449,7 @@ def chat_gemini(
     except Exception as e:
         raise Exception(f"An error occurred: {e}")
 
-    content, tools_used, tool_outputs, input_toks, output_toks = (
+    content, tool_outputs, input_toks, output_toks = (
         _process_gemini_response_handler(
             client=client,
             response=response,
@@ -1472,7 +1469,6 @@ def chat_gemini(
         time=round(time.time() - t, 3),
         input_tokens=input_toks,
         output_tokens=output_toks,
-        tools_used=tools_used,
         tool_outputs=tool_outputs,
     )
 
@@ -1563,7 +1559,7 @@ async def chat_gemini_async(
     except Exception as e:
         raise Exception(f"An error occurred: {e}")
 
-    content, tools_used, tool_outputs, input_toks, output_toks = (
+    content, tool_outputs, input_toks, output_toks = (
         await _process_gemini_response_handler(
             client=client,
             response=response,
@@ -1583,7 +1579,6 @@ async def chat_gemini_async(
         time=round(time.time() - t, 3),
         input_tokens=input_toks,
         output_tokens=output_toks,
-        tools_used=tools_used,
         tool_outputs=tool_outputs,
     )
 

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -1449,19 +1449,17 @@ def chat_gemini(
     except Exception as e:
         raise Exception(f"An error occurred: {e}")
 
-    content, tool_outputs, input_toks, output_toks = (
-        _process_gemini_response_handler(
-            client=client,
-            response=response,
-            request_params=request_params,
-            tools=tools,
-            tool_dict=tool_dict,
-            response_format=response_format,
-            messages=messages,
-            model=model,
-            is_async=False,
-            post_tool_function=post_tool_function,
-        )
+    content, tool_outputs, input_toks, output_toks = _process_gemini_response_handler(
+        client=client,
+        response=response,
+        request_params=request_params,
+        tools=tools,
+        tool_dict=tool_dict,
+        response_format=response_format,
+        messages=messages,
+        model=model,
+        is_async=False,
+        post_tool_function=post_tool_function,
     )
     return LLMResponse(
         model=model,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ uvicorn
 tqdm
 setuptools
 pydantic
-anthropic==0.43.1
-google-genai==0.5.0
-openai==1.61.0
+anthropic==0.46.0
+google-genai==1.2.0
+openai==1.63.2
 together==1.3.11
 pytest

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.67.5",
+    version="0.67.6",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -208,7 +208,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(expected["name"], actual["name"])
             self.assertEqual(expected["args"], actual["args"])
             self.assertEqual(expected["result"], actual["result"])
-        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
 
     @pytest.mark.asyncio
     async def test_tool_use_weather_async_openai(self):
@@ -224,7 +225,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_retries=1,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"get_weather"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"get_weather"})
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertGreaterEqual(float(result.content), 21)
         self.assertLessEqual(float(result.content), 38)
@@ -242,7 +244,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=self.tools,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
         for expected, actual in zip(
             self.arithmetic_expected_tool_outputs, result.tool_outputs
         ):
@@ -265,7 +268,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_retries=1,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"get_weather"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"get_weather"})
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertGreaterEqual(float(result.content), 21)
         self.assertLessEqual(float(result.content), 38)
@@ -290,7 +294,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(expected["name"], actual["name"])
             self.assertEqual(expected["args"], actual["args"])
             self.assertEqual(expected["result"], actual["result"])
-        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
 
     @pytest.mark.asyncio
     async def test_tool_use_weather_async_gemini(self):
@@ -306,7 +311,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_retries=1,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"get_weather"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"get_weather"})
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertEqual(
             result.tool_outputs[0]["args"], {"latitude": 1.3521, "longitude": 103.8198}
@@ -335,7 +341,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(expected["name"], actual["name"])
             self.assertEqual(expected["args"], actual["args"])
             self.assertEqual(expected["result"], actual["result"])
-        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
         expected_stream_value = (
             json.dumps(
                 {
@@ -382,7 +389,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(expected["name"], actual["name"])
             self.assertEqual(expected["args"], actual["args"])
             self.assertEqual(expected["result"], actual["result"])
-        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
         expected_stream_value = (
             json.dumps(
                 {
@@ -430,7 +438,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(expected["name"], actual["name"])
             self.assertEqual(expected["args"], actual["args"])
             self.assertEqual(expected["result"], actual["result"])
-        self.assertSetEqual(set(result.tools_used), {"numsum", "numprod"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
         expected_stream_value = (
             json.dumps(
                 {
@@ -469,7 +478,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=self.tools,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"get_weather"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"get_weather"})
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertGreaterEqual(float(result.content), 21)
         self.assertLessEqual(float(result.content), 38)
@@ -486,7 +496,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=self.tools,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"get_weather"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"get_weather"})
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertGreaterEqual(float(result.content), 21)
         self.assertLessEqual(float(result.content), 38)
@@ -503,7 +514,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tools=self.tools,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"get_weather"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"get_weather"})
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertEqual(
             result.tool_outputs[0]["args"], {"latitude": 1.3521, "longitude": 103.8198}
@@ -524,7 +536,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tool_choice="required",
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"numsum"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum"})
         self.assertEqual(result.tool_outputs[0]["name"], "numsum")
         self.assertIn("104", result.content.lower())
 
@@ -542,7 +555,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_completion_tokens=1000,
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"numsum"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum"})
         self.assertEqual(result.tool_outputs[0]["name"], "numsum")
         self.assertIn("104", result.content.lower())
 
@@ -559,7 +573,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tool_choice="required",
         )
         print(result)
-        self.assertSetEqual(set(result.tools_used), {"numsum"})
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertSetEqual(set(tools_used), {"numsum"})
         self.assertEqual(result.tool_outputs[0]["name"], "numsum")
         self.assertIn("2", result.content.lower())
 

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -594,7 +594,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tool_choice="numprod",
         )
         print(result)
-        self.assertIn("numprod", set(result.tools_used))
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertIn("numprod", set(tools_used))
         self.assertEqual(result.tool_outputs[0]["name"], "numprod")
         self.assertEqual(result.tool_outputs[0]["result"], 204)
 
@@ -615,7 +616,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             max_completion_tokens=1000,
         )
         print(result)
-        self.assertIn("numprod", set(result.tools_used))
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertIn("numprod", set(tools_used))
         self.assertEqual(result.tool_outputs[0]["name"], "numprod")
         self.assertEqual(result.tool_outputs[0]["result"], 204)
 
@@ -635,7 +637,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
             tool_choice="numprod",
         )
         print(result)
-        self.assertIn("numprod", set(result.tools_used))
+        tools_used = [output["name"] for output in result.tool_outputs]
+        self.assertIn("numprod", set(tools_used))
         self.assertEqual(result.tool_outputs[0]["name"], "numprod")
         self.assertEqual(result.tool_outputs[0]["result"], 204)
 


### PR DESCRIPTION
## Added `tool_id` to outputs
Added a `tool_id` to `tool_outputs` for better tracking. This only works for OpenAI and Anthropic, and is `None` for Gemini as Gemini (strangely) does not return a tool id – despite having a field for it.

## Removed `tools_used`
Removed the `tools_used` field from `LLMResponse`, since those can be easily extracted from `tool_outputs`.

## Upped all requirements to latest SDK version
We now use the latest version of the `google-genai`, `openai`, and `anthropic` libraries