### PR TITLE
Add Model Context Protocol (MCP) Support to chat_async when using the Anthropic provider

### DIFF
--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -51,6 +51,7 @@ class BaseLLMProvider(ABC):
         timeout: int = 100,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs
     ) -> Tuple[Dict[str, Any], List[Dict[str, str]]]:
         """Build parameters for the provider's API call."""
@@ -90,6 +91,7 @@ class BaseLLMProvider(ABC):
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
         post_tool_function: Optional[Callable] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs
     ) -> LLMResponse:
         """Execute a chat completion with the provider."""

--- a/defog/llm/providers/gemini_provider.py
+++ b/defog/llm/providers/gemini_provider.py
@@ -40,6 +40,7 @@ class GeminiProvider(BaseLLMProvider):
         timeout: int = 100,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, str]]]:
         """Construct parameters for Gemini's generate_content call."""
@@ -278,6 +279,7 @@ class GeminiProvider(BaseLLMProvider):
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
         post_tool_function: Optional[Callable] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with Gemini."""

--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -48,6 +48,7 @@ class OpenAIProvider(BaseLLMProvider):
         timeout: int = 100,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, str]]]:
         """
@@ -325,6 +326,7 @@ class OpenAIProvider(BaseLLMProvider):
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
         post_tool_function: Optional[Callable] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with OpenAI."""

--- a/defog/llm/providers/together_provider.py
+++ b/defog/llm/providers/together_provider.py
@@ -39,6 +39,7 @@ class TogetherProvider(BaseLLMProvider):
         timeout: int = 100,
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, str]]]:
         """Build parameters for Together's API call."""
@@ -91,6 +92,7 @@ class TogetherProvider(BaseLLMProvider):
         prediction: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
         post_tool_function: Optional[Callable] = None,
+        mcp_servers: Optional[List[Dict[str, Any]]] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with Together."""

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -106,6 +106,7 @@ async def chat_async(
     max_retries: Optional[int] = None,
     post_tool_function: Optional[Callable] = None,
     config: Optional[LLMConfig] = None,
+    mcp_servers: Optional[List[Dict[str, Any]]] = None,
 ) -> LLMResponse:
     """
     Execute a chat completion with explicit provider parameter.
@@ -130,6 +131,7 @@ async def chat_async(
         max_retries: Maximum number of retry attempts
         post_tool_function: Function to call after each tool execution
         config: LLM configuration object
+        mcp_servers: List of MCP server configurations (Anthropic only)
 
     Returns:
         LLMResponse object containing the result
@@ -182,6 +184,7 @@ async def chat_async(
                 prediction=prediction,
                 reasoning_effort=reasoning_effort,
                 post_tool_function=post_tool_function,
+                mcp_servers=mcp_servers,
             )
 
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ uvicorn
 tqdm
 setuptools
 pydantic
-anthropic==0.52.0
+anthropic==0.52.2
 google-genai==1.16.1
-openai==1.82.0
+openai==1.84.0
 together==1.3.11
 tiktoken==0.9.0
 pytest

--- a/tests/test_mcp_chat_async.py
+++ b/tests/test_mcp_chat_async.py
@@ -12,8 +12,12 @@ from defog.llm.llm_providers import LLMProvider
 
 
 # Paths to arithmetic server scripts
-SSE_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp", "mcp_arithmetic_sse.py")
-STDIO_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp", "mcp_arithmetic_stdio.py")
+SSE_SERVER_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "mcp", "mcp_arithmetic_sse.py"
+)
+STDIO_SERVER_SCRIPT = os.path.join(
+    os.path.dirname(__file__), "mcp", "mcp_arithmetic_stdio.py"
+)
 
 
 @pytest.fixture
