### PR TITLE
Add MCP (Model Control Protocol) Client Support

### DIFF
--- a/defog/llm/mcp_readme.md
+++ b/defog/llm/mcp_readme.md
@@ -1,0 +1,129 @@
+# MCP Servers Guide
+
+This guide outlines the steps for setting up and using Model Context Protocol (MCP) servers, which allow external tools to be used within Introspect. This feature is currently not integrated into the application.
+
+## 1. Set Up Your MCP Servers
+Set up your MCP servers by following the official [SDKs](https://github.com/modelcontextprotocol).
+If you're hosting them outside of this application, ensure that your servers operate with [SSE transport](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse).
+
+```python
+from mcp.server.fastmcp import FastMCP
+
+# Initialize FastMCP with an available port
+mcp = FastMCP(
+  name="name_of_remote_server",
+  port=3001,
+)
+
+# Add your tools and prompts
+# @mcp.tool()
+# async def example_tool():
+#     ...
+
+# Start the server with SSE transport
+if __name__ == "__main__":
+    mcp.run(transport="sse")
+```
+
+## 2. Configure mcp_config.json
+
+After your servers are running, create `mcp_config.json` and add the servers to connect to them:
+
+```json
+{
+    "mcpServers": {
+        "name_of_remote_server": {
+            "command": "sse", 
+            "args": ["http://host.docker.internal:3001"]
+        },
+        "name_of_local_server": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/package-name"]
+        }
+    }
+}
+```
+
+### Configuration Options:
+
+1. **Remote Servers (SSE):**
+   - Use `"command": "sse"` 
+   - Use `"args": ["url_to_server"]` for remote servers
+   - Use `"args": ["http://host.docker.internal:PORT/sse"]` for servers running on your local machine
+   - Make sure the port matches your server's configuration
+
+2. **Local Servers in this Docker (stdio):**
+   - Specify the command to run the server (e.g., `"npx"`, `"python"`)
+   - Provide arguments in an array (e.g., `["-y", "package-name"]`)
+   - Optionally provide environment variables with `"env": {}`
+
+## 3. Using MCPClient
+
+Once your servers are configured, use the `MCPClient` class from the defog library to interact with them:
+
+### Step 1: Initialize and Connect
+
+```python
+from defog import MCPClient
+import json
+
+# Load config
+with open("path/to/mcp_config.json", "r") as f:
+    config = json.load(f)
+
+# Initialize client with your preferred model. Only Claude and OpenAI models are supported.
+mcp_client = MCPClient(model_name="claude-3-7-sonnet-20250219")
+
+# Connect to all servers defined in config
+await mcp_client.connect_to_server_from_config(config)
+```
+
+### Step 2: Process Queries
+
+```python
+# Send a query to be processed by the LLM with access to MCP tools
+# The response contains the final text output
+# tool_outputs is a list of all tool calls made during processing
+response, tool_outputs = await mcp_client.mcp_chat(query="What is the average sale in the northeast region?")
+```
+
+### Step 3: Clean Up
+
+```python
+# Always clean up when done to close connections
+await mcp_client.cleanup()
+```
+
+## 4. Using Prompt Templates
+
+Prompt templates that are defined in the MCP servers can be invoked in queries using the `/command` syntax:
+
+```python
+# This will apply the "gen_report" prompt template to "sales by region"
+response, _ = await mcp_client.mcp_chat(query="/gen_report sales by region")
+```
+If no further text is provided after the command, the prompt template will be applied to the output of the previous message in the message history.
+
+## 5. Troubleshooting
+
+If you encounter the "unhandled errors in a TaskGroup" error:
+
+1. **Check Server Status**: Make sure your server is running on the specified port
+2. **Verify Configuration**: Ensure port numbers match in both server and config
+3. **Host Binding**: Server must use `host="0.0.0.0"` (not `127.0.0.1`)
+4. **Network Access**: For Docker, ensure host.docker.internal resolves correctly
+5. **Port Exposure**: Make sure the port is accessible from the Docker container
+
+If using stdio servers, check for syntax errors in your command or arguments.
+
+## 6. MCPClient Reference
+
+Key methods in `MCPClient`:
+
+- `connect_to_server_from_config(config)`: Connect to all servers in config json file
+- `mcp_chat(query)`: Process a query using LLM and available tools
+  - Calls tools in a loop until no more tools are called or max tokens are reached
+  - Stores messages in message history so the LLM can use it as context for following queries
+- `call_tool(tool_name, tool_args)`: Directly call a specific tool
+- `get_prompt(prompt_name, args)`: Retrieve a specific prompt template
+- `cleanup()`: Close all server connections

--- a/defog/llm/mcp_readme.md
+++ b/defog/llm/mcp_readme.md
@@ -1,10 +1,10 @@
 # MCP Servers Guide
 
-This guide outlines the steps for setting up and using Model Context Protocol (MCP) servers, which allow external tools to be used within Introspect. This feature is currently not integrated into the application.
+This guide outlines the steps for setting up and using Model Context Protocol (MCP) servers, which allow external tools to be used by an LLM.
 
 ## 1. Set Up Your MCP Servers
 Set up your MCP servers by following the official [SDKs](https://github.com/modelcontextprotocol).
-If you're hosting them outside of this application, ensure that your servers operate with [SSE transport](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse).
+If you're hosting them outside of your application, ensure that your servers operate with [SSE transport](https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse).
 
 ```python
 from mcp.server.fastmcp import FastMCP
@@ -49,22 +49,22 @@ After your servers are running, create `mcp_config.json` and add the servers to 
 1. **Remote Servers (SSE):**
    - Use `"command": "sse"` 
    - Use `"args": ["url_to_server"]` for remote servers
-   - Use `"args": ["http://host.docker.internal:PORT/sse"]` for servers running on your local machine
+   - Use `"args": ["http://host.docker.internal:PORT/sse"]` if your application is running in a Docker container and the servers are running on your local machine
    - Make sure the port matches your server's configuration
 
-2. **Local Servers in this Docker (stdio):**
+2. **Local Servers in your application (stdio):**
    - Specify the command to run the server (e.g., `"npx"`, `"python"`)
    - Provide arguments in an array (e.g., `["-y", "package-name"]`)
    - Optionally provide environment variables with `"env": {}`
 
 ## 3. Using MCPClient
 
-Once your servers are configured, use the `MCPClient` class from the defog library to interact with them:
+Once your servers are configured, use the `MCPClient` class to interact with them:
 
 ### Step 1: Initialize and Connect
 
 ```python
-from defog import MCPClient
+from defog.llm.utils_mcp import MCPClient
 import json
 
 # Load config

--- a/defog/llm/utils_mcp.py
+++ b/defog/llm/utils_mcp.py
@@ -1,0 +1,887 @@
+import asyncio
+import json
+from typing import Optional, Any
+from contextlib import AsyncExitStack
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.client.sse import sse_client
+from anthropic import AsyncAnthropic
+from openai import AsyncOpenAI
+from anthropic.types import ToolUseBlock, TextBlock
+
+
+class MCPClient:
+    def __init__(self, model_name=None):
+        # Initialize session and client objects
+        self.connections = {}  # Dictionary to store connections to multiple servers
+        self.exit_stack = AsyncExitStack()
+
+        # Set up model parameters
+        self.model_name = (
+            model_name or "claude-3-7-sonnet-20250219"
+        )  # Default to Claude
+
+        if (
+            self.model_name.startswith("gpt")
+            or self.model_name.startswith("o1")
+            or self.model_name.startswith("chatgpt")
+            or self.model_name.startswith("o3")
+        ):
+            self.model_provider = "openai"
+        elif self.model_name.startswith("claude"):
+            self.model_provider = "anthropic"
+        else:
+            raise ValueError(f"Unsupported model name: {self.model_name}")
+
+        # Initialize appropriate client based on model provider
+        if self.model_provider == "anthropic":
+            self.anthropic = AsyncAnthropic()
+            self.openai = None
+        elif self.model_provider == "openai":
+            self.openai = AsyncOpenAI()
+            self.anthropic = None
+        else:
+            raise ValueError(f"Unsupported model provider: {self.model_provider}")
+
+        self.max_tokens = 8191
+        self.all_tools = []  # List of all tools from all servers
+        self.tool_to_server = {}  # Mapping of tool names to server connections
+        self.prompt_to_server = {}  # Mapping of prompt names to server connections
+        self.message_history = []  # Store conversation history across queries
+        self.tool_outputs = []  # List of tool outputs
+
+    async def call_tool(self, tool_name: str, tool_args: dict):
+        """Route a tool call to the appropriate server
+
+        This method attempts to call a tool on the appropriate server.
+        All errors are handled internally and converted to error responses
+        rather than exceptions to ensure the conversation can continue.
+
+        Args:
+            tool_name (str): Name of the tool to call
+            tool_args (dict): Arguments to pass to the tool
+
+        Returns:
+            mcp.types.CallToolResult: The result object from the tool call
+
+        Raises:
+            ValueError: If no servers are connected or the tool is not found
+            TimeoutError: If the tool call times out
+            ConnectionError: If connection to the server is lost
+            Exception: For other errors during tool execution
+        """
+
+        # Handle no connections case
+        if not self.connections:
+            error_msg = (
+                "No server connections available. Please connect to a server first."
+            )
+            raise ValueError(error_msg)
+
+        if tool_name not in self.tool_to_server:
+            error_msg = f"Tool '{tool_name}' not found in any connected server"
+            raise ValueError(error_msg)
+
+        # Get the server that provides this tool
+        server_name = self.tool_to_server[tool_name]
+        if server_name not in self.connections:
+            error_msg = (
+                f"Server '{server_name}' for tool '{tool_name}' is not connected"
+            )
+            raise ValueError(error_msg)
+
+        session = self.connections[server_name]["session"]
+
+        # Call the tool on the appropriate server with timeout
+        try:
+            return await asyncio.wait_for(
+                session.call_tool(tool_name, tool_args), timeout=30.0
+            )
+        except asyncio.TimeoutError:
+            error_msg = f"Timeout while calling tool '{tool_name}'"
+            raise TimeoutError(error_msg)
+        except Exception as e:
+            if "connection" in str(e).lower() or "pipe" in str(e).lower():
+                error_msg = f"Connection to server '{server_name}' lost: {str(e)}"
+            else:
+                error_msg = str(e)
+            raise Exception(error_msg) from e
+
+    async def get_prompt(self, prompt_name: str, args: dict[str, Any]):
+        """
+        Retrieve the prompt from the appropriate server.
+
+        Args:
+            prompt_name (str): Name of the prompt to retrieve
+            args (dict[str, Any]): Arguments to pass to the prompt
+
+        Returns:
+            mcp.types.GetPromptResult: The prompt result object with messages
+
+        Raises:
+            ValueError: If no servers are connected or the prompt is not found
+            ConnectionError: If the server connection fails
+            TimeoutError: If the prompt retrieval times out
+            Exception: For other errors during prompt retrieval
+        """
+
+        if not self.connections:
+            error_msg = (
+                "No server connections available. Please connect to a server first."
+            )
+            print(f"Error: {error_msg}")
+            raise ValueError(error_msg)
+
+        if prompt_name not in self.prompt_to_server:
+            error_msg = f"Prompt '{prompt_name}' not found in any connected server"
+            print(f"Error: {error_msg}")
+            raise ValueError(error_msg)
+
+        server_name = self.prompt_to_server[prompt_name]
+        if server_name not in self.connections:
+            error_msg = (
+                f"Server '{server_name}' for prompt '{prompt_name}' is not connected"
+            )
+            print(f"Error: {error_msg}")
+            raise ValueError(error_msg)
+
+        session = self.connections[server_name]["session"]
+
+        # Call the prompt on the appropriate server with timeout
+        try:
+            return await asyncio.wait_for(
+                session.get_prompt(prompt_name, args), timeout=30.0
+            )
+        except asyncio.TimeoutError:
+            error_msg = f"Timeout while getting prompt '{prompt_name}'"
+            print(f"Error: {error_msg}")
+            raise TimeoutError(error_msg)
+        except Exception as e:
+            if "connection" in str(e).lower() or "pipe" in str(e).lower():
+                error_msg = f"Connection to server '{server_name}' lost: {str(e)}"
+                print(f"Error: {error_msg}")
+                raise ConnectionError(error_msg) from e
+            else:
+                error_msg = f"Error getting prompt '{prompt_name}': {str(e)}"
+                print(f"Error: {error_msg}")
+                raise Exception(error_msg) from e
+
+    def _add_to_message_history(self, message, messages):
+        """Add a message to both the persistent history and current message list
+
+        Args:
+            message: The message to add
+            messages: The current message list for this query
+        """
+        self.message_history.append(message)
+        messages.append(message)
+
+    async def _handle_tool_call(
+        self,
+        tool_name: str,
+        tool_args: dict,
+    ):
+        """Handle a tool call from any model provider
+
+        Args:
+            tool_name (str): Name of the tool to call
+            tool_args (dict): Arguments for the tool
+            tool_id (str): ID of the tool call (for response mapping)
+            messages (list): Current message list for context
+            thinking_text (list): List to store thinking output
+
+        Returns:
+            tuple[mcp.types.CallToolResult, str]: Tuple containing the tool result object and result text
+        """
+        print(f"Calling tool {tool_name} with args {tool_args}")
+
+        # Call the tool with retry mechanism
+        max_retries = 3
+        retry_count = 0
+        backoff_time = 1  # seconds
+
+        while retry_count < max_retries:
+            try:
+                result = await self.call_tool(tool_name, tool_args)
+                if result.isError:
+                    raise Exception(result.content[0].text)
+
+                # Get result text from the first content item
+                result_text = (
+                    result.content[0].text if result.content else "No result content"
+                )
+
+                print(f"Tool result: {result_text}")
+
+                return result, result_text
+            except Exception as e:
+                retry_count += 1
+                error_msg = f"Error calling tool `{tool_name}`: {str(e)}"
+                print(f"Tool error: {error_msg}")
+
+                if retry_count >= max_retries:
+                    print(f"Giving up after {max_retries} attempts")
+                    # Create a mock result object
+                    from mcp.types import CallToolResult, TextContent
+
+                    error_response = f"Error: Failed to call tool `{tool_name}` after {max_retries} attempts. {str(e)} \nModify input args or call another tool. DO NOT call the same tool with the same args."
+                    result = CallToolResult(
+                        content=[TextContent(type="text", text=error_response)],
+                        isError=True,
+                    )
+
+                    return result, error_response
+                else:
+                    # Wait with exponential backoff before retrying
+                    print(
+                        f"Retrying in {backoff_time} seconds ({retry_count}/{max_retries})"
+                    )
+                    await asyncio.sleep(backoff_time)
+                    backoff_time *= 2
+
+    async def _process_anthropic_query(self, messages: list, available_tools: list):
+        """Process a query using Anthropic's API
+
+        Args:
+            messages (list): Message history for context
+            available_tools (list): Tools descriptions to make available to the model
+
+        Returns:
+            str: The final response text from the model or error message
+        """
+        # Initial Anthropic API call
+        try:
+            response = await self.anthropic.messages.create(
+                model=self.model_name,
+                max_tokens=self.max_tokens,
+                messages=messages,
+                tools=available_tools,
+            )
+        except Exception as e:
+            error_msg = f"Error calling Anthropic API: {str(e)}"
+            print(error_msg)
+            return error_msg
+
+        while True:
+            # Check for tool call in response
+            tool_call_block = next(
+                (
+                    block
+                    for block in response.content
+                    if isinstance(block, ToolUseBlock)
+                ),
+                None,
+            )
+            text_block = next(
+                (block for block in response.content if isinstance(block, TextBlock)),
+                None,
+            )
+
+            if tool_call_block:
+                # Extract tool call details
+                tool_name = tool_call_block.name
+                tool_args = tool_call_block.input
+                tool_id = tool_call_block.id
+
+                # Add tool call to message history
+                assistant_message = {"role": "assistant", "content": [tool_call_block]}
+                self._add_to_message_history(assistant_message, messages)
+
+                # Handle the tool call
+                result, result_text = await self._handle_tool_call(tool_name, tool_args)
+
+                # Add tool result to message history
+                tool_result_message = {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_id,
+                            "content": result.content,
+                        }
+                    ],
+                }
+                self._add_to_message_history(tool_result_message, messages)
+
+                # Add tool result to tool outputs
+                self.tool_outputs.append(
+                    {
+                        "tool_call_id": tool_id,
+                        "name": tool_name,
+                        "args": tool_args,
+                        "result": result_text,
+                        "text": text_block.text if text_block else None,
+                    }
+                )
+
+                # Get next response from Anthropic
+                try:
+                    response = await self.anthropic.messages.create(
+                        model=self.model_name,
+                        max_tokens=self.max_tokens,
+                        messages=messages,
+                        tools=available_tools,
+                    )
+                except Exception as e:
+                    error_msg = f"Error calling Anthropic API: {str(e)}"
+                    print(error_msg)
+                    return error_msg
+            else:
+                # Final response with no tool calls
+                final_text = text_block.text
+
+                # Add final assistant response to message history
+                final_message = {"role": "assistant", "content": final_text}
+                self.message_history.append(final_message)
+
+                return final_text
+
+    async def _process_openai_query(self, messages: list, available_tools: list):
+        """Process a query using OpenAI's API
+
+        Args:
+            messages (list): Message history for context
+            available_tools (list): Tools descriptions to make available to the model
+            thinking_text (list): List to store thinking text
+
+        Returns:
+            str: The final response text from the model or error message
+        """
+        # Convert tools format for OpenAI
+        openai_tools = []
+        for tool in available_tools:
+            openai_tool = {
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool["description"],
+                    "parameters": tool["input_schema"],
+                },
+            }
+            openai_tools.append(openai_tool)
+
+        # Initial OpenAI API call
+        try:
+            response = await self.openai.chat.completions.create(
+                model=self.model_name,
+                max_completion_tokens=self.max_tokens,
+                messages=messages,
+                tools=openai_tools,
+            )
+        except Exception as e:
+            error_msg = f"Error calling OpenAI API: {str(e)}"
+            print(error_msg)
+            return error_msg
+
+        while True:
+            # Check for tool call in response
+            tool_call = None
+            if response.choices and response.choices[0].message.tool_calls:
+                tool_call = response.choices[0].message.tool_calls[0]
+
+            if tool_call:
+                # Extract tool call details
+                tool_name = tool_call.function.name
+
+                # Parse args from JSON string
+                import json
+
+                tool_args = json.loads(tool_call.function.arguments)
+                tool_id = tool_call.id
+
+                # Add tool call to message history
+                assistant_message = {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": tool_id,
+                            "type": "function",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": tool_call.function.arguments,
+                            },
+                        }
+                    ],
+                }
+                self._add_to_message_history(assistant_message, messages)
+
+                # Handle the tool call
+                result, result_text = await self._handle_tool_call(tool_name, tool_args)
+
+                # Add tool result to message history
+                tool_result_message = {
+                    "role": "tool",
+                    "tool_call_id": tool_id,
+                    "content": result_text,
+                }
+                self._add_to_message_history(tool_result_message, messages)
+
+                # Add tool result to tool outputs
+                self.tool_outputs.append(
+                    {
+                        "tool_call_id": tool_id,
+                        "name": tool_name,
+                        "args": tool_args,
+                        "result": result_text,
+                        "text": (
+                            response.choices[0].message.content
+                            if response.choices[0].message.content
+                            else None
+                        ),
+                    }
+                )
+
+                # Get next response from OpenAI
+                try:
+                    response = await self.openai.chat.completions.create(
+                        model=self.model_name,
+                        max_completion_tokens=self.max_tokens,
+                        messages=messages,
+                        tools=openai_tools,
+                    )
+                except Exception as e:
+                    error_msg = f"Error calling OpenAI API: {str(e)}"
+                    print(error_msg)
+                    return error_msg
+            else:
+                # Final response with no tool calls
+                final_text = response.choices[0].message.content
+
+                # Add final assistant response to message history
+                final_message = {"role": "assistant", "content": final_text}
+                self.message_history.append(final_message)
+
+                return final_text
+
+    async def _process_prompt_templates(self, query: str) -> str:
+        """Process prompt templates in the query
+
+        Args:
+            query (str): The user's input text that may contain prompt commands
+
+        Returns:
+            str: The processed query with prompt templates applied
+        """
+        # Get any commands from query. Commands are prefixed by /
+        commands = [command[1:] for command in query.split() if command.startswith("/")]
+
+        # Filter out non-existent prompts
+        commands = [command for command in commands if command in self.prompt_to_server]
+
+        # Only use the first command
+        command = commands[0] if commands else ""
+        if len(commands) > 1:
+            print(
+                "Multiple prompt commands found in query. Only using the first command."
+            )
+
+        # If no valid command or query is empty, return original query
+        if command == "":
+            return query
+
+        try:
+            if f"/{command}" == query:
+                # If query only consists of the command, use previous message as arg of the template
+                try:
+                    # Get content from the last message in history
+                    last_message = self.message_history[-1]
+                    if isinstance(last_message.get("content"), str):
+                        query = last_message["content"]
+                    else:
+                        print(
+                            f"Warning: Previous message has no text content to use for command /{command}"
+                        )
+                        return query
+                except Exception as e:
+                    print(
+                        f"Warning: Error accessing message history for command /{command}: {str(e)}"
+                    )
+                    return query
+
+                # Get prompt template
+                try:
+                    response = await self.get_prompt(command, {"input": query})
+                    if hasattr(response, "messages") and response.messages:
+                        if hasattr(response.messages[0], "content") and hasattr(
+                            response.messages[0].content, "text"
+                        ):
+                            query = response.messages[0].content.text
+                        else:
+                            print(
+                                f"Warning: Prompt response for /{command} has invalid structure"
+                            )
+                            return query
+                    else:
+                        print(
+                            f"Warning: Prompt response for /{command} has no messages"
+                        )
+                        return query
+                except Exception as e:
+                    print(
+                        f"Error processing prompt template /{command}: {str(e)}"
+                    )
+                    return query
+
+            elif f"/{command}" in query:
+                # Remove command from query
+                query_text = query.replace(f"/{command}", "").strip()
+
+                # Get prompt template
+                try:
+                    response = await self.get_prompt(command, {"input": query_text})
+                    if hasattr(response, "messages") and response.messages:
+                        if hasattr(response.messages[0], "content") and hasattr(
+                            response.messages[0].content, "text"
+                        ):
+                            query = response.messages[0].content.text
+                        else:
+                            print(
+                                f"Warning: Prompt response for /{command} has invalid structure"
+                            )
+                            return query_text
+                    else:
+                        print(
+                            f"Warning: Prompt response for /{command} has no messages"
+                        )
+                        return query_text
+                except Exception as e:
+                    print(
+                        f"Error processing prompt template /{command}: {str(e)}"
+                    )
+                    return query_text
+        except Exception as e:
+            print(f"Unexpected error processing prompt template: {str(e)}")
+            # Return original query if anything fails
+            return query
+
+        return query
+
+    async def process_query(self, query: str) -> tuple[str, list[str]]:
+        """Process a user's query using LLM and available tools
+
+        Args:
+            query (str): The user's query to process
+
+        Returns:
+            tuple[str, list[str]]: Tuple containing (final_response_text, thinking_logs)
+
+        Raises:
+            Exception: If there are errors processing the query
+        """
+        # Process prompt templates if any
+        query = await self._process_prompt_templates(query)
+        print(f"Processed query: {query}")
+
+        # Add user query to message history
+        user_message = {"role": "user", "content": query}
+        self.message_history.append(user_message)
+
+        # Use full message history for context
+        messages = self.message_history.copy()
+
+        # Collect all tools from all connected servers
+        available_tools = [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "input_schema": tool.inputSchema,
+            }
+            for tool in self.all_tools
+        ]
+
+        # Process based on model provider
+        if self.model_provider == "anthropic":
+            final_text = await self._process_anthropic_query(messages, available_tools)
+        else:
+            final_text = await self._process_openai_query(messages, available_tools)
+
+        return final_text
+
+    async def mcp_chat(self, query: str = None):
+        """Run a chat loop for MCP"""
+
+        while True:
+            try:
+                response = await self.process_query(query)
+                return response, self.tool_outputs
+
+            except Exception as e:
+                print(f"Error: {str(e)}")
+                raise
+
+    async def _connect_to_mcp_sse_server(self, server_name: str, server_url: str):
+        """Connect to a single MCP SSE server and register its tools
+
+        Args:
+            server_name: Unique name to identify this server
+            command: Command to run the server
+            args: Arguments for the command
+            env: Optional environment variables
+
+        Returns:
+            int: Number of tools registered from this server
+
+        Raises:
+            ConnectionError: If connection to server fails
+            TimeoutError: If server connection times out
+        """
+        try:
+            streams = await self.exit_stack.enter_async_context(sse_client(server_url))
+            session = await self.exit_stack.enter_async_context(
+                ClientSession(streams[0], streams[1])
+            )
+
+            # Initialize the connection with timeout
+            try:
+                await asyncio.wait_for(session.initialize(), timeout=10.0)
+            except asyncio.TimeoutError:
+                raise TimeoutError(
+                    f"Timeout while initializing connection to server '{server_name}'"
+                )
+
+            # Store connection details
+            self.connections[server_name] = {
+                "session": session,
+            }
+
+            # List and register available tools
+            try:
+                response = await asyncio.wait_for(session.list_tools(), timeout=5.0)
+                tools = response.tools
+                for tool in tools:
+                    self.all_tools.append(tool)
+                    self.tool_to_server[tool.name] = server_name
+            except Exception as e:
+                print(
+                    f"Failed to list tools from server '{server_name}': {str(e)}"
+                )
+                raise
+
+            # List and register available prompts
+            try:
+                response = await asyncio.wait_for(session.list_prompts(), timeout=5.0)
+                prompts = response.prompts
+            except Exception as e:
+                # If no prompts are available
+                prompts = []
+            for prompt in prompts:
+                self.prompt_to_server[prompt.name] = server_name
+
+            print(
+                f"Connected to server '{server_name}' with {len(tools)} tool(s) and {len(prompts)} prompt(s)"
+            )
+
+            return len(tools)
+
+        except Exception as e:
+            if isinstance(e, (TimeoutError, asyncio.TimeoutError)):
+                raise TimeoutError(
+                    f"Timeout connecting to server '{server_name}': {str(e)}"
+                )
+            else:
+                raise ConnectionError(
+                    f"Failed to connect to server '{server_name}':\n{str(e)}"
+                ) from e
+
+    async def _connect_to_mcp_stdio_server(
+        self, server_name: str, command: str, args: list, env: Optional[dict] = None
+    ):
+        """Connect to a single MCP stdio server and register its tools
+
+        Args:
+            server_name: Unique name to identify this server
+            command: Command to run the server
+            args: Arguments for the command
+            env: Optional environment variables
+
+        Returns:
+            int: Number of tools registered from this server
+
+        Raises:
+            ConnectionError: If connection to server fails
+            TimeoutError: If server connection times out
+        """
+        server_params = StdioServerParameters(command=command, args=args, env=env)
+
+        try:
+            # Create connection
+            stdio_transport = await self.exit_stack.enter_async_context(
+                stdio_client(server_params)
+            )
+            stdio, write = stdio_transport
+            session = await self.exit_stack.enter_async_context(
+                ClientSession(stdio, write)
+            )
+
+            # Initialize the connection with timeout
+            try:
+                await asyncio.wait_for(session.initialize(), timeout=10.0)
+            except asyncio.TimeoutError:
+                raise TimeoutError(
+                    f"Timeout while initializing connection to server '{server_name}'"
+                )
+
+            # Store connection details
+            self.connections[server_name] = {
+                "stdio": stdio,
+                "write": write,
+                "session": session,
+            }
+
+            # List and register available tools
+            try:
+                response = await asyncio.wait_for(session.list_tools(), timeout=5.0)
+                tools = response.tools
+                for tool in tools:
+                    self.all_tools.append(tool)
+                    self.tool_to_server[tool.name] = server_name
+            except Exception as e:
+                print(
+                    f"Failed to list tools from server '{server_name}': {str(e)}"
+                )
+                raise
+
+            # List and register available prompts
+            try:
+                response = await asyncio.wait_for(session.list_prompts(), timeout=5.0)
+                prompts = response.prompts
+            except Exception as e:
+                # If no prompts are available
+                prompts = []
+            for prompt in prompts:
+                self.prompt_to_server[prompt.name] = server_name
+
+            print(
+                f"Connected to server '{server_name}' with {len(tools)} tool(s) and {len(prompts)} prompt(s)"
+            )
+
+            return len(tools)
+
+        except Exception as e:
+            if isinstance(e, (TimeoutError, asyncio.TimeoutError)):
+                raise TimeoutError(
+                    f"Timeout connecting to server '{server_name}': {str(e)}"
+                )
+            else:
+                print(
+                    f"Failed to connect to server '{server_name}': {str(e)}"
+                )
+                raise
+
+    async def connect_to_server_from_config(self, config: dict):
+        """Connect to all MCP servers defined in a config dictionary
+
+        Args:
+            config: Dict containing server configuration in the mcpServers format
+
+        Raises:
+            ValueError: If config is invalid or missing required fields
+            ConnectionError: If any server connection fails
+        """
+        if "mcpServers" not in config or not config["mcpServers"]:
+            raise ValueError("No MCP servers defined in config")
+
+        # Connect to all available servers
+        print(f"Found {len(config['mcpServers'])} servers in config")
+        tool_count = 0
+        connection_errors = []
+
+        for server_name, server_info in config["mcpServers"].items():
+
+            # Validate server configuration
+            if "command" not in server_info or not server_info["command"]:
+                connection_errors.append(
+                    f"Server '{server_name}' missing required 'command' field"
+                )
+                continue
+
+            command = server_info.get("command", "")
+            args = server_info.get("args", [])
+            env = server_info.get("env", None)
+
+            # Connect to this server
+            try:
+                if command == "sse":
+                    print(
+                        f"Connecting to SSE server '{server_name}' with URL: {args[0]}"
+                    )
+                    tools_added = await self._connect_to_mcp_sse_server(
+                        server_name, args[0]
+                    )
+                else:
+                    print(
+                        f"Connecting to stdio server '{server_name}' with command: {command} and args: {args}"
+                    )
+                    tools_added = await self._connect_to_mcp_stdio_server(
+                        server_name, command, args, env
+                    )
+                tool_count += tools_added
+            except Exception as e:
+                error_msg = f"Failed to connect to server '{server_name}': {str(e)}"
+                print(f"Error: {error_msg}")
+                connection_errors.append(error_msg)
+
+        # Report results and show detailed tool/prompt information
+        if tool_count == 0 and connection_errors:
+            error_details = "\n- " + "\n- ".join(connection_errors)
+            print(f"Warning: Failed to connect to any servers:{error_details}")
+            print(
+                "The client will continue to function, but tool functionality will be limited."
+            )
+        elif connection_errors:
+            print(
+                f"Warning: {len(connection_errors)} server(s) failed to connect. {connection_errors}"
+            )
+
+    async def cleanup(self):
+        """Clean up resources"""
+        # The AsyncExitStack will handle closing all connections
+        # that were entered with enter_async_context
+        await self.exit_stack.aclose()
+
+        # Clear our connection tracking data
+        self.connections = {}
+        self.all_tools = []
+        self.tool_to_server = {}
+
+        print("All MCP server connections closed.")
+
+
+async def initialize_mcp_client(config_path, model):
+    """
+    Initialize MCP client with config loaded from the specified path.
+
+    Args:
+        config_path (str): Path to the MCP config file
+        model (str): Model name to use for the client
+
+    Returns:
+        Union[MCPClient, dict]: The initialized MCP client or an error dict
+    """
+    try:
+        print(f"Loading MCP config from {config_path}")
+        with open(config_path, "r") as f:
+            config = json.load(f)
+
+    except json.JSONDecodeError as e:
+        error_msg = f"Failed to parse MCP config file: {str(e)}"
+        print(error_msg)
+        raise ValueError(error_msg)
+
+    except Exception as e:
+        error_msg = f"Error loading MCP config: {str(e)}"
+        print(error_msg)
+        raise RuntimeError(error_msg)
+
+    try:
+        mcp_client = MCPClient(model_name=model)
+        await mcp_client.connect_to_server_from_config(config)
+
+    except Exception as e:
+        error_msg = f"Failed to initialize MCP client: {str(e)}"
+        print(error_msg)
+        raise RuntimeError(error_msg)
+
+    return mcp_client

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ google-genai==1.2.0
 openai==1.63.2
 together==1.3.11
 pytest
