### PR TITLE
Enable parallel tool calling by default

### DIFF
--- a/defog/llm/config/settings.py
+++ b/defog/llm/config/settings.py
@@ -19,10 +19,12 @@ class LLMConfig:
         default_temperature: float = DEFAULT_TEMPERATURE,
         api_keys: Optional[Dict[str, str]] = None,
         base_urls: Optional[Dict[str, str]] = None,
+        enable_parallel_tool_calls: bool = True,
     ):
         self.timeout = timeout
         self.max_retries = max_retries
         self.default_temperature = default_temperature
+        self.enable_parallel_tool_calls = enable_parallel_tool_calls
 
         # API keys with environment fallbacks
         self.api_keys = api_keys or {}

--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, List, Any, Optional, Callable, Tuple
 from dataclasses import dataclass
+from ..config.settings import LLMConfig
 
 
 @dataclass
@@ -19,9 +20,15 @@ class LLMResponse:
 class BaseLLMProvider(ABC):
     """Abstract base class for all LLM providers."""
 
-    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        config: Optional[LLMConfig] = None,
+    ):
         self.api_key = api_key
         self.base_url = base_url
+        self.config = config or LLMConfig()
 
     @abstractmethod
     def get_provider_name(self) -> str:

--- a/defog/llm/providers/together_provider.py
+++ b/defog/llm/providers/together_provider.py
@@ -10,8 +10,8 @@ from ..cost import CostCalculator
 class TogetherProvider(BaseLLMProvider):
     """Together AI provider implementation."""
 
-    def __init__(self, api_key: Optional[str] = None):
-        super().__init__(api_key or os.getenv("TOGETHER_API_KEY"))
+    def __init__(self, api_key: Optional[str] = None, config=None):
+        super().__init__(api_key or os.getenv("TOGETHER_API_KEY"), config=config)
 
     def get_provider_name(self) -> str:
         return "together"

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -14,6 +14,7 @@ from .providers.base import LLMResponse
 from .exceptions import LLMError, ProviderError, ConfigurationError
 from .config import LLMConfig
 from .llm_providers import LLMProvider
+from copy import deepcopy
 
 # Keep the original LLMResponse for backwards compatibility
 # (it's now defined in providers.base but we re-export it here)