@@ -31,11 +35,7 @@ def deepwiki_mcp_server():
     Uses the public DeepWiki MCP server which supports HTTPS.
     """
     # Return the MCP server configuration for DeepWiki
-    yield [{
-        "type": "url",
-        "url": "https://mcp.deepwiki.com/sse",
-        "name": "deepwiki"
-    }]
+    yield [{"type": "url", "url": "https://mcp.deepwiki.com/sse", "name": "deepwiki"}]
 
 
 @pytest.fixture(scope="function")
@@ -48,7 +48,9 @@ def arithmetic_stdio_server():
     # Note: For stdio servers, we can't use the direct server config format
     # because the Anthropic API expects HTTP endpoints for MCP servers
     # So we'll skip this test for now
-    pytest.skip("Stdio servers are not supported directly by Anthropic API MCP connector")
+    pytest.skip(
+        "Stdio servers are not supported directly by Anthropic API MCP connector"
+    )
 
 
 class TestMCPChatAsync:
@@ -61,17 +63,15 @@ class TestMCPChatAsync:
     )
     async def test_chat_async_without_mcp(self):
         """Test chat_async without MCP servers"""
-        messages = [
-            {"role": "user", "content": "What is 2 + 2?"}
-        ]
-        
+        messages = [{"role": "user", "content": "What is 2 + 2?"}]
+
         response = await chat_async(
             provider=LLMProvider.ANTHROPIC,
             model="claude-3-7-sonnet-20250219",
             messages=messages,
-            temperature=0.0
+            temperature=0.0,
         )
-        
+
         assert response is not None
         assert response.content is not None
         assert isinstance(response.content, str)
@@ -88,28 +88,31 @@ class TestMCPChatAsync:
     async def test_chat_async_with_mcp_servers(self, deepwiki_mcp_server):
         """Test chat_async with MCP servers enabled using DeepWiki"""
         messages = [
-            {"role": "user", "content": "Use the read_wiki_structure tool to get documentation topics for the python/cpython GitHub repository"}
+            {
+                "role": "user",
+                "content": "Use the read_wiki_structure tool to get documentation topics for the python/cpython GitHub repository",
+            }
         ]
-        
+
         response = await chat_async(
             provider=LLMProvider.ANTHROPIC,
             model="claude-3-7-sonnet-20250219",
             messages=messages,
             temperature=0.0,
-            mcp_servers=deepwiki_mcp_server
+            mcp_servers=deepwiki_mcp_server,
         )
-        
+
         assert response is not None
         assert response.content is not None
         assert isinstance(response.content, str)
         assert response.model == "claude-3-7-sonnet-20250219"
         assert response.input_tokens > 0
         assert response.output_tokens > 0
-        
+
         # Check that tool outputs are included
         assert response.tool_outputs is not None
         assert len(response.tool_outputs) > 0
-        
+
         # Verify the read_wiki_structure tool was used
         tool_used = False
         for tool_output in response.tool_outputs:
@@ -118,7 +121,7 @@ class TestMCPChatAsync:
                 # Should have repository-related argument (repoName or repository)
                 args_str = str(tool_output.get("args", {}))
                 assert "repository" in args_str or "repoName" in args_str
-        
+
         assert tool_used, "read_wiki_structure tool was not used"
 
     @pytest.mark.asyncio
@@ -129,30 +132,33 @@ class TestMCPChatAsync:
     async def test_chat_async_with_multiple_tool_calls(self, deepwiki_mcp_server):
         """Test chat_async with multiple MCP tool calls using DeepWiki"""
         messages = [
-            {"role": "user", "content": "First use read_wiki_structure to get the structure of the Python repository, then use ask_question to ask about Python's installation process"}
+            {
+                "role": "user",
+                "content": "First use read_wiki_structure to get the structure of the Python repository, then use ask_question to ask about Python's installation process",
+            }
         ]
-        
+
         response = await chat_async(
             provider=LLMProvider.ANTHROPIC,
             model="claude-3-7-sonnet-20250219",
             messages=messages,
             temperature=0.0,
-            mcp_servers=deepwiki_mcp_server
+            mcp_servers=deepwiki_mcp_server,
         )
-        
+
         assert response is not None
         assert response.content is not None
         assert isinstance(response.content, str)
-        
+
         # Check that multiple tools were used
         assert response.tool_outputs is not None
         assert len(response.tool_outputs) >= 1  # At least one tool should be used
-        
+
         # Verify DeepWiki tools were used
         tools_used = set()
         for tool_output in response.tool_outputs:
             tools_used.add(tool_output.get("name"))
-        
+
         # Should use at least one DeepWiki tool
         deepwiki_tools = {"read_wiki_structure", "read_wiki_contents", "ask_question"}
         assert len(tools_used.intersection(deepwiki_tools)) > 0
@@ -160,17 +166,13 @@ class TestMCPChatAsync:
     @pytest.mark.asyncio
     async def test_chat_async_mcp_with_non_anthropic_provider(self):
         """Test that MCP servers are ignored for non-Anthropic providers"""
-        messages = [
-            {"role": "user", "content": "What is 2 + 2?"}
-        ]
-        
+        messages = [{"role": "user", "content": "What is 2 + 2?"}]
+
         # Mock MCP servers config
-        mcp_servers = [{
-            "type": "url",
-            "url": "http://localhost:8001/sse",
-            "name": "test_server"
-        }]
-        
+        mcp_servers = [
+            {"type": "url", "url": "http://localhost:8001/sse", "name": "test_server"}
+        ]
+
         # This should work without errors even though OpenAI doesn't support MCP
         # (assuming OpenAI API key is available)
         if os.environ.get("OPENAI_API_KEY"):
@@ -179,9 +181,9 @@ class TestMCPChatAsync:
                 model="gpt-3.5-turbo",
                 messages=messages,
                 temperature=0.0,
-                mcp_servers=mcp_servers  # This should be ignored
+                mcp_servers=mcp_servers,  # This should be ignored
             )
-            
+
             assert response is not None
             assert response.content is not None
             assert "4" in response.content
@@ -194,28 +196,33 @@ class TestMCPChatAsync:
     async def test_chat_async_mcp_with_system_message(self, deepwiki_mcp_server):
         """Test chat_async with MCP servers and a system message"""
         messages = [
-            {"role": "system", "content": "You are a helpful documentation assistant. Always use the available tools to lookup information about repositories."},
-            {"role": "user", "content": "Look up information about the defog/introspect repository structure"}
+            {
+                "role": "system",
+                "content": "You are a helpful documentation assistant. Always use the available tools to lookup information about repositories.",
+            },
+            {
+                "role": "user",
+                "content": "Look up information about the defog/introspect repository structure",
+            },
         ]
-        
+
         response = await chat_async(
             provider=LLMProvider.ANTHROPIC,
             model="claude-3-7-sonnet-20250219",
             messages=messages,
             temperature=0.0,
-            mcp_servers=deepwiki_mcp_server
+            mcp_servers=deepwiki_mcp_server,
         )
-        
+
         assert response is not None
         assert response.content is not None
         assert isinstance(response.content, str)
-        
+
         # Verify a DeepWiki tool was used
         assert response.tool_outputs is not None
         deepwiki_tools = {"read_wiki_structure", "read_wiki_contents", "ask_question"}
         tool_used = any(
-            tool.get("name") in deepwiki_tools
-            for tool in response.tool_outputs
+            tool.get("name") in deepwiki_tools for tool in response.tool_outputs
         )
         assert tool_used
 
@@ -227,35 +234,37 @@ class TestMCPChatAsync:
     async def test_chat_async_mcp_with_response_format(self, deepwiki_mcp_server):
         """Test chat_async with MCP servers and response format"""
         from pydantic import BaseModel
-        
+
         class RepositoryInfo(BaseModel):
             repository_name: str
             has_documentation: bool
-            
+
         messages = [
-            {"role": "user", "content": "Look up information about the defog/introspect repository and return details in the specified format"}
+            {
+                "role": "user",
+                "content": "Look up information about the defog/introspect repository and return details in the specified format",
+            }
         ]
-        
+
         response = await chat_async(
             provider=LLMProvider.ANTHROPIC,
             model="claude-3-7-sonnet-20250219",
             messages=messages,
             temperature=0.0,
             mcp_servers=deepwiki_mcp_server,
-            response_format=RepositoryInfo
+            response_format=RepositoryInfo,
         )
-        
+
         assert response is not None
         assert response.content is not None
         assert isinstance(response.content, RepositoryInfo)
         assert isinstance(response.content.repository_name, str)
         assert isinstance(response.content.has_documentation, bool)
-        
+
         # Verify a DeepWiki tool was used
         assert response.tool_outputs is not None
         deepwiki_tools = {"read_wiki_structure", "read_wiki_contents", "ask_question"}
         tool_used = any(
-            tool.get("name") in deepwiki_tools
-            for tool in response.tool_outputs
+            tool.get("name") in deepwiki_tools for tool in response.tool_outputs
         )
         assert tool_used

--- a/tests/test_mcp_chat_async.py
+++ b/tests/test_mcp_chat_async.py
@@ -7,15 +7,6 @@ from defog.llm.utils import chat_async
 from defog.llm.llm_providers import LLMProvider
 
 
-# Paths to arithmetic server scripts
-SSE_SERVER_SCRIPT = os.path.join(
-    os.path.dirname(__file__), "mcp", "mcp_arithmetic_sse.py"
-)
-STDIO_SERVER_SCRIPT = os.path.join(
-    os.path.dirname(__file__), "mcp", "mcp_arithmetic_stdio.py"
-)
-
-
 @pytest.fixture
 def event_loop():
     """Create an event loop for the test session"""
@@ -32,21 +23,6 @@ def deepwiki_mcp_server():
     """
     # Return the MCP server configuration for DeepWiki
     yield [{"type": "url", "url": "https://mcp.deepwiki.com/sse", "name": "deepwiki"}]