+mcp

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.67.15",
+    version="0.68.15",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/tests/mcp/mcp_arithmetic_sse.py
+++ b/tests/mcp/mcp_arithmetic_sse.py
@@ -1,0 +1,27 @@
+from mcp.server.fastmcp import FastMCP
+
+host = "0.0.0.0"
+port = 8001
+mcp = FastMCP(
+    name = "arithmetic_sse",
+    host = host,
+    port = port,
+    )
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers together"""
+    return a + b
+
+@mcp.tool()
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers together"""
+    return a * b
+
+
+if __name__ == "__main__":
+    try:
+        print(f"Starting FastMCP server {mcp.name} with host {host} and port {port}")
+        mcp.run(transport="sse")
+    except Exception as e:
+        print(f"Error running FastMCP server {mcp.name}: {e}")

--- a/tests/mcp/mcp_arithmetic_sse.py
+++ b/tests/mcp/mcp_arithmetic_sse.py
@@ -3,15 +3,17 @@ from mcp.server.fastmcp import FastMCP
 host = "0.0.0.0"
 port = 8001
 mcp = FastMCP(
-    name = "arithmetic_sse",
-    host = host,
-    port = port,
-    )
+    name="arithmetic_sse",
+    host=host,
+    port=port,
+)
+
 
 @mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers together"""
     return a + b
+
 
 @mcp.tool()
 def multiply(a: int, b: int) -> int:

--- a/tests/mcp/mcp_arithmetic_stdio.py
+++ b/tests/mcp/mcp_arithmetic_stdio.py
@@ -2,13 +2,15 @@ from mcp.server.fastmcp import FastMCP
 
 
 mcp = FastMCP(
-    name = "arithmetic_sse",
-    )
+    name="arithmetic_sse",
+)
+
 
 @mcp.tool()
 def add(a: int, b: int) -> int:
     """Add two numbers together"""
     return a + b
+
 
 @mcp.tool()
 def multiply(a: int, b: int) -> int:

--- a/tests/mcp/mcp_arithmetic_stdio.py
+++ b/tests/mcp/mcp_arithmetic_stdio.py
@@ -1,0 +1,24 @@
+from mcp.server.fastmcp import FastMCP
+
+
+mcp = FastMCP(
+    name = "arithmetic_sse",
+    )
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two numbers together"""
+    return a + b
+
+@mcp.tool()
+def multiply(a: int, b: int) -> int:
+    """Multiply two numbers together"""
+    return a * b
+
+
+if __name__ == "__main__":
+    try:
+        print(f"Starting FastMCP server {mcp.name} with transport stdio")
+        mcp.run(transport="stdio")
+    except Exception as e:
+        print(f"Error running FastMCP server {mcp.name}: {e}")

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -314,6 +314,48 @@ class TestLiveMCPClient:
             print("stdio server connection test completed")
 
     @pytest.mark.asyncio
