### PR TITLE
Enable extended thinking for Claude 3.7 Sonnet and up models

### DIFF
--- a/defog/llm/citations.py
+++ b/defog/llm/citations.py
@@ -140,7 +140,7 @@ async def citations_tool(
             model="claude-4-sonnet-20250514",
             messages=messages,
             system=instructions,
-            max_tokens=8191,
+            max_tokens=32000,
         )
 
         response_with_citations = [item.to_dict() for item in response.content]

--- a/defog/llm/citations.py
+++ b/defog/llm/citations.py
@@ -34,6 +34,7 @@ async def citations_tool(
     documents: list[dict],
     model: str,
     provider: LLMProvider,
+    max_tokens: int = 16000,
 ):
     """
     Use this tool to get an answer to a well-cited answer to a question,
@@ -82,6 +83,7 @@ async def citations_tool(
             ],
             tool_choice="required",
             instructions=instructions,
+            max_output_tokens=max_tokens,
         )
 
         # convert the response to a list of blocks
@@ -137,10 +139,10 @@ async def citations_tool(
         ]
 
         response = await client.messages.create(
-            model="claude-4-sonnet-20250514",
+            model=model,
             messages=messages,
             system=instructions,
-            max_tokens=32000,
+            max_tokens=max_tokens,
         )
 
         response_with_citations = [item.to_dict() for item in response.content]

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -9,6 +9,7 @@ from ..cost import CostCalculator
 from ..tools import ToolHandler
 from ..utils_function_calling import get_function_specs, convert_tool_choice
 
+
 class AnthropicProvider(BaseLLMProvider):
     """Anthropic Claude provider implementation."""
 
@@ -219,7 +220,7 @@ THE RESPONSE SHOULD START WITH '{{' AND END WITH '}}' WITH NO OTHER CHARACTERS B
                         assistant_content = []
                         if thinking_block:
                             assistant_content.append(thinking_block)
-                        
+
                         assistant_content.append(tool_call_block)
 
                         # Append the tool call as an assistant response

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -49,11 +49,7 @@ class AnthropicProvider(BaseLLMProvider):
         else:
             sys_msg = ""
 
-        if reasoning_effort is not None and (
-            model.startswith("claude-3-7")
-            or model.startswith("claude-sonnet-4")
-            or model.startswith("claude-opus-4")
-        ):
+        if reasoning_effort is not None:
             temperature = 1.0
             if reasoning_effort == "low":
                 thinking = {

--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -55,8 +55,9 @@ class OpenAIProvider(BaseLLMProvider):
         # if a message is called "system", rename it to "developer"
         # create a new list of messages
         import copy
+
         messages = copy.deepcopy(messages)
-        
+
         for i in range(len(messages)):
             if model not in ["gpt-4o", "gpt-4o-mini"]:
                 if messages[i].get("role") == "system":

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": next_static_files},
-    version="0.69.4",
+    version="0.69.5",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -146,8 +146,6 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
             )
             self.check_sql(response.content)
             self.assertIsInstance(response.time, float)
-    
-
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_sql_chat_structured_reasoning_effort_async(self):

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -273,7 +273,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertGreaterEqual(float(result.content), 21)
         self.assertLessEqual(float(result.content), 38)
-    
+
     @pytest.mark.asyncio
     async def test_tool_use_arithmetic_async_anthropic_reasoning_effort(self):
         result = await chat_async(

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -72,8 +72,8 @@ def numprod(input: Numbers):
 # ==================================================================================================
 class TestGetFunctionSpecs(unittest.TestCase):
     def setUp(self):
-        self.openai_model = "gpt-4o"
-        self.anthropic_model = "claude-3-5-sonnet-20241022"
+        self.openai_model = "gpt-4.1"
+        self.anthropic_model = "claude-3-7-sonnet-latest"
         self.tools = [get_weather, numsum, numprod]
         self.maxDiff = None
         self.openai_specs = [
@@ -234,7 +234,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     async def test_tool_use_arithmetic_async_anthropic(self):
         result = await chat_async(
-            model="claude-3-5-sonnet-20241022",
+            model="claude-3-7-sonnet-latest",
             messages=[
                 {
                     "role": "user",
@@ -257,7 +257,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
     @pytest.mark.asyncio
     async def test_tool_use_weather_async_anthropic(self):
         result = await chat_async(
-            model="claude-3-5-sonnet-20241022",
+            model="claude-3-7-sonnet-latest",
             messages=[
                 {
                     "role": "user",
@@ -273,6 +273,30 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result.tool_outputs[0]["name"], "get_weather")
         self.assertGreaterEqual(float(result.content), 21)
         self.assertLessEqual(float(result.content), 38)
+    
+    @pytest.mark.asyncio
+    async def test_tool_use_arithmetic_async_anthropic_reasoning_effort(self):
+        result = await chat_async(
+            model="claude-3-7-sonnet-latest",
+            messages=[
+                {
+                    "role": "user",
+                    "content": self.arithmetic_qn,
+                },
+            ],
+            tools=self.tools,
+            reasoning_effort="low",
+            max_retries=1,
+        )
+        print(result)
+        self.assertEqual(result.content, self.arithmetic_answer)
+        for expected, actual in zip(
+            self.arithmetic_expected_tool_outputs, result.tool_outputs
+        ):
+            self.assertEqual(expected["name"], actual["name"])
+            self.assertEqual(expected["args"], actual["args"])
+            self.assertEqual(expected["result"], actual["result"])
+        self.assertEqual(result.content, self.arithmetic_answer)
 
     @pytest.mark.asyncio
     async def test_tool_use_arithmetic_async_gemini(self):
@@ -371,7 +395,7 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
 
     async def test_post_tool_calls_anthropic(self):
         result = await chat_async(
-            model="claude-3-5-sonnet-latest",
+            model="claude-3-7-sonnet-latest",
             messages=[
                 {
                     "role": "user",


### PR DESCRIPTION
This adds support for thinking for all Anthropic models after Claude 3.7 Sonnet.

Now, thinking can be used both as part of tool calls and as standalone.

To keep this consistent with the OpenAI API, we keep a `reasoning_effort` param. When `reasoning_effort` is one of the following parameters, we use the following thinking budgets:
- `low`: 2048
- `medium`: 4096
- `high`: 8192

Tests have been updated to incorporate this.