@@ -73,13 +74,16 @@ def get_provider_instance(
         return provider_class(
             api_key=config.get_api_key("deepseek"),
             base_url=config.get_base_url("deepseek"),
+            config=config,
         )
     elif provider_name == "openai":
         return provider_class(
-            api_key=config.get_api_key("openai"), base_url=config.get_base_url("openai")
+            api_key=config.get_api_key("openai"),
+            base_url=config.get_base_url("openai"),
+            config=config,
         )
     else:
-        return provider_class(api_key=config.get_api_key(provider_name))
+        return provider_class(api_key=config.get_api_key(provider_name), config=config)
 
 
 async def chat_async(
@@ -135,6 +139,9 @@ async def chat_async(
         ProviderError: If the provider API call fails
         LLMError: For other LLM-related errors
     """
+    # create a deep copy of the messages to avoid modifying the original messages
+    messages = deepcopy(messages)
+
     if config is None:
         config = LLMConfig()
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     name="defog",
     packages=find_packages(),
     package_data={"defog": next_static_files},
-    version="0.69.7",
+    version="0.70.0",
     description="Defog is a Python library that helps you generate data queries from natural language questions.",
     author="Full Stack Data Pte. Ltd.",
     license="MIT",

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -202,12 +202,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         )
         print(result)
         self.assertEqual(result.content, self.arithmetic_answer)
-        for expected, actual in zip(
-            self.arithmetic_expected_tool_outputs, result.tool_outputs
-        ):
-            self.assertEqual(expected["name"], actual["name"])
-            self.assertEqual(expected["args"], actual["args"])
-            self.assertEqual(expected["result"], actual["result"])
         tools_used = [output["name"] for output in result.tool_outputs]
         self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
 
@@ -246,12 +240,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         print(result)
         tools_used = [output["name"] for output in result.tool_outputs]
         self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
-        for expected, actual in zip(
-            self.arithmetic_expected_tool_outputs, result.tool_outputs
-        ):
-            self.assertEqual(expected["name"], actual["name"])
-            self.assertEqual(expected["args"], actual["args"])
-            self.assertEqual(expected["result"], actual["result"])
         self.assertEqual(result.content, self.arithmetic_answer)
 
     @pytest.mark.asyncio
@@ -290,12 +278,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         )
         print(result)
         self.assertEqual(result.content, self.arithmetic_answer)
-        for expected, actual in zip(
-            self.arithmetic_expected_tool_outputs, result.tool_outputs
-        ):
-            self.assertEqual(expected["name"], actual["name"])
-            self.assertEqual(expected["args"], actual["args"])
-            self.assertEqual(expected["result"], actual["result"])
         self.assertEqual(result.content, self.arithmetic_answer)
 
     @pytest.mark.asyncio
@@ -312,12 +294,6 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         )
         print(result)
         self.assertEqual(result.content, self.arithmetic_answer)
-        for expected, actual in zip(
-            self.arithmetic_expected_tool_outputs, result.tool_outputs
-        ):
-            self.assertEqual(expected["name"], actual["name"])
-            self.assertEqual(expected["args"], actual["args"])
-            self.assertEqual(expected["result"], actual["result"])
         tools_used = [output["name"] for output in result.tool_outputs]
         self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
 
@@ -359,39 +335,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         )
         print(result)
         self.assertEqual(result.content, self.arithmetic_answer)
-        for expected, actual in zip(
-            self.arithmetic_expected_tool_outputs, result.tool_outputs
-        ):
-            self.assertEqual(expected["name"], actual["name"])
-            self.assertEqual(expected["args"], actual["args"])
-            self.assertEqual(expected["result"], actual["result"])
         tools_used = [output["name"] for output in result.tool_outputs]
         self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
-        expected_stream_value = (
-            json.dumps(
-                {
-                    "function_name": "numprod",
-                    "args": {"a": 31283, "b": 2323},
-                    "result": 72670409,
-                },
-                indent=4,
-            )
-            + "\n"
-            + json.dumps(
-                {
-                    "function_name": "numsum",
-                    "args": {"a": 72670409, "b": 5},
-                    "result": 72670414,
-                },
-                indent=4,
-            )
-            + "\n"
-        )
-        self.assertEqual(IO_STREAM.getvalue(), expected_stream_value)
-
-        # clear IO_STREAM
-        IO_STREAM.seek(0)
-        IO_STREAM.truncate()
 
     async def test_post_tool_calls_anthropic(self):
         result = await chat_async(
@@ -407,39 +352,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         )
         print(result)
         self.assertEqual(result.content, self.arithmetic_answer)
-        for expected, actual in zip(
-            self.arithmetic_expected_tool_outputs, result.tool_outputs
-        ):
-            self.assertEqual(expected["name"], actual["name"])
-            self.assertEqual(expected["args"], actual["args"])
-            self.assertEqual(expected["result"], actual["result"])
         tools_used = [output["name"] for output in result.tool_outputs]
         self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
-        expected_stream_value = (
-            json.dumps(
-                {
-                    "function_name": "numprod",
-                    "args": {"a": 31283, "b": 2323},
-                    "result": 72670409,
-                },
-                indent=4,
-            )
-            + "\n"
-            + json.dumps(
-                {
-                    "function_name": "numsum",
-                    "args": {"a": 72670409, "b": 5},
-                    "result": 72670414,
-                },
-                indent=4,
-            )
-            + "\n"
-        )
-        self.assertEqual(IO_STREAM.getvalue(), expected_stream_value)
-
-        # clear IO_STREAM
-        IO_STREAM.seek(0)
-        IO_STREAM.truncate()
 
     @pytest.mark.asyncio
     async def test_post_tool_calls_gemini(self):
@@ -456,39 +370,8 @@ class TestToolUseFeatures(unittest.IsolatedAsyncioTestCase):
         )
         print(result)
         self.assertEqual(result.content, self.arithmetic_answer)
-        for expected, actual in zip(
-            self.arithmetic_expected_tool_outputs, result.tool_outputs
-        ):
-            self.assertEqual(expected["name"], actual["name"])
-            self.assertEqual(expected["args"], actual["args"])
-            self.assertEqual(expected["result"], actual["result"])
         tools_used = [output["name"] for output in result.tool_outputs]
         self.assertSetEqual(set(tools_used), {"numsum", "numprod"})
-        expected_stream_value = (
-            json.dumps(
-                {
-                    "function_name": "numprod",
-                    "args": {"a": 31283, "b": 2323},
-                    "result": 72670409,
-                },
-                indent=4,
-            )
-            + "\n"
-            + json.dumps(
-                {
-                    "function_name": "numsum",
-                    "args": {"a": 72670409, "b": 5},
-                    "result": 72670414,
-                },
-                indent=4,
-            )
-            + "\n"
-        )
-        self.assertEqual(IO_STREAM.getvalue(), expected_stream_value)
-
-        # clear IO_STREAM
-        IO_STREAM.seek(0)
-        IO_STREAM.truncate()
 
 
 class TestParallelToolCalls(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -732,55 +732,6 @@ You MUST use the numsum and numprod tools for these calculations. Do not calcula
         print(f"  Difference: {abs(parallel_time - sequential_time):.2f}s")
 
         # we can't really test Gemini, as it always has parallel tool calls enabled
-        """Test Gemini's parallel tool call behavior."""
-        from defog.llm.config.settings import LLMConfig
-        from defog.llm.utils import chat_async
-        import time
-
-        # Test with parallel enabled (should make one API call with multiple tools)
-        config_parallel = LLMConfig(enable_parallel_tool_calls=True)
-        start_time = time.time()
-        result_parallel = await chat_async(
-            provider="gemini",
-            model="gemini-2.5-pro-preview-05-06",
-            messages=self.messages,
-            tools=self.tools,
-            config=config_parallel,
-            temperature=0,
-            max_retries=1,
-        )
-        parallel_time = time.time() - start_time
-
-        # Test with parallel disabled (may require multiple API calls)
-        config_sequential = LLMConfig(enable_parallel_tool_calls=False)
-        start_time = time.time()
-        result_sequential = await chat_async(
-            provider="gemini",
-            model="gemini-2.5-pro-preview-05-06",
-            messages=self.messages,
-            tools=self.tools,
-            config=config_sequential,
-            temperature=0,
-            max_retries=1,
-        )
-        sequential_time = time.time() - start_time
-
-        # Verify results
-        self.assertEqual(len(result_parallel.tool_outputs), 2)
-        self.assertEqual(len(result_sequential.tool_outputs), 2)
-
-        # Check results
-        outputs_parallel = {
-            o["name"]: o["result"] for o in result_parallel.tool_outputs
-        }
-        self.assertEqual(outputs_parallel["numsum"], 2735586954)
-        self.assertEqual(outputs_parallel["numprod"], 287680120)
-
-        print(f"\nGemini Timing Results:")
-        print(f"  Parallel execution: {parallel_time:.2f}s")
-        print(f"  Sequential execution: {sequential_time:.2f}s")
-        print(f"  Difference: {abs(parallel_time - sequential_time):.2f}s")
-
     def test_provider_config_propagation(self):
         """Test that config properly propagates to all providers."""
         from defog.llm.config.settings import LLMConfig

--- a/tests/test_llm_tool_calls.py
+++ b/tests/test_llm_tool_calls.py
@@ -729,9 +729,10 @@ You MUST use the numsum and numprod tools for these calculations. Do not calcula
         print(f"\nAnthropic Timing Results:")
         print(f"  Parallel execution: {parallel_time:.2f}s")
         print(f"  Sequential execution: {sequential_time:.2f}s")
-        print(f"  Difference: {abs(parallel_time - sequential_time):.2f}s")
+        print(f"  Speedup: {sequential_time/parallel_time:.2f}x")
 
-        # we can't really test Gemini, as it always has parallel tool calls enabled
+    # we can't really test Gemini, as it always has parallel tool calls enabled
+
     def test_provider_config_propagation(self):
         """Test that config properly propagates to all providers."""
         from defog.llm.config.settings import LLMConfig


### PR DESCRIPTION
With the Claude 4 models, parallel tool calls are [finally intelligent enough](https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices#optimize-parallel-tool-calling) to use in production.

In this PR, we enable parallel tool calls and update tests to verify completion.

We also fix a minor issue in `chat_async` – creating deep copies of input messages, instead of modifying them directly.

This is enable by default, but can be disabled like so:

```python
config_sequential = LLMConfig(enable_parallel_tool_calls=False)
result_sequential = await chat_async(
    provider="openai",
    model="gpt-4.1",
    messages=messages,
    tools=[...],
    config=config_sequential,
)
```

It is recommended to do keep parallel tool calls enabled for Claude 4 models. But for best results, consider disabling if you're using non-reasoning OpenAI models.