+    async def test_initialize_with_invalid_config_type(self):
+        """Test initializing MCP client with an invalid config type"""
+        try:
+            # Try to initialize with an invalid config type (integer)
+            await initialize_mcp_client(123, "claude-3-7-sonnet-20250219")
+            pytest.fail("Should have raised ValueError for invalid config type")
+        except ValueError as e:
+            # Ensure the error message mentions the invalid type
+            assert "must be a string path or dictionary" in str(e)
+            print(f"Correctly raised ValueError: {str(e)}")
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_invalid_config_dict(self):
+        """Test initializing MCP client with an invalid config dictionary (missing mcpServers)"""
+        try:
+            # Create a dictionary without the mcpServers key
+            invalid_config = {"someOtherKey": "value"}
+
+            # Try to initialize with an invalid config dictionary
+            await initialize_mcp_client(invalid_config, "claude-3-7-sonnet-20250219")
+            pytest.fail("Should have raised ValueError for missing mcpServers key")
+        except ValueError as e:
+            # Ensure the error message mentions the missing key
+            assert "missing required 'mcpServers' key" in str(e)
+            print(f"Correctly raised ValueError: {str(e)}")
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_empty_mcpservers(self):
+        """Test initializing MCP client with empty mcpServers dictionary"""
+        try:
+            # Create a dictionary with empty mcpServers
+            invalid_config = {"mcpServers": {}}
+
+            # Try to initialize with empty mcpServers
+            await initialize_mcp_client(invalid_config, "claude-3-7-sonnet-20250219")
+            pytest.fail("Should have raised ValueError for empty mcpServers")
+        except ValueError as e:
+            # Ensure the error message mentions empty mcpServers
+            assert "No MCP servers defined in config" in str(e)
+            print(f"Correctly raised ValueError: {str(e)}")
+
+    @pytest.mark.asyncio
     @pytest.mark.skipif(
         not os.environ.get("ANTHROPIC_API_KEY"),
         reason="ANTHROPIC_API_KEY environment variable not set",

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -1,0 +1,319 @@
+import os
+import json
+import pytest
+import asyncio
+import subprocess
+import tempfile
+import time
+from unittest.mock import patch, MagicMock, AsyncMock
+
+from defog.llm.utils_mcp import MCPClient, initialize_mcp_client
+
+# Paths to arithmetic server scripts 
+SSE_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp_arithmetic_sse.py")
+STDIO_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp_arithmetic_stdio.py")
+
+# Verify that server scripts exist
+if not os.path.exists(SSE_SERVER_SCRIPT):
+    print(f"Warning: SSE server script not found at {SSE_SERVER_SCRIPT}")
+if not os.path.exists(STDIO_SERVER_SCRIPT):
+    print(f"Warning: stdio server script not found at {STDIO_SERVER_SCRIPT}")
+
+
+@pytest.fixture
+def event_loop():
+    """Create an event loop for the test session"""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="function")
+def arithmetic_sse_server(request):
+    """
+    Start an arithmetic SSE server for testing.
+    The server will be terminated only after the test using this fixture completes.
+    """
+    # Skip if server script doesn't exist
+    if not os.path.exists(SSE_SERVER_SCRIPT):
+        pytest.skip(f"SSE server script not found at {SSE_SERVER_SCRIPT}")
+    
+    # Create a config file for the server
+    config_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+    config = {
+        "mcpServers": {
+            "arithmetic_sse": {
+                "command": "sse",
+                "args": ["http://localhost:8001/sse"]
+            }
+        }
+    }
+    json.dump(config, config_file)
+    config_file.close()
+    
+    # Start the server in a subprocess
+    process = subprocess.Popen(["python", SSE_SERVER_SCRIPT])
+    print(f"Started SSE server: {process.pid}")
+    
+    # Wait for server to start
+    time.sleep(2)
+    
+    # Store the process in the request object for cleanup
+    request.addfinalizer(lambda: process.terminate())
+    
+    yield config_file.name
+    
+    # Clean up config file
+    os.unlink(config_file.name)
+
+
+@pytest.fixture(scope="function")
+def arithmetic_stdio_server():
+    """Create a config for an arithmetic stdio server for testing"""
+    # Skip if server script doesn't exist
+    if not os.path.exists(STDIO_SERVER_SCRIPT):
+        pytest.skip(f"stdio server script not found at {STDIO_SERVER_SCRIPT}")
+    
+    # Create a config file for the server
+    config_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+    
+    config = {
+        "mcpServers": {
+            "arithmetic_stdio": {
+                "command": "python",
+                "args": [STDIO_SERVER_SCRIPT]
+            }
+        }
+    }
+    json.dump(config, config_file)
+    config_file.close()
+    
+    yield config_file.name
+    
+    # Clean up config file
+    os.unlink(config_file.name)
+
+
+class TestMCPClient:
+    """Test the MCPClient class"""
+    
+    @pytest.mark.asyncio
+    async def test_initialization(self):
+        """Test basic initialization of MCPClient"""
+        client = MCPClient(model_name="claude-3-7-sonnet-20250219")
+        assert client.model_name == "claude-3-7-sonnet-20250219"
+        assert client.model_provider == "anthropic"
+        assert client.anthropic is not None
+        assert client.openai is None
+        
+        client = MCPClient(model_name="gpt-4")
+        assert client.model_name == "gpt-4"
+        assert client.model_provider == "openai"
+        assert client.anthropic is None
+        assert client.openai is not None
+        
+        # Cleanup
+        await client.cleanup()
+    
+    @pytest.mark.asyncio
+    async def test_invalid_model_name(self):
+        """Test initialization with invalid model name"""
+        with pytest.raises(ValueError, match="Unsupported model name"):
+            MCPClient(model_name="invalid-model")
+    
+    @pytest.mark.asyncio
+    async def test_call_tool_no_connections(self):
+        """Test call_tool with no server connections"""
+        client = MCPClient()
+        
+        with pytest.raises(ValueError, match="No server connections available"):
+            await client.call_tool("test_tool", {})
+        
+        # Cleanup
+        await client.cleanup()
+    
+    @pytest.mark.asyncio
+    async def test_call_tool_nonexistent_tool(self):
+        """Test call_tool with a tool that doesn't exist"""
+        client = MCPClient()
+        # Manually set up connections to avoid actual connection
+        client.connections = {"test_server": {"session": AsyncMock()}}
+        
+        with pytest.raises(ValueError, match="not found in any connected server"):
+            await client.call_tool("nonexistent_tool", {})
+        
+        # Cleanup
+        await client.cleanup()
+
+
+# Live tests that require API keys and running servers
+class TestLiveMCPClient:
+    """Live tests for MCPClient functionality"""
+    
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), 
+                       reason="ANTHROPIC_API_KEY environment variable not set")
+    async def test_anthropic_live(self):
+        """Test live Anthropic API integration (requires API key)"""
+        # Create client
+        client = MCPClient(model_name="claude-3-7-sonnet-20250219")
+        
+        try:
+            # Simple query that should not use tools
+            result = await client.process_query("What is 2+2?")
+            
+            # Verify result
+            assert result is not None
+            assert isinstance(result, str)
+            assert len(result) > 0
+            print(f"Anthropic response: {result}")
+            
+            # Basic check for correct answer
+            assert "4" in result
+        finally:
+            # Clean up
+            await client.cleanup()
+    
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), 
+                       reason="OPENAI_API_KEY environment variable not set")
+    async def test_openai_live(self):
+        """Test live OpenAI API integration (requires API key)"""
+        # Create client
+        client = MCPClient(model_name="gpt-3.5-turbo")
+        
+        try:
+            # Simple query that should not use tools
+            result = await client.process_query("What is 2+2?")
+            
+            # Verify result
+            assert result is not None
+            assert isinstance(result, str)
+            assert len(result) > 0
+            print(f"OpenAI response: {result}")
+            
+            # Basic check for correct answer
+            assert "4" in result
+        finally:
+            # Clean up
+            await client.cleanup()
+    
+    @pytest.mark.asyncio
+    async def test_sse_server_connection(self, arithmetic_sse_server):
+        """Test connection to SSE server"""
+        client = None
+        try:
+            print("Starting SSE server connection test...")
+            # Initialize client
+            client = await initialize_mcp_client(arithmetic_sse_server, "claude-3-7-sonnet-20250219")
+            
+            # Check the connection
+            assert client is not None
+            assert len(client.connections) > 0
+            
+            # Print available tools
+            print(f"Connected to server with {len(client.all_tools)} tools:")
+            for tool in client.all_tools:
+                print(f"- {tool.name}: {tool.description}")
+            
+            # Verify we have arithmetic tools
+            assert any(tool.name == "add" for tool in client.all_tools)
+            assert any(tool.name == "multiply" for tool in client.all_tools)
+            
+            # Test calling a tool directly
+            result, result_text = await client._handle_tool_call("add", {"a": 5, "b": 3})
+            assert result.isError is False
+            assert "8" in result_text
+            print(f"Successfully called add tool, result: {result_text}")
+            
+        except Exception as e:
+            pytest.fail(f"Failed to connect to SSE server: {str(e)}")
+        finally:
+            # Clean up client
+            if client:
+                print("Cleaning up MCP client...")
+                await client.cleanup()
+            print("SSE server connection test completed")
+    
+    @pytest.mark.asyncio
+    async def test_stdio_server_connection(self, arithmetic_stdio_server):
+        """Test connection to stdio server"""
+        client = None
+        try:
+            print("Starting stdio server connection test...")
+            # Initialize client
+            client = await initialize_mcp_client(arithmetic_stdio_server, "claude-3-7-sonnet-20250219")
+            
+            # Check the connection
+            assert client is not None
+            assert len(client.connections) > 0
+            
+            # Print available tools
+            print(f"Connected to stdio server with {len(client.all_tools)} tools:")
+            for tool in client.all_tools:
+                print(f"- {tool.name}: {tool.description}")
+            
+            # Verify we have arithmetic tools
+            assert any(tool.name == "add" for tool in client.all_tools)
+            assert any(tool.name == "multiply" for tool in client.all_tools)
+            
+            # Test calling a tool directly
+            result, result_text = await client._handle_tool_call("multiply", {"a": 5, "b": 3})
+            assert result.isError is False
+            assert "15" in result_text
+            print(f"Successfully called multiply tool, result: {result_text}")
+            
+        except Exception as e:
+            pytest.fail(f"Failed to connect to stdio server: {str(e)}")
+        finally:
+            # Clean up client
+            if client:
+                print("Cleaning up MCP client...")
+                await client.cleanup()
+            print("stdio server connection test completed")
+    
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), 
+                       reason="ANTHROPIC_API_KEY environment variable not set")
+    async def test_end_to_end_with_tool_use(self, arithmetic_stdio_server):
+        """End-to-end test with tool use (requires API key and server)"""
+        client = None
+        try:
+            print("Starting end-to-end tool use test...")
+            # Initialize client
+            client = await initialize_mcp_client(arithmetic_stdio_server, "claude-3-7-sonnet-20250219")
+            
+            # Query that should use the multiply tool
+            query = "I need to multiply 12 and 34. Can you use the multiply tool to help me?"
+            
+            # Use mcp_chat instead of process_query to test the full client API
+            result, tool_outputs = await client.mcp_chat(query=query)
+            
+            # Verify result
+            assert result is not None
+            assert isinstance(result, str)
+            print(f"End-to-end response: {result}")
+            
+            # Check if the tool was used (using the returned tool_outputs)
+            assert len(tool_outputs) > 0
+            tool_used = False
+            for tool in tool_outputs:
+                print(f"Tool used: {tool['name']}")
+                print(f"Tool args: {tool['args']}")
+                print(f"Tool result: {tool['result']}")
+                if tool['name'] == 'multiply':
+                    tool_used = True
+            
+            assert tool_used, "Multiply tool was not used"
+            
+            # Basic check for correct answer (408)
+            assert "408" in result
+            
+        except Exception as e:
+            pytest.fail(f"End-to-end test failed: {str(e)}")
+        finally:
+            # Clean up client
+            if client:
+                print("Cleaning up MCP client...")
+                await client.cleanup()
+            print("End-to-end tool use test completed")