-
-
-@pytest.fixture(scope="function")
-def arithmetic_stdio_server():
-    """Create a config for an arithmetic stdio server for testing"""
-    # Skip if server script doesn't exist
-    if not os.path.exists(STDIO_SERVER_SCRIPT):
-        pytest.skip(f"stdio server script not found at {STDIO_SERVER_SCRIPT}")
-
-    # Note: For stdio servers, we can't use the direct server config format
-    # because the Anthropic API expects HTTP endpoints for MCP servers
-    # So we'll skip this test for now
-    pytest.skip(
-        "Stdio servers are not supported directly by Anthropic API MCP connector"
-    )
 
 
 class TestMCPChatAsync:

--- a/tests/test_mcp_chat_async.py
+++ b/tests/test_mcp_chat_async.py
@@ -1,0 +1,261 @@
+import os
+import json
+import pytest
+import asyncio
+import subprocess
+import tempfile
+import time
+from typing import Dict, Any
+
+from defog.llm.utils import chat_async
+from defog.llm.llm_providers import LLMProvider
+
+
+# Paths to arithmetic server scripts
+SSE_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp", "mcp_arithmetic_sse.py")
+STDIO_SERVER_SCRIPT = os.path.join(os.path.dirname(__file__), "mcp", "mcp_arithmetic_stdio.py")
+
+
+@pytest.fixture
+def event_loop():
+    """Create an event loop for the test session"""
+    loop = asyncio.get_event_loop_policy().new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="function")
+def deepwiki_mcp_server():
+    """
+    DeepWiki MCP server configuration for testing.
+    Uses the public DeepWiki MCP server which supports HTTPS.
+    """
+    # Return the MCP server configuration for DeepWiki
+    yield [{
+        "type": "url",
+        "url": "https://mcp.deepwiki.com/sse",
+        "name": "deepwiki"
+    }]
+
+
+@pytest.fixture(scope="function")
+def arithmetic_stdio_server():
+    """Create a config for an arithmetic stdio server for testing"""
+    # Skip if server script doesn't exist
+    if not os.path.exists(STDIO_SERVER_SCRIPT):
+        pytest.skip(f"stdio server script not found at {STDIO_SERVER_SCRIPT}")
+
+    # Note: For stdio servers, we can't use the direct server config format
+    # because the Anthropic API expects HTTP endpoints for MCP servers
+    # So we'll skip this test for now
+    pytest.skip("Stdio servers are not supported directly by Anthropic API MCP connector")
+
+
+class TestMCPChatAsync:
+    """Test the chat_async function with MCP servers"""
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY environment variable not set",
+    )
+    async def test_chat_async_without_mcp(self):
+        """Test chat_async without MCP servers"""
+        messages = [
+            {"role": "user", "content": "What is 2 + 2?"}
+        ]
+        
+        response = await chat_async(
+            provider=LLMProvider.ANTHROPIC,
+            model="claude-3-7-sonnet-20250219",
+            messages=messages,
+            temperature=0.0
+        )
+        
+        assert response is not None
+        assert response.content is not None
+        assert isinstance(response.content, str)
+        assert "4" in response.content
+        assert response.model == "claude-3-7-sonnet-20250219"
+        assert response.input_tokens > 0
+        assert response.output_tokens > 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY environment variable not set",
+    )
+    async def test_chat_async_with_mcp_servers(self, deepwiki_mcp_server):
+        """Test chat_async with MCP servers enabled using DeepWiki"""
+        messages = [
+            {"role": "user", "content": "Use the read_wiki_structure tool to get documentation topics for the python/cpython GitHub repository"}
+        ]
+        
+        response = await chat_async(
+            provider=LLMProvider.ANTHROPIC,
+            model="claude-3-7-sonnet-20250219",
+            messages=messages,
+            temperature=0.0,
+            mcp_servers=deepwiki_mcp_server
+        )
+        
+        assert response is not None
+        assert response.content is not None
+        assert isinstance(response.content, str)
+        assert response.model == "claude-3-7-sonnet-20250219"
+        assert response.input_tokens > 0
+        assert response.output_tokens > 0
+        
+        # Check that tool outputs are included
+        assert response.tool_outputs is not None
+        assert len(response.tool_outputs) > 0
+        
+        # Verify the read_wiki_structure tool was used
+        tool_used = False
+        for tool_output in response.tool_outputs:
+            if tool_output.get("name") == "read_wiki_structure":
+                tool_used = True
+                # Should have repository-related argument (repoName or repository)
+                args_str = str(tool_output.get("args", {}))
+                assert "repository" in args_str or "repoName" in args_str
+        
+        assert tool_used, "read_wiki_structure tool was not used"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY environment variable not set",
+    )
+    async def test_chat_async_with_multiple_tool_calls(self, deepwiki_mcp_server):
+        """Test chat_async with multiple MCP tool calls using DeepWiki"""
+        messages = [
+            {"role": "user", "content": "First use read_wiki_structure to get the structure of the Python repository, then use ask_question to ask about Python's installation process"}
+        ]
+        
+        response = await chat_async(
+            provider=LLMProvider.ANTHROPIC,
+            model="claude-3-7-sonnet-20250219",
+            messages=messages,
+            temperature=0.0,
+            mcp_servers=deepwiki_mcp_server
+        )
+        
+        assert response is not None
+        assert response.content is not None
+        assert isinstance(response.content, str)
+        
+        # Check that multiple tools were used
+        assert response.tool_outputs is not None
+        assert len(response.tool_outputs) >= 1  # At least one tool should be used
+        
+        # Verify DeepWiki tools were used
+        tools_used = set()
+        for tool_output in response.tool_outputs:
+            tools_used.add(tool_output.get("name"))
+        
+        # Should use at least one DeepWiki tool
+        deepwiki_tools = {"read_wiki_structure", "read_wiki_contents", "ask_question"}
+        assert len(tools_used.intersection(deepwiki_tools)) > 0
+
+    @pytest.mark.asyncio
+    async def test_chat_async_mcp_with_non_anthropic_provider(self):
+        """Test that MCP servers are ignored for non-Anthropic providers"""
+        messages = [
+            {"role": "user", "content": "What is 2 + 2?"}
+        ]
+        
+        # Mock MCP servers config
+        mcp_servers = [{
+            "type": "url",
+            "url": "http://localhost:8001/sse",
+            "name": "test_server"
+        }]
+        
+        # This should work without errors even though OpenAI doesn't support MCP
+        # (assuming OpenAI API key is available)
+        if os.environ.get("OPENAI_API_KEY"):
+            response = await chat_async(
+                provider=LLMProvider.OPENAI,
+                model="gpt-3.5-turbo",
+                messages=messages,
+                temperature=0.0,
+                mcp_servers=mcp_servers  # This should be ignored
+            )
+            
+            assert response is not None
+            assert response.content is not None
+            assert "4" in response.content
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY environment variable not set",
+    )
+    async def test_chat_async_mcp_with_system_message(self, deepwiki_mcp_server):
+        """Test chat_async with MCP servers and a system message"""
+        messages = [
+            {"role": "system", "content": "You are a helpful documentation assistant. Always use the available tools to lookup information about repositories."},
+            {"role": "user", "content": "Look up information about the defog/introspect repository structure"}
+        ]
+        
+        response = await chat_async(
+            provider=LLMProvider.ANTHROPIC,
+            model="claude-3-7-sonnet-20250219",
+            messages=messages,
+            temperature=0.0,
+            mcp_servers=deepwiki_mcp_server
+        )
+        
+        assert response is not None
+        assert response.content is not None
+        assert isinstance(response.content, str)
+        
+        # Verify a DeepWiki tool was used
+        assert response.tool_outputs is not None
+        deepwiki_tools = {"read_wiki_structure", "read_wiki_contents", "ask_question"}
+        tool_used = any(
+            tool.get("name") in deepwiki_tools
+            for tool in response.tool_outputs
+        )
+        assert tool_used
+
+    @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        not os.environ.get("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY environment variable not set",
+    )
+    async def test_chat_async_mcp_with_response_format(self, deepwiki_mcp_server):
+        """Test chat_async with MCP servers and response format"""
+        from pydantic import BaseModel
+        
+        class RepositoryInfo(BaseModel):
+            repository_name: str
+            has_documentation: bool
+            
+        messages = [
+            {"role": "user", "content": "Look up information about the defog/introspect repository and return details in the specified format"}
+        ]
+        
+        response = await chat_async(
+            provider=LLMProvider.ANTHROPIC,
+            model="claude-3-7-sonnet-20250219",
+            messages=messages,
+            temperature=0.0,
+            mcp_servers=deepwiki_mcp_server,
+            response_format=RepositoryInfo
+        )
+        
+        assert response is not None
+        assert response.content is not None
+        assert isinstance(response.content, RepositoryInfo)
+        assert isinstance(response.content.repository_name, str)
+        assert isinstance(response.content.has_documentation, bool)
+        
+        # Verify a DeepWiki tool was used
+        assert response.tool_outputs is not None
+        deepwiki_tools = {"read_wiki_structure", "read_wiki_contents", "ask_question"}
+        tool_used = any(
+            tool.get("name") in deepwiki_tools
+            for tool in response.tool_outputs
+        )
+        assert tool_used

