### PR TITLE
Fix Tool Calling

### DIFF
--- a/defog/llm/models.py
+++ b/defog/llm/models.py
@@ -3,6 +3,13 @@ from enum import Enum
 from typing import Optional, Union, Dict, Any, Literal
 
 
+class Provider(Enum):
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    GEMINI = "gemini"
+    TOGETHER = "together"
+
+
 class OpenAIFunctionSpecs(BaseModel):
     name: str  # name of the function to call
     description: Optional[str] = None  # description of the function


### PR DESCRIPTION
# Motivation

We were only running the first tool if tool calls were enabled previously, which would result in wasted round trips with the LLM if there were multiple tool calls that we could have run locally. [DEF-757](https://linear.app/defog/issue/DEF-757/fix-tool-calling)

# Changes

- We refactored the 3 `_process_{providers}_response` functions to run all indicated tools instead of just the first.
- We also update the follow-on API calls' messages and parameters based on the documentation for function calling from each of the model providers:
  - [OpenAI](https://platform.openai.com/docs/guides/function-calling#handling-function-calls)
    - "role" should be "tool", not "assistant" ([docs](https://platform.openai.com/docs/guides/function-calling#handling-function-calls))
  - [Anthropic](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#best-practices-for-tool-definitions)
    - set "is_error" when we get an exception during the tool execution ([docs](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/overview#best-practices-for-tool-definitions:~:text=or%20image%20types.-,is_error,-(optional)%3A%20Set%20to))
  - [Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/function-calling)
    - tool execution results should be returned in a single `Content` (if > 1 tool indicated) with the `parts` attribute containing a list of each tool's execution results in a `Part.from_function_response` class.
- We also shifted providers over to an enum to make switching between providers more robust
- Learnt that it is _very important_ to set the `tool_choice="auto"` after a round of tool use, if not the model will keep returning function calls, instead of synthesizing the results from the function execution.

# Tests

Updated a whole bunch of tests. Should all work now, although time to time I do get random api failures from the weather API.

# Misc

I tried to refactor the common parts of all 3 providers' `_process_*_response` function, but failed because I haven't appreciated the nuances of the differences between each of them, and ended up wasting a lot of time trying to bend the tests. I ended up scraping the whole refactoring, concentrating on just getting the updated functionality to work, 1 provider at a time, always running and updating the tests first before moving on to the next. This made the fixing a lot more manageable and less prone to hallucinations or failure sinks.