--- a/tests/mcp/test_mcp.py
+++ b/tests/mcp/test_mcp.py
@@ -9,7 +9,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 
 from defog.llm.utils_mcp import MCPClient, initialize_mcp_client
 
-# Paths to arithmetic server scripts 
+# Paths to arithmetic server scripts
 SSE_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp_arithmetic_sse.py")
 STDIO_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp_arithmetic_stdio.py")
 
@@ -37,32 +37,29 @@ def arithmetic_sse_server(request):
     # Skip if server script doesn't exist
     if not os.path.exists(SSE_SERVER_SCRIPT):
         pytest.skip(f"SSE server script not found at {SSE_SERVER_SCRIPT}")
-    
+
     # Create a config file for the server
-    config_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
+    config_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
     config = {
         "mcpServers": {
-            "arithmetic_sse": {
-                "command": "sse",
-                "args": ["http://localhost:8001/sse"]
-            }
+            "arithmetic_sse": {"command": "sse", "args": ["http://localhost:8001/sse"]}
         }
     }
     json.dump(config, config_file)
     config_file.close()
-    
+
     # Start the server in a subprocess
     process = subprocess.Popen(["python", SSE_SERVER_SCRIPT])
     print(f"Started SSE server: {process.pid}")
-    
+
     # Wait for server to start
     time.sleep(2)