--- a/tests/test_mcp_chat_async.py
+++ b/tests/test_mcp_chat_async.py
@@ -1,10 +1,6 @@
 import os
-import json
 import pytest
 import asyncio
-import subprocess
-import tempfile
-import time
 from typing import Dict, Any
 
 from defog.llm.utils import chat_async


### PR DESCRIPTION
## Summary
This PR adds support for Model Context Protocol (MCP) to the Anthropic provider, enabling integration with external MCP servers for enhanced AI capabilities.

**Important note**: This works only with external MCP servers that publicly exposed and are on HTTPS. It doesn't work for local and HTTP servers. This is an limitation of the Anthropic SDK.

## Key Features
- **MCP Server Integration**: Connect to external MCP servers (HTTPS required)
- **Tool Execution**: Automatic execution of MCP tools by Anthropic's API
- **Mixed Tool Support**: Handle both local tools and MCP tools in the same conversation
- **Proper Response Handling**: Use `stop_reason` to determine conversation flow
- **Beta API Support**: Seamless switching between regular and beta endpoints

## Technical Implementation
- Added `mcp_servers` parameter to all provider interfaces for consistency
- handle `mcp_tool_use` and `mcp_tool_result` blocks in the Anthropic handler
- Replaced `isinstance` checks with `block.type` property for better reliability
- Implemented proper conversation flow based on `response.stop_reason`
- Added comprehensive test suite using DeepWiki public MCP server

## Test Coverage
- Basic MCP tool calling functionality
- Multiple tool calls in sequence
- System message support with MCP
- Structured response format with MCP
- Graceful handling for non-Anthropic providers

## Example Usage
```python
from defog.llm.utils import chat_async
from defog.llm.llm_providers import LLMProvider

# Configure DeepWiki MCP server
mcp_servers = [{
    "type": "url", 
    "url": "https://mcp.deepwiki.com/sse",
    "name": "deepwiki"
}]

response = await chat_async(
    provider=LLMProvider.ANTHROPIC,
    model="claude-3-7-sonnet-20250219", 
    messages=[{"role": "user", "content": "Use read_wiki_structure to get the CPython repo info"}],
    mcp_servers=mcp_servers
)

# Access tool results
print(f"Tool outputs: {response.tool_outputs}")
```

🤖 Generated with [Claude Code](https://claude.ai/code)