### PR TITLE
Better structured outputs handling

### DIFF
--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -878,7 +878,7 @@ async def _process_openai_response(
             except Exception as e:
                 content = response.choices[0].message.content
                 # parse the content as json
-                try: 
+                try:
                     # clean up any markdown formatting
                     content = re.sub(r"```(.*)```", r"\1", content)
                     content = json.loads(content)

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -2,6 +2,7 @@ import os
 import time
 import json
 import traceback
+import re
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Any, Union, Callable
 
@@ -872,7 +873,17 @@ async def _process_openai_response(
     else:
         # No tools provided
         if response_format and model not in ["o1-mini", "o1-preview"]:
-            content = response.choices[0].message.parsed
+            try:
+                content = response.choices[0].message.parsed
+            except Exception as e:
+                content = response.choices[0].message.content
+                # parse the content as json
+                try: 
+                    # clean up any markdown formatting
+                    content = re.sub(r"```(.*)```", r"\1", content)
+                    content = json.loads(content)
+                except Exception as e:
+                    raise Exception(f"Error parsing content: {e}")
         else:
             content = response.choices[0].message.content
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": ["gcp/*", "aws/*"] + next_static_files},
-    version="0.68.0",
+    version="0.68.1",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",


### PR DESCRIPTION
We now add fallbacks to structured output handling. This is useful when the LLM uses markdown or other artifacts to the JSON returned instead of just outputting clean JSON.

This _should_ handle this issue: https://github.com/defog-ai/introspect/issues/479