-    
+
     # Store the process in the request object for cleanup
     request.addfinalizer(lambda: process.terminate())
-    
+
     yield config_file.name
-    
+
     # Clean up config file
     os.unlink(config_file.name)
 
@@ -73,30 +70,27 @@ def arithmetic_stdio_server():
     # Skip if server script doesn't exist
     if not os.path.exists(STDIO_SERVER_SCRIPT):
         pytest.skip(f"stdio server script not found at {STDIO_SERVER_SCRIPT}")
-    
+
     # Create a config file for the server
-    config_file = tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False)
-    
+    config_file = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
+
     config = {
         "mcpServers": {
-            "arithmetic_stdio": {
-                "command": "python",
-                "args": [STDIO_SERVER_SCRIPT]
-            }
+            "arithmetic_stdio": {"command": "python", "args": [STDIO_SERVER_SCRIPT]}
         }
     }
     json.dump(config, config_file)
     config_file.close()
-    
+
     yield config_file.name
-    
+
     # Clean up config file
     os.unlink(config_file.name)
 
 
 class TestMCPClient:
     """Test the MCPClient class"""
-    
+
     @pytest.mark.asyncio
     async def test_initialization(self):
         """Test basic initialization of MCPClient"""
@@ -106,51 +100,51 @@ class TestMCPClient:
         assert client.anthropic is not None
         assert client.openai is None
         assert client.gemini is None
