### PR TITLE
Exceptions in Tool Chains

### DIFF
--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -233,14 +233,17 @@ async def _process_anthropic_response(
 
                 # Execute post-tool function if provided
                 if post_tool_function:
-                    if inspect.iscoroutinefunction(post_tool_function):
-                        await post_tool_function(
-                            function_name=func_name, input_args=args, tool_result=result
-                        )
-                    else:
-                        post_tool_function(
-                            function_name=func_name, input_args=args, tool_result=result
-                        )
+                    try:
+                        if inspect.iscoroutinefunction(post_tool_function):
+                            await post_tool_function(
+                                function_name=func_name, input_args=args, tool_result=result
+                            )
+                        else:
+                            post_tool_function(
+                                function_name=func_name, input_args=args, tool_result=result
+                            )
+                    except Exception as e:
+                        raise Exception(f"Error executing post-tool function: {e}")
 
                 # Store the tool call, result, and text
                 tool_outputs.append(
@@ -295,6 +298,7 @@ async def _process_anthropic_response(
                 else:
                     response = client.messages.create(**request_params)
             else:
+                # Break out of loop when tool calls are finished
                 content = response.content[0].text
                 break
     else:
@@ -688,14 +692,17 @@ async def _process_openai_response(
 
                 # Execute post-tool function if provided
                 if post_tool_function:
-                    if inspect.iscoroutinefunction(post_tool_function):
-                        await post_tool_function(
-                            function_name=func_name, input_args=args, tool_result=result
-                        )
-                    else:
-                        post_tool_function(
-                            function_name=func_name, input_args=args, tool_result=result
-                        )
+                    try:
+                        if inspect.iscoroutinefunction(post_tool_function):
+                            await post_tool_function(
+                                function_name=func_name, input_args=args, tool_result=result
+                            )
+                        else:
+                            post_tool_function(
+                                function_name=func_name, input_args=args, tool_result=result
+                            )
+                    except Exception as e:
+                        raise Exception(f"Error executing post_tool_function: {e}")
 
                 # Store the tool call, result, and text
                 tool_outputs.append(
@@ -736,6 +743,7 @@ async def _process_openai_response(
                 else:
                     response = client.chat.completions.create(**request_params)
             else:
+                # Break out of loop when tool calls are finished
                 content = message.content
                 break
     else:
@@ -1280,14 +1288,17 @@ async def _process_gemini_response(
 
                 # Execute post-tool function if provided
                 if post_tool_function:
-                    if inspect.iscoroutinefunction(post_tool_function):
-                        await post_tool_function(
-                            function_name=func_name, input_args=args, tool_result=result
-                        )
-                    else:
-                        post_tool_function(
-                            function_name=func_name, input_args=args, tool_result=result
-                        )
+                    try:
+                        if inspect.iscoroutinefunction(post_tool_function):
+                            await post_tool_function(
+                                function_name=func_name, input_args=args, tool_result=result
+                            )
+                        else:
+                            post_tool_function(
+                                function_name=func_name, input_args=args, tool_result=result
+                            )
+                    except Exception as e:
+                        raise Exception(f"Error executing post-tool function: {e}")
 
                 # Store the tool call, result, and text
                 try:
@@ -1343,6 +1354,7 @@ async def _process_gemini_response(
                         config=types.GenerateContentConfig(**request_params),
                     )
             else:
+                # Break out of loop when tool calls are finished
                 content = response.text.strip() if response.text else None
                 break
     else:

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -236,11 +236,15 @@ async def _process_anthropic_response(
                     try:
                         if inspect.iscoroutinefunction(post_tool_function):
                             await post_tool_function(
-                                function_name=func_name, input_args=args, tool_result=result
+                                function_name=func_name,
+                                input_args=args,
+                                tool_result=result,
                             )
                         else:
                             post_tool_function(
-                                function_name=func_name, input_args=args, tool_result=result
+                                function_name=func_name,
+                                input_args=args,
+                                tool_result=result,
                             )
                     except Exception as e:
                         raise Exception(f"Error executing post-tool function: {e}")
@@ -664,7 +668,11 @@ async def _process_openai_response(
     total_output_tokens = 0
     if tools and len(tools) > 0:
         while True:
-            total_input_tokens += response.usage.prompt_tokens
+            total_input_tokens += (
+                response.usage.prompt_tokens
+                - response.usage.prompt_tokens_details.cached_tokens
+            )
+            total_cached_input_tokens += response.usage.cached_prompt_tokens
             total_output_tokens += response.usage.completion_tokens
             message = response.choices[0].message
             if message.tool_calls:
@@ -695,11 +703,15 @@ async def _process_openai_response(
                     try:
                         if inspect.iscoroutinefunction(post_tool_function):
                             await post_tool_function(
-                                function_name=func_name, input_args=args, tool_result=result
+                                function_name=func_name,
+                                input_args=args,
+                                tool_result=result,
                             )
                         else:
                             post_tool_function(
-                                function_name=func_name, input_args=args, tool_result=result
+                                function_name=func_name,
+                                input_args=args,
+                                tool_result=result,
                             )
                     except Exception as e:
                         raise Exception(f"Error executing post_tool_function: {e}")
@@ -1291,11 +1303,15 @@ async def _process_gemini_response(
                     try:
                         if inspect.iscoroutinefunction(post_tool_function):
                             await post_tool_function(
-                                function_name=func_name, input_args=args, tool_result=result
+                                function_name=func_name,
+                                input_args=args,
+                                tool_result=result,
                             )
                         else:
                             post_tool_function(
-                                function_name=func_name, input_args=args, tool_result=result
+                                function_name=func_name,
+                                input_args=args,
+                                tool_result=result,
                             )
                     except Exception as e:
                         raise Exception(f"Error executing post-tool function: {e}")


### PR DESCRIPTION
## Main change
Modified `_process_openai_response`, `_process_gemini_response`, and `_process_gemini_response`: 
  - to raise an exception only if there are 3 consecutive errors in the tool chain. 
  - if threshold is not met, the error message will be appended to the message list and fed back into the model for correction
 
The threshold ensures that the agent does not go on an infinite loop if there is an error in the tool name, tool execution or post tool function execution. Tests have been added too.

## Minor change
- Ensured that cached input token costs are calculated for tool chaining of openai models