### PR TITLE
Fix: Handle missing prompt_tokens_details in OpenAI-compatible APIs

### DIFF
--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -754,14 +754,17 @@ async def _process_openai_response(
         consecutive_exceptions = 0
         while True:
             # Check if prompt_tokens_details exists in the response
-            if hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details is not None:
+            if (
+                hasattr(response.usage, "prompt_tokens_details")
+                and response.usage.prompt_tokens_details is not None
+            ):
                 cached_tokens = response.usage.prompt_tokens_details.cached_tokens
                 total_input_tokens += response.usage.prompt_tokens - cached_tokens
                 total_cached_input_tokens += cached_tokens
             else:
                 # If prompt_tokens_details doesn't exist, assume all tokens are uncached
                 total_input_tokens += response.usage.prompt_tokens
-            
+
             total_output_tokens += response.usage.completion_tokens
             message = response.choices[0].message
             if message.tool_calls:
@@ -875,14 +878,17 @@ async def _process_openai_response(
 
     usage = response.usage
     # Check if prompt_tokens_details exists in the response
-    if hasattr(usage, 'prompt_tokens_details') and usage.prompt_tokens_details is not None:
+    if (
+        hasattr(usage, "prompt_tokens_details")
+        and usage.prompt_tokens_details is not None
+    ):
         cached_tokens = usage.prompt_tokens_details.cached_tokens
         total_cached_input_tokens += cached_tokens
         total_input_tokens += usage.prompt_tokens - cached_tokens
     else:
         # If prompt_tokens_details doesn't exist, assume all tokens are uncached
         total_input_tokens += usage.prompt_tokens
-    
+
     total_output_tokens += usage.completion_tokens
     return (
         content,

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -753,13 +753,15 @@ async def _process_openai_response(
     if tools and len(tools) > 0:
         consecutive_exceptions = 0
         while True:
-            total_input_tokens += (
-                response.usage.prompt_tokens
-                - response.usage.prompt_tokens_details.cached_tokens
-            )
-            total_cached_input_tokens += (
-                response.usage.prompt_tokens_details.cached_tokens
-            )
+            # Check if prompt_tokens_details exists in the response
+            if hasattr(response.usage, 'prompt_tokens_details') and response.usage.prompt_tokens_details is not None:
+                cached_tokens = response.usage.prompt_tokens_details.cached_tokens
+                total_input_tokens += response.usage.prompt_tokens - cached_tokens
+                total_cached_input_tokens += cached_tokens
+            else:
+                # If prompt_tokens_details doesn't exist, assume all tokens are uncached
+                total_input_tokens += response.usage.prompt_tokens
+            
             total_output_tokens += response.usage.completion_tokens
             message = response.choices[0].message
             if message.tool_calls:
@@ -872,10 +874,15 @@ async def _process_openai_response(
             content = response.choices[0].message.content
 
     usage = response.usage
-    total_cached_input_tokens += usage.prompt_tokens_details.cached_tokens
-    total_input_tokens += (
-        usage.prompt_tokens - usage.prompt_tokens_details.cached_tokens
-    )
+    # Check if prompt_tokens_details exists in the response
+    if hasattr(usage, 'prompt_tokens_details') and usage.prompt_tokens_details is not None:
+        cached_tokens = usage.prompt_tokens_details.cached_tokens
+        total_cached_input_tokens += cached_tokens
+        total_input_tokens += usage.prompt_tokens - cached_tokens
+    else:
+        # If prompt_tokens_details doesn't exist, assume all tokens are uncached
+        total_input_tokens += usage.prompt_tokens
+    
     total_output_tokens += usage.completion_tokens
     return (
         content,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.67.13",
+    version="0.67.14",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
## Summary
- Add checks for existence of prompt_tokens_details in OpenAI response objects before accessing properties
- Fix TypeError when using third-party OpenAI-compatible APIs that don't include cache-related information

## Test plan
- The fix adds proper null checking before accessing cached_tokens property
- When prompt_tokens_details is missing, all tokens will be treated as uncached

Fixes #82

🤖 Generated with [Claude Code](https://claude.ai/code)