-        
+
         client = MCPClient(model_name="gpt-4")
         assert client.model_name == "gpt-4"
         assert client.model_provider == "openai"
         assert client.anthropic is None
         assert client.openai is not None
         assert client.gemini is None
-        
+
         client = MCPClient(model_name="gemini-1.5-pro")
         assert client.model_name == "gemini-1.5-pro"
         assert client.model_provider == "gemini"
         assert client.anthropic is None
         assert client.openai is None
         assert client.gemini is not None
-        
+
         # Cleanup
         await client.cleanup()
-    
+
     @pytest.mark.asyncio
     async def test_invalid_model_name(self):
         """Test initialization with invalid model name"""
         with pytest.raises(ValueError, match="Unsupported model name"):
             MCPClient(model_name="invalid-model")
-    
+
     @pytest.mark.asyncio
     async def test_call_tool_no_connections(self):
         """Test call_tool with no server connections"""
         client = MCPClient()
-        
+
         with pytest.raises(ValueError, match="No server connections available"):
             await client.call_tool("test_tool", {})
-        
+
         # Cleanup
         await client.cleanup()
-    
+
     @pytest.mark.asyncio
     async def test_call_tool_nonexistent_tool(self):
         """Test call_tool with a tool that doesn't exist"""
         client = MCPClient()
         # Manually set up connections to avoid actual connection
         client.connections = {"test_server": {"session": AsyncMock()}}
-        
+
         with pytest.raises(ValueError, match="not found in any connected server"):
             await client.call_tool("nonexistent_tool", {})
-        
+
         # Cleanup
         await client.cleanup()
 
@@ -158,79 +152,85 @@ class TestMCPClient:
 # Live tests that require API keys and running servers
 class TestLiveMCPClient:
     """Live tests for MCPClient functionality"""
-    
+
     @pytest.mark.asyncio
-    @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), 
-                       reason="ANTHROPIC_API_KEY environment variable not set")
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY environment variable not set",
+    )
     async def test_anthropic_live(self):
         """Test live Anthropic API integration (requires API key)"""
         # Create client
         client = MCPClient(model_name="claude-3-7-sonnet-20250219")
-        
+
         try:
             # Simple query that should not use tools
             result = await client.process_query("What is 2+2?")
-            
+
             # Verify result
             assert result is not None
             assert isinstance(result, str)
             assert len(result) > 0
             print(f"Anthropic response: {result}")
-            
+
             # Basic check for correct answer
             assert "4" in result
         finally:
             # Clean up
             await client.cleanup()
-    
+
     @pytest.mark.asyncio
-    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), 
-                       reason="OPENAI_API_KEY environment variable not set")
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY environment variable not set",
+    )
     async def test_openai_live(self):
         """Test live OpenAI API integration (requires API key)"""
         # Create client
         client = MCPClient(model_name="gpt-3.5-turbo")
-        
+
         try:
             # Simple query that should not use tools
             result = await client.process_query("What is 2+2?")
-            
+
             # Verify result
             assert result is not None
             assert isinstance(result, str)
             assert len(result) > 0
             print(f"OpenAI response: {result}")
-            
+
             # Basic check for correct answer
             assert "4" in result
         finally:
             # Clean up
             await client.cleanup()
-    
+
     @pytest.mark.asyncio
-    @pytest.mark.skipif(not os.environ.get("GEMINI_API_KEY"),
-                       reason="GEMINI_API_KEY environment variable not set")
+    @pytest.mark.skipif(
+        not os.environ.get("GEMINI_API_KEY"),
+        reason="GEMINI_API_KEY environment variable not set",
+    )
     async def test_gemini_live(self):
         """Test live Gemini API integration (requires API key)"""
         # Create client
         client = MCPClient(model_name="gemini-1.5-pro")
-        
+
         try:
             # Simple query that should not use tools
             result = await client.process_query("What is 2+2?")
-            
+
             # Verify result
             assert result is not None
             assert isinstance(result, str)
             assert len(result) > 0
             print(f"Gemini response: {result}")
-            
+
             # Basic check for correct answer
             assert "4" in result
         finally:
             # Clean up
             await client.cleanup()
-    
+
     @pytest.mark.asyncio
     async def test_sse_server_connection(self, arithmetic_sse_server):
         """Test connection to SSE server"""
@@ -238,27 +238,31 @@ class TestLiveMCPClient:
         try:
             print("Starting SSE server connection test...")
             # Initialize client
-            client = await initialize_mcp_client(arithmetic_sse_server, "claude-3-7-sonnet-20250219")
-            
+            client = await initialize_mcp_client(
+                arithmetic_sse_server, "claude-3-7-sonnet-20250219"
+            )
+
             # Check the connection
             assert client is not None
             assert len(client.connections) > 0
-            
+
             # Print available tools
             print(f"Connected to server with {len(client.all_tools)} tools:")
             for tool in client.all_tools:
                 print(f"- {tool.name}: {tool.description}")
-            
+
             # Verify we have arithmetic tools
             assert any(tool.name == "add" for tool in client.all_tools)
             assert any(tool.name == "multiply" for tool in client.all_tools)
-            
+
             # Test calling a tool directly
-            result, result_text = await client._handle_tool_call("add", {"a": 5, "b": 3})
+            result, result_text = await client._handle_tool_call(
+                "add", {"a": 5, "b": 3}
+            )
             assert result.isError is False
             assert "8" in result_text
             print(f"Successfully called add tool, result: {result_text}")
-            
+
         except Exception as e:
             pytest.fail(f"Failed to connect to SSE server: {str(e)}")
         finally:
@@ -267,7 +271,7 @@ class TestLiveMCPClient:
                 print("Cleaning up MCP client...")
                 await client.cleanup()
             print("SSE server connection test completed")
-    
+
     @pytest.mark.asyncio
     async def test_stdio_server_connection(self, arithmetic_stdio_server):
         """Test connection to stdio server"""
@@ -275,27 +279,31 @@ class TestLiveMCPClient:
         try:
             print("Starting stdio server connection test...")
             # Initialize client
-            client = await initialize_mcp_client(arithmetic_stdio_server, "claude-3-7-sonnet-20250219")
-            
+            client = await initialize_mcp_client(
+                arithmetic_stdio_server, "claude-3-7-sonnet-20250219"
+            )
+
             # Check the connection
             assert client is not None
             assert len(client.connections) > 0
-            
+
             # Print available tools
             print(f"Connected to stdio server with {len(client.all_tools)} tools:")
             for tool in client.all_tools:
                 print(f"- {tool.name}: {tool.description}")
-            
+
             # Verify we have arithmetic tools
             assert any(tool.name == "add" for tool in client.all_tools)
             assert any(tool.name == "multiply" for tool in client.all_tools)
-            
+
             # Test calling a tool directly
-            result, result_text = await client._handle_tool_call("multiply", {"a": 5, "b": 3})
+            result, result_text = await client._handle_tool_call(
+                "multiply", {"a": 5, "b": 3}
+            )
             assert result.isError is False
             assert "15" in result_text
             print(f"Successfully called multiply tool, result: {result_text}")
-            
+
         except Exception as e:
             pytest.fail(f"Failed to connect to stdio server: {str(e)}")
         finally:
@@ -304,29 +312,33 @@ class TestLiveMCPClient:
                 print("Cleaning up MCP client...")
                 await client.cleanup()
             print("stdio server connection test completed")
-    
+
     @pytest.mark.asyncio
-    @pytest.mark.skipif(not os.environ.get("ANTHROPIC_API_KEY"), 
-                       reason="ANTHROPIC_API_KEY environment variable not set")
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY environment variable not set",
+    )
     async def test_end_to_end_with_tool_use_anthropic(self, arithmetic_stdio_server):
         """End-to-end test with tool use using Anthropic (requires API key and server)"""
         client = None
         try:
             print("Starting end-to-end tool use test with Anthropic...")
             # Initialize client
-            client = await initialize_mcp_client(arithmetic_stdio_server, "claude-3-7-sonnet-20250219")
-            
+            client = await initialize_mcp_client(
+                arithmetic_stdio_server, "claude-3-7-sonnet-20250219"
+            )
+
             # Query that should use the multiply tool
             query = "I need to multiply 12 and 34. Can you use the multiply tool to help me?"
-            
+
             # Use mcp_chat to test the full client API
             result, tool_outputs = await client.mcp_chat(query=query)
-            
+
             # Verify result
             assert result is not None
             assert isinstance(result, str)
             print(f"End-to-end response from Anthropic: {result}")
-            
+
             # Check if the tool was used (using the returned tool_outputs)
             assert len(tool_outputs) > 0
             tool_used = False
@@ -334,14 +346,14 @@ class TestLiveMCPClient:
                 print(f"Tool used: {tool['name']}")
                 print(f"Tool args: {tool['args']}")
                 print(f"Tool result: {tool['result']}")
-                if tool['name'] == 'multiply':
+                if tool["name"] == "multiply":
                     tool_used = True
-            
+
             assert tool_used, "Multiply tool was not used"
-            
+
             # Basic check for correct answer (408)
             assert "408" in result
-            
+
         except Exception as e:
             pytest.fail(f"End-to-end test with Anthropic failed: {str(e)}")
         finally:
@@ -352,27 +364,31 @@ class TestLiveMCPClient:
             print("End-to-end tool use test with Anthropic completed")
 
     @pytest.mark.asyncio
-    @pytest.mark.skipif(not os.environ.get("GEMINI_API_KEY"), 
-                       reason="GEMINI_API_KEY environment variable not set")
+    @pytest.mark.skipif(
+        not os.environ.get("GEMINI_API_KEY"),
+        reason="GEMINI_API_KEY environment variable not set",
+    )
     async def test_end_to_end_with_tool_use_gemini(self, arithmetic_stdio_server):
         """End-to-end test with tool use using Gemini (requires API key and server)"""
         client = None
         try:
             print("Starting end-to-end tool use test with Gemini...")
             # Initialize client
-            client = await initialize_mcp_client(arithmetic_stdio_server, "gemini-1.5-pro")
-            
+            client = await initialize_mcp_client(
+                arithmetic_stdio_server, "gemini-1.5-pro"
+            )
+
             # Query that should use the multiply tool
             query = "I need to multiply 12 and 34. Can you use the multiply tool to help me?"
-            
+
             # Use mcp_chat to test the full client API
             result, tool_outputs = await client.mcp_chat(query=query)
-            
+
             # Verify result
             assert result is not None
             assert isinstance(result, str)
             print(f"End-to-end response from Gemini: {result}")
-            
+
             # Check if the tool was used (using the returned tool_outputs)
             assert len(tool_outputs) > 0
             tool_used = False
@@ -380,14 +396,14 @@ class TestLiveMCPClient:
                 print(f"Tool used: {tool['name']}")
                 print(f"Tool args: {tool['args']}")
                 print(f"Tool result: {tool['result']}")
-                if tool['name'] == 'multiply':
+                if tool["name"] == "multiply":
                     tool_used = True
-            
+
             assert tool_used, "Multiply tool was not used"
-            
+
             # Basic check for correct answer (408)
             assert "408" in result
-            
+
         except Exception as e:
             pytest.fail(f"End-to-end test with Gemini failed: {str(e)}")
         finally:
@@ -396,10 +412,12 @@ class TestLiveMCPClient:
                 print("Cleaning up MCP client...")
                 await client.cleanup()
             print("End-to-end tool use test with Gemini completed")
-            
+
     @pytest.mark.asyncio
-    @pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY"), 
-                       reason="OPENAI_API_KEY environment variable not set")
+    @pytest.mark.skipif(
+        not os.environ.get("OPENAI_API_KEY"),
+        reason="OPENAI_API_KEY environment variable not set",
+    )
     async def test_end_to_end_with_tool_use_openai(self, arithmetic_stdio_server):
         """End-to-end test with tool use using OpenAI (requires API key and server)"""
         client = None
@@ -407,18 +425,18 @@ class TestLiveMCPClient:
             print("Starting end-to-end tool use test with OpenAI...")
             # Initialize client with GPT-4
             client = await initialize_mcp_client(arithmetic_stdio_server, "o3-mini")
-            
+
             # Query that should use the multiply tool
             query = "I need to multiply 12 and 34. Can you use the multiply tool to help me?"
-            
+
             # Use mcp_chat to test the full client API
             result, tool_outputs = await client.mcp_chat(query=query)
-            
+
             # Verify result
             assert result is not None
             assert isinstance(result, str)
             print(f"End-to-end response from OpenAI: {result}")
-            
+
             # Check if the tool was used (using the returned tool_outputs)
             assert len(tool_outputs) > 0
             tool_used = False
@@ -426,14 +444,14 @@ class TestLiveMCPClient:
                 print(f"Tool used: {tool['name']}")
                 print(f"Tool args: {tool['args']}")
                 print(f"Tool result: {tool['result']}")
-                if tool['name'] == 'multiply':
+                if tool["name"] == "multiply":
                     tool_used = True
-            
+
             assert tool_used, "Multiply tool was not used"
-            
+
             # Basic check for correct answer (408)
             assert "408" in result
-            
+
         except Exception as e:
             pytest.fail(f"End-to-end test with OpenAI failed: {str(e)}")
         finally:


### PR DESCRIPTION
## Background

[Model Context Protocol](https://github.com/modelcontextprotocol) provides a standardized way for LLMs to use external tools. This PR adds support for connecting to MCP servers and letting models use tools working with both Anthropic, OpenAI and Gemini models.

## Changes
- Add a complete MCP client implementation for connecting to both SSE and stdio MCP servers
- Add comprehensive testing suite with live API and server connection tests
- Integrate with current Anthropic, OpenAI and Gemini API handling


## How to Use MCPClient

```
from defog.llm.utils_mcp import initialize_mcp_client


# Initialize with config file
client = await initialize_mcp_client("path/to/config.json",
"claude-3-haiku")

# Chat with tool usage
response, tool_outputs = await client.mcp_chat("Use tools to help me
   multiply 12 and 34")

# Clean up
await client.cleanup()
```