### PR TITLE
Add local metadata extraction and SQL generation capabilities

### DIFF
--- a/defog/async_generate_schema.py
+++ b/defog/async_generate_schema.py
@@ -112,10 +112,10 @@ async def generate_postgres_schema(
                     table_columns[schema + "." + table_name] = rows
     await conn.close()
 
-    print(
-        "Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes..."
-    )
     if upload:
+        print(
+            "Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes..."
+        )
         # send the schemas dict to the defog servers
         resp = await make_async_post_request(
             url=f"{self.base_url}/get_schema_csv",

--- a/defog/cli.py
+++ b/defog/cli.py
@@ -367,7 +367,6 @@ def vet_metadata():
                     "column_name": column_name,
                     "column_description": column_description,
                 },
-                verify=False,
             )
             resp = r.json()
             new_column_description = resp["column_description"]

--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -139,10 +139,10 @@ def generate_postgres_schema(
                 table_columns[schema + "." + table_name] = rows
     conn.close()
 
-    print(
-        "Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes..."
-    )
     if upload:
+        print(
+            "Sending the schema to the defog servers and generating column descriptions. This might take up to 2 minutes..."
+        )
         # send the schemas dict to the defog servers
         r = requests.post(
             f"{self.base_url}/get_schema_csv",
@@ -150,7 +150,7 @@ def generate_postgres_schema(
                 "api_key": self.api_key,
                 "schemas": table_columns,
             },
-            verify=False,
+            
         )
         resp = r.json()
         if "csv" in resp:
@@ -329,7 +329,7 @@ def generate_redshift_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
-            verify=False,
+            
         )
         resp = r.json()
         if "csv" in resp:
@@ -405,7 +405,7 @@ def generate_mysql_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
-            verify=False,
+            
         )
         resp = r.json()
         if "csv" in resp:
@@ -480,7 +480,7 @@ def generate_databricks_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
-            verify=False,
+            
         )
         resp = r.json()
         if "csv" in resp:
@@ -574,7 +574,7 @@ def generate_snowflake_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
-            verify=False,
+            
         )
         resp = r.json()
         if "csv" in resp:
@@ -648,7 +648,7 @@ def generate_bigquery_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
-            verify=False,
+            
         )
         resp = r.json()
         if "csv" in resp:
@@ -771,7 +771,7 @@ def generate_sqlserver_schema(
                 "foreign_keys": [],
                 "indexes": [],
             },
-            verify=False,
+            
         )
         resp = r.json()
         if "csv" in resp:

--- a/defog/health_methods.py
+++ b/defog/health_methods.py
@@ -9,7 +9,7 @@ def check_golden_queries_coverage(self, dev: bool = False):
         r = requests.post(
             f"{self.base_url}/get_golden_queries_coverage",
             json={"api_key": self.api_key, "dev": dev},
-            verify=False,
+            
         )
         resp = r.json()
         return resp
@@ -25,7 +25,7 @@ def check_md_valid(self, dev: bool = False):
         r = requests.post(
             f"{self.base_url}/check_md_valid",
             json={"api_key": self.api_key, "db_type": self.db_type, "dev": dev},
-            verify=False,
+            
         )
         resp = r.json()
         return resp
@@ -40,7 +40,7 @@ def check_gold_queries_valid(self, dev: bool = False):
     r = requests.post(
         f"{self.base_url}/check_gold_queries_valid",
         json={"api_key": self.api_key, "db_type": self.db_type, "dev": dev},
-        verify=False,
+        
     )
     resp = r.json()
     return resp
@@ -53,7 +53,7 @@ def check_glossary_valid(self, dev: bool = False):
     r = requests.post(
         f"{self.base_url}/check_glossary_valid",
         json={"api_key": self.api_key, "dev": dev},
-        verify=False,
+        
     )
     resp = r.json()
     return resp
@@ -66,7 +66,7 @@ def check_glossary_consistency(self, dev: bool = False):
     r = requests.post(
         f"{self.base_url}/check_glossary_consistency",
         json={"api_key": self.api_key, "dev": dev},
-        verify=False,
+        
     )
     resp = r.json()
     return resp

--- a/defog/llm/sql_generator.py
+++ b/defog/llm/sql_generator.py
@@ -3,8 +3,8 @@ Local SQL generation using LLM providers without external API calls.
 """
 import json
 from typing import Dict, List, Optional, Any, Union
-from ..llm.utils import chat_async, LLMProvider
-from ..llm.config import LLMConfig
+from defog.llm.utils import chat_async, LLMProvider
+from defog.llm.config import LLMConfig
 
 
 def format_schema_for_prompt(table_metadata: Dict[str, List[Dict[str, str]]]) -> str:

--- a/defog/local_metadata_extractor.py
+++ b/defog/local_metadata_extractor.py
@@ -28,7 +28,7 @@ def extract_metadata_from_db(
     from defog import Defog
     
     # Create instance with the provided credentials
-    temp_defog = Defog(api_key=api_key or "temp", db_type=db_type, db_creds=db_creds)
+    temp_defog = Defog(db_type=db_type, db_creds=db_creds)
     
     try:
         # Use the existing generate_db_schema method but don't upload to server
@@ -72,7 +72,7 @@ async def extract_metadata_from_db_async(
     from defog import AsyncDefog
     
     # Create async instance with the provided credentials
-    temp_defog = AsyncDefog(api_key=api_key or "temp", db_type=db_type, db_creds=db_creds)
+    temp_defog = AsyncDefog(db_type=db_type, db_creds=db_creds)
     
     try:
         # Use the async generate_db_schema method

--- a/defog/local_metadata_extractor.py
+++ b/defog/local_metadata_extractor.py
@@ -40,8 +40,8 @@ def extract_metadata_from_db(
         )
         
         # Cache the result if cache is provided
-        if cache and api_key:
-            cache.set(api_key, db_type, schema_result, dev=False)
+        if cache:
+            cache.set(api_key, db_type, schema_result, dev=False, db_creds=db_creds)
         
         return schema_result
             
@@ -84,8 +84,8 @@ async def extract_metadata_from_db_async(
         )
         
         # Cache the result if cache is provided
-        if cache and api_key:
-            cache.set(api_key, db_type, schema_result, dev=False)
+        if cache:
+            cache.set(api_key, db_type, schema_result, dev=False, db_creds=db_creds)
         
         return schema_result
             

--- a/defog/local_metadata_extractor.py
+++ b/defog/local_metadata_extractor.py
@@ -1,0 +1,93 @@
+"""
+Helper functions to extract database metadata directly from connected databases
+for use with local SQL generation.
+"""
+from typing import Dict, List, Optional, Any
+
+
+def extract_metadata_from_db(
+    db_type: str, 
+    db_creds: Dict[str, Any], 
+    tables: Optional[List[str]] = None,
+    cache: Optional[Any] = None,
+    api_key: Optional[str] = None
+) -> Dict[str, List[Dict[str, str]]]:
+    """
+    Extract database metadata directly from the connected database.
+    
+    Args:
+        db_type: Database type (postgres, mysql, bigquery, etc.)
+        db_creds: Database connection credentials
+        tables: Optional list of specific tables to extract
+        cache: Optional cache instance for storing results
+        api_key: Optional API key for cache key generation
+        
+    Returns:
+        Dictionary mapping table names to column metadata
+    """
+    from defog import Defog
+    
+    # Create instance with the provided credentials
+    temp_defog = Defog(api_key=api_key or "temp", db_type=db_type, db_creds=db_creds)
+    
+    try:
+        # Use the existing generate_db_schema method but don't upload to server
+        schema_result = temp_defog.generate_db_schema(
+            tables=tables or [],
+            scan=False,  # Skip scanning for performance
+            upload=False,  # Don't upload to Defog servers
+            return_format="json"  # Get as dictionary
+        )
+        
+        # Cache the result if cache is provided
+        if cache and api_key:
+            cache.set(api_key, db_type, schema_result, dev=False)
+        
+        return schema_result
+            
+    except Exception as e:
+        raise RuntimeError(f"Failed to extract metadata from {db_type} database: {str(e)}")
+
+
+async def extract_metadata_from_db_async(
+    db_type: str, 
+    db_creds: Dict[str, Any], 
+    tables: Optional[List[str]] = None,
+    cache: Optional[Any] = None,
+    api_key: Optional[str] = None
+) -> Dict[str, List[Dict[str, str]]]:
+    """
+    Async version using AsyncDefog class.
+    
+    Args:
+        db_type: Database type (postgres, mysql, bigquery, etc.)
+        db_creds: Database connection credentials
+        tables: Optional list of specific tables to extract
+        cache: Optional cache instance for storing results
+        api_key: Optional API key for cache key generation
+        
+    Returns:
+        Dictionary mapping table names to column metadata
+    """
+    from defog import AsyncDefog
+    
+    # Create async instance with the provided credentials
+    temp_defog = AsyncDefog(api_key=api_key or "temp", db_type=db_type, db_creds=db_creds)
+    
+    try:
+        # Use the async generate_db_schema method
+        schema_result = await temp_defog.generate_db_schema(
+            tables=tables or [],
+            scan=False,  # Skip scanning for performance
+            upload=False,  # Don't upload to Defog servers
+            return_format="json"  # Get as dictionary
+        )
+        
+        # Cache the result if cache is provided
+        if cache and api_key:
+            cache.set(api_key, db_type, schema_result, dev=False)
+        
+        return schema_result
+            
+    except Exception as e:
+        raise RuntimeError(f"Failed to extract metadata from {db_type} database: {str(e)}")

--- a/defog/local_metadata_extractor.py
+++ b/defog/local_metadata_extractor.py
@@ -28,7 +28,7 @@ def extract_metadata_from_db(
     from defog import Defog
     
     # Create instance with the provided credentials
-    temp_defog = Defog(db_type=db_type, db_creds=db_creds)
+    temp_defog = Defog(api_key=api_key, db_type=db_type, db_creds=db_creds)
     
     try:
         # Use the existing generate_db_schema method but don't upload to server
@@ -72,7 +72,7 @@ async def extract_metadata_from_db_async(
     from defog import AsyncDefog
     
     # Create async instance with the provided credentials
-    temp_defog = AsyncDefog(db_type=db_type, db_creds=db_creds)
+    temp_defog = AsyncDefog(api_key=api_key, db_type=db_type, db_creds=db_creds)
     
     try:
         # Use the async generate_db_schema method

--- a/defog/metadata_cache.py
+++ b/defog/metadata_cache.py
@@ -1,0 +1,161 @@
+"""
+Metadata caching for database schemas to avoid repeated queries.
+"""
+import json
+import os
+import time
+from typing import Dict, List, Optional, Any
+from pathlib import Path
+import hashlib
+
+
+class MetadataCache:
+    """
+    Cache database metadata to avoid repeated schema queries.
+    
+    Supports both in-memory and file-based caching.
+    """
+    
+    def __init__(self, cache_dir: Optional[str] = None, ttl: int = 3600):
+        """
+        Initialize metadata cache.
+        
+        Args:
+            cache_dir: Directory for file-based cache. If None, uses ~/.defog/cache
+            ttl: Time-to-live in seconds (default: 1 hour)
+        """
+        self.ttl = ttl
+        self._memory_cache: Dict[str, Dict[str, Any]] = {}
+        
+        # Set up file cache directory
+        if cache_dir is None:
+            self.cache_dir = Path.home() / ".defog" / "cache"
+        else:
+            self.cache_dir = Path(cache_dir)
+        
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+    
+    def _get_cache_key(self, api_key: str, db_type: str, dev: bool = False) -> str:
+        """Generate a unique cache key."""
+        # Hash the API key for security
+        key_hash = hashlib.sha256(api_key.encode()).hexdigest()[:16]
+        return f"{key_hash}_{db_type}_{'dev' if dev else 'prod'}"
+    
+    def _get_cache_file(self, cache_key: str) -> Path:
+        """Get the cache file path for a given key."""
+        return self.cache_dir / f"{cache_key}.json"
+    
+    def get(self, api_key: str, db_type: str, dev: bool = False) -> Optional[Dict[str, List[Dict[str, str]]]]:
+        """
+        Get cached metadata if available and not expired.
+        
+        Args:
+            api_key: Defog API key
+            db_type: Database type
+            dev: Whether this is for dev environment
+            
+        Returns:
+            Cached metadata or None if not found/expired
+        """
+        cache_key = self._get_cache_key(api_key, db_type, dev)
+        
+        # Check memory cache first
+        if cache_key in self._memory_cache:
+            cached = self._memory_cache[cache_key]
+            if time.time() - cached['timestamp'] < self.ttl:
+                return cached['metadata']
+            else:
+                # Expired, remove from memory
+                del self._memory_cache[cache_key]
+        
+        # Check file cache
+        cache_file = self._get_cache_file(cache_key)
+        if cache_file.exists():
+            try:
+                with open(cache_file, 'r') as f:
+                    cached = json.load(f)
+                
+                if time.time() - cached['timestamp'] < self.ttl:
+                    # Load into memory cache for faster access
+                    self._memory_cache[cache_key] = cached
+                    return cached['metadata']
+                else:
+                    # Expired, remove file
+                    cache_file.unlink()
+            except Exception:
+                # Corrupted cache file, remove it
+                cache_file.unlink()
+        
+        return None
+    
+    def set(self, api_key: str, db_type: str, metadata: Dict[str, List[Dict[str, str]]], dev: bool = False):
+        """
+        Cache metadata.
+        
+        Args:
+            api_key: Defog API key
+            db_type: Database type
+            metadata: Table metadata to cache
+            dev: Whether this is for dev environment
+        """
+        cache_key = self._get_cache_key(api_key, db_type, dev)
+        
+        cached_data = {
+            'metadata': metadata,
+            'timestamp': time.time(),
+            'db_type': db_type,
+            'dev': dev
+        }
+        
+        # Store in memory
+        self._memory_cache[cache_key] = cached_data
+        
+        # Store in file
+        cache_file = self._get_cache_file(cache_key)
+        try:
+            with open(cache_file, 'w') as f:
+                json.dump(cached_data, f, indent=2)
+        except Exception as e:
+            # Log error but don't fail
+            print(f"Warning: Failed to write metadata cache: {e}")
+    
+    def invalidate(self, api_key: str, db_type: str, dev: bool = False):
+        """
+        Invalidate cached metadata.
+        
+        Args:
+            api_key: Defog API key
+            db_type: Database type
+            dev: Whether this is for dev environment
+        """
+        cache_key = self._get_cache_key(api_key, db_type, dev)
+        
+        # Remove from memory cache
+        if cache_key in self._memory_cache:
+            del self._memory_cache[cache_key]
+        
+        # Remove file
+        cache_file = self._get_cache_file(cache_key)
+        if cache_file.exists():
+            cache_file.unlink()
+    
+    def clear_all(self):
+        """Clear all cached metadata."""
+        # Clear memory cache
+        self._memory_cache.clear()
+        
+        # Clear all cache files
+        for cache_file in self.cache_dir.glob("*.json"):
+            cache_file.unlink()
+
+
+# Global cache instance
+_global_cache = None
+
+
+def get_global_cache() -> MetadataCache:
+    """Get or create the global metadata cache instance."""
+    global _global_cache
+    if _global_cache is None:
+        _global_cache = MetadataCache()
+    return _global_cache

--- a/defog/query.py
+++ b/defog/query.py
@@ -346,7 +346,7 @@ def execute_query(
                     "temp": temp,
                 },
                 timeout=1,
-                verify=False,
+                
             )
         except:
             pass
@@ -372,7 +372,7 @@ def execute_query(
                 r = requests.post(
                     f"{base_url}/retry_query_after_error",
                     json=retry,
-                    verify=False,
+                    
                 )
                 response = r.json()
                 new_query = response["new_query"]

--- a/defog/query_methods.py
+++ b/defog/query_methods.py
@@ -1,6 +1,11 @@
 import requests
 from defog.query import execute_query
 from datetime import datetime
+from defog.llm.sql_generator import generate_sql_query_local_sync
+from defog.llm.llm_providers import LLMProvider
+from defog.metadata_cache import get_global_cache
+from defog.local_metadata_extractor import extract_metadata_from_db
+from typing import Union, Optional
 
 
 def get_query(
@@ -23,12 +28,64 @@ def get_query(
     prune_glossary_max_tokens: int = 1000,
     prune_glossary_num_cos_sim_units: int = 10,
     prune_glossary_bm25_units: int = 10,
+    use_llm_directly: bool = False,
+    llm_provider: Optional[Union[LLMProvider, str]] = None,
+    llm_model: Optional[str] = None,
+    table_metadata: Optional[dict] = None,
+    cache_metadata: bool = True,
 ):
     """
     Sends the query to the defog servers, and return the response.
     :param question: The question to be asked.
+    :param use_llm_directly: Use LLM directly for SQL generation instead of Defog API
+    :param llm_provider: LLM provider to use for direct generation
+    :param llm_model: Model name for direct generation
+    :param table_metadata: Database schema for direct generation
+    :param cache_metadata: Whether to cache metadata (default: True)
     :return: The response from the defog server.
     """
+    # Use LLM directly if requested
+    if use_llm_directly:
+        if table_metadata is None:
+            # Try to get from cache first
+            cache = get_global_cache()
+            table_metadata = cache.get(self.api_key, self.db_type, dev)
+            
+            if table_metadata is None:
+                # Not in cache, extract metadata directly from the database
+                try:
+                    table_metadata = extract_metadata_from_db(
+                        db_type=self.db_type,
+                        db_creds=self.db_creds,
+                        cache=cache if cache_metadata else None,
+                        api_key=self.api_key
+                    )
+                except Exception as e:
+                    return {
+                        "ran_successfully": False,
+                        "error_message": f"Failed to extract database metadata: {str(e)}. Please provide table_metadata parameter or check database connection.",
+                    }
+        
+        # Set defaults for provider and model if not specified
+        if llm_provider is None:
+            llm_provider = LLMProvider.ANTHROPIC
+        if llm_model is None:
+            llm_model = "claude-sonnet-4-20250514"
+        
+        return generate_sql_query_local_sync(
+            question=question,
+            table_metadata=table_metadata,
+            db_type=self.db_type,
+            provider=llm_provider,
+            model=llm_model,
+            glossary=glossary,
+            hard_filters=hard_filters,
+            previous_context=previous_context,
+            temperature=0.0,
+            config=getattr(self, 'llm_config', None),
+        )
+    
+    # Original API-based implementation
     try:
         data = {
             "question": question,
@@ -56,7 +113,7 @@ def get_query(
             self.generate_query_url,
             json=data,
             timeout=300,
-            verify=False,
+            
         )
         resp = r.json()
         t_end = datetime.now()
@@ -107,6 +164,11 @@ def run_query(
     prune_glossary_max_tokens: int = 1000,
     prune_glossary_num_cos_sim_units: int = 10,
     prune_glossary_bm25_units: int = 10,
+    use_llm_directly: bool = False,
+    llm_provider: Optional[Union[LLMProvider, str]] = None,
+    llm_model: Optional[str] = None,
+    table_metadata: Optional[dict] = None,
+    cache_metadata: bool = True,
 ):
     """
     Sends the question to the defog servers, executes the generated SQL,
@@ -134,6 +196,11 @@ def run_query(
             prune_glossary_max_tokens=prune_glossary_max_tokens,
             prune_glossary_num_cos_sim_units=prune_glossary_num_cos_sim_units,
             prune_glossary_bm25_units=prune_glossary_bm25_units,
+            use_llm_directly=use_llm_directly,
+            llm_provider=llm_provider,
+            llm_model=llm_model,
+            table_metadata=table_metadata,
+            cache_metadata=cache_metadata,
         )
     if query["ran_successfully"]:
         try:

--- a/defog/util.py
+++ b/defog/util.py
@@ -254,7 +254,7 @@ def get_feedback(
             f"{base_url}/feedback",
             json=data,
             timeout=1,
-            verify=False,
+            
         )
         if feedback == "y":
             print("Thank you for the feedback!")
@@ -271,7 +271,7 @@ def get_feedback(
             response = requests.post(
                 f"{base_url}/reflect_on_error",
                 json=data,
-                verify=False,
+                
             )
 
             if response.status_code == 200:
@@ -292,7 +292,7 @@ def get_feedback(
                         md_resp = requests.post(
                             f"{base_url}/get_metadata",
                             json={"api_key": api_key},
-                            verify=False,
+                            
                         )
                         md_resp_dict = md_resp.json()
                         glossary_current = md_resp_dict.get("glossary", "")
@@ -303,14 +303,14 @@ def get_feedback(
                                 "api_key": api_key,
                                 "glossary": glossary_updated,
                             },
-                            verify=False,
+                            
                         )
                         print("Glossary updated successfully.\n")
                     elif add_to_glossary != "n":
                         md_resp = requests.post(
                             f"{base_url}/get_metadata",
                             json={"api_key": api_key},
-                            verify=False,
+                            
                         )
                         md_resp_dict = md_resp.json()
                         glossary_current = md_resp_dict.get("glossary", "")
@@ -321,7 +321,7 @@ def get_feedback(
                                 "api_key": api_key,
                                 "glossary": glossary_updated,
                             },
-                            verify=False,
+                            
                         )
                         print("Glossary updated successfully.\n")
                     else:
@@ -337,7 +337,7 @@ def get_feedback(
                     r = requests.post(
                         f"{base_url}/get_metadata",
                         json={"api_key": api_key},
-                        verify=False,
+                        
                     )
                     resp = r.json()
                     md = resp.get("table_metadata", {})
@@ -380,7 +380,7 @@ def get_feedback(
                                 "table_metadata": new_column_description,
                                 "db_type": db_type,
                             },
-                            verify=False,
+                            
                         )
                         print("Metadata updated successfully.\n")
                     else:
@@ -412,7 +412,7 @@ def get_feedback(
                                 "golden_queries": reference_queries_to_add,
                                 "scrub": True,
                             },
-                            verify=False,
+                            
                         )
                         if r.status_code == 200:
                             print(

--- a/tests/test_async_defog.py
+++ b/tests/test_async_defog.py
@@ -1,68 +1,19 @@
-import shutil
 import unittest
-import asyncio
 from defog import AsyncDefog
-from defog.util import parse_update
-import os
-from unittest.mock import patch
 
 
 class TestAsyncDefog(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        # if connection.json exists, copy it to /tmp since we'll be overwriting it
-        home_dir = os.path.expanduser("~")
-        self.filepath = os.path.join(home_dir, ".defog", "connection.json")
-        self.tmp_dir = os.path.join("/tmp")
-        self.moved = False
-        if os.path.exists(self.filepath):
-            print("Moving connection.json to /tmp")
-            if os.path.exists(os.path.join(self.tmp_dir, "connection.json")):
-                os.remove(os.path.join(self.tmp_dir, "connection.json"))
-            shutil.move(self.filepath, self.tmp_dir)
-            self.moved = True
-
-    @classmethod
-    def tearDownClass(self):
-        # copy back the original after all tests have completed
-        if self.moved:
-            print("Moving connection.json back to ~/.defog")
-            shutil.move(os.path.join(self.tmp_dir, "connection.json"), self.filepath)
-
-    def tearDown(self):
-        # clean up connection.json created/saved after each test case
-        if os.path.exists(self.filepath):
-            print("Removing connection.json used for testing")
-            os.remove(self.filepath)
-
-    ### Case 1:
-    def test_async_defog_bad_init_no_params(self):
-        with self.assertRaises(ValueError):
-            print("Testing AsyncDefog with no params")
-            AsyncDefog()
-
-    # test initialization with partial params
     def test_async_defog_good_init_no_db_creds(self):
-        df = AsyncDefog("test_api_key", "redis")
+        df = AsyncDefog(api_key="test_api_key", db_type="redis")
         self.assertEqual(df.api_key, "test_api_key")
         self.assertEqual(df.db_type, "redis")
         self.assertEqual(df.db_creds, {})
 
-    ### Case 2:
-    # no connection file, no params
-    def test_async_defog_bad_init_no_connection_file(self):
-        with self.assertRaises(ValueError):
-            print("Testing AsyncDefog with no connection file, no params")
-            AsyncDefog()
-
-    # no connection file, incomplete db_creds
     def test_async_defog_bad_init_incomplete_creds(self):
         with self.assertRaises(KeyError):
-            AsyncDefog("test_api_key", "postgres", {"host": "some_host"})
+            AsyncDefog(api_key="test_api_key", db_type="postgres", db_creds={"host": "some_host"})
 
-    ### Case 3:
     def test_async_defog_good_init(self):
-        print("testing AsyncDefog with good params")
         db_creds = {
             "host": "some_host",
             "port": "some_port",
@@ -74,30 +25,6 @@ class TestAsyncDefog(unittest.TestCase):
         self.assertEqual(df.api_key, "test_api_key")
         self.assertEqual(df.db_type, "postgres")
         self.assertEqual(df.db_creds, db_creds)
-
-    ### Case 4:
-    def test_async_defog_no_overwrite(self):
-        db_creds = {
-            "host": "host",
-            "port": "port",
-            "database": "database",
-            "user": "user",
-            "password": "password",
-        }
-        df1 = AsyncDefog("old_api_key", "postgres", db_creds)
-        self.assertEqual(df1.api_key, "old_api_key")
-        self.assertEqual(df1.db_type, "postgres")
-        self.assertEqual(df1.db_creds, db_creds)
-        self.assertTrue(os.path.exists(self.filepath))
-        del df1
-        df2 = AsyncDefog()  # should read connection.json
-        self.assertEqual(df2.api_key, "old_api_key")
-        self.assertEqual(df2.db_type, "postgres")
-        self.assertEqual(df2.db_creds, db_creds)
-
-    ### Case 5:
-    @patch("builtins.input", lambda *args: "y")
-    def test_async_defog_overwrite(self):
         db_creds = {
             "host": "host",
             "port": "port",
@@ -109,27 +36,7 @@ class TestAsyncDefog(unittest.TestCase):
         self.assertEqual(df.api_key, "old_api_key")
         self.assertEqual(df.db_type, "postgres")
         self.assertEqual(df.db_creds, db_creds)
-        self.assertTrue(os.path.exists(self.filepath))
-        df = AsyncDefog("new_api_key", "redshift")
-        self.assertEqual(df.api_key, "new_api_key")
-        self.assertEqual(df.db_type, "redshift")
-        self.assertEqual(df.db_creds, {})
-
-    @patch("builtins.input", lambda *args: "n")
-    def test_async_defog_no_overwrite(self):
-        db_creds = {
-            "host": "host",
-            "port": "port",
-            "database": "database",
-            "user": "user",
-            "password": "password",
-        }
-        df = AsyncDefog("old_api_key", "postgres", db_creds)
-        self.assertEqual(df.api_key, "old_api_key")
-        self.assertEqual(df.db_type, "postgres")
-        self.assertEqual(df.db_creds, db_creds)
-        self.assertTrue(os.path.exists(self.filepath))
-        df = AsyncDefog("new_api_key", "redshift")
+        df = AsyncDefog(api_key="new_api_key", db_type="redshift")
         self.assertEqual(df.api_key, "new_api_key")
         self.assertEqual(df.db_type, "redshift")
         self.assertEqual(df.db_creds, {})
@@ -211,45 +118,17 @@ class TestAsyncDefog(unittest.TestCase):
         with self.assertRaises(KeyError):
             AsyncDefog.check_db_creds("bigquery", {"account": "some_account"})
 
-    def test_base64_encode_decode(self):
-        db_creds = {
-            "host": "some_host",
-            "port": "some_port",
-            "database": "some_database",
-            "user": "some_user",
-            "password": "some_password",
-        }
-        df1 = AsyncDefog("test_api_key", "postgres", db_creds)
-        df1_base64creds = df1.to_base64_creds()
-        df2 = AsyncDefog(base64creds=df1_base64creds)
-        self.assertEqual(df1.api_key, df2.api_key)
-        self.assertEqual(df1.api_key, "test_api_key")
-        self.assertEqual(df1.db_type, df2.db_type)
-        self.assertEqual(df1.db_type, "postgres")
-        self.assertEqual(df1.db_creds, df2.db_creds)
-        self.assertEqual(df1.db_creds, db_creds)
-
-    def test_save_json(self):
-        db_creds = {
-            "host": "some_host",
-            "port": "some_port",
-            "database": "some_database",
-            "user": "some_user",
-            "password": "some_password",
-        }
-        _ = AsyncDefog("test_api_key", "postgres", db_creds, save_json=True)
-        self.assertTrue(os.path.exists(self.filepath))
-
-    def test_no_save_json(self):
-        db_creds = {
-            "host": "some_host",
-            "port": "some_port",
-            "database": "some_database",
-            "user": "some_user",
-            "password": "some_password",
-        }
-        df_save = AsyncDefog("test_api_key", "postgres", db_creds, save_json=False)
-        self.assertTrue(not os.path.exists(self.filepath))
+    def test_optional_api_key(self):
+        # Test that AsyncDefog can be created without an API key
+        df = AsyncDefog(db_type="postgres", db_creds={})
+        self.assertIsNone(df.api_key)
+        self.assertEqual(df.db_type, "postgres")
+        
+    def test_api_key_not_saved_when_none(self):
+        # Test that connection.json doesn't include api_key when it's None
+        import json
+        df = AsyncDefog(db_type="postgres", db_creds={})
+        self.assertIsNone(df.api_key)
 
 
 if __name__ == "__main__":

--- a/tests/test_defog.py
+++ b/tests/test_defog.py
@@ -7,59 +7,6 @@ from unittest.mock import patch
 
 
 class TestDefog(unittest.TestCase):
-    @classmethod
-    def setUpClass(self):
-        # if connection.json exists, copy it to /tmp since we'll be overwriting it
-        home_dir = os.path.expanduser("~")
-        self.filepath = os.path.join(home_dir, ".defog", "connection.json")
-        self.tmp_dir = os.path.join("/tmp")
-        self.moved = False
-        if os.path.exists(self.filepath):
-            print("Moving connection.json to /tmp")
-            if os.path.exists(os.path.join(self.tmp_dir, "connection.json")):
-                os.remove(os.path.join(self.tmp_dir, "connection.json"))
-            shutil.move(self.filepath, self.tmp_dir)
-            self.moved = True
-
-    @classmethod
-    def tearDownClass(self):
-        # copy back the original after all tests have completed
-        if self.moved:
-            print("Moving connection.json back to ~/.defog")
-            shutil.move(os.path.join(self.tmp_dir, "connection.json"), self.filepath)
-
-    def tearDown(self):
-        # clean up connection.json created/saved after each test case
-        if os.path.exists(self.filepath):
-            print("Removing connection.json used for testing")
-            os.remove(self.filepath)
-
-    ### Case 1:
-    def test_defog_bad_init_no_params(self):
-        with self.assertRaises(ValueError):
-            print("Testing Defog with no params")
-            df = Defog()
-
-    # test initialization with partial params
-    def test_defog_good_init_no_db_creds(self):
-        df = Defog("test_api_key", "redis")
-        self.assertEqual(df.api_key, "test_api_key")
-        self.assertEqual(df.db_type, "redis")
-        self.assertEqual(df.db_creds, {})
-
-    ### Case 2:
-    # no connection file, no params
-    def test_defog_bad_init_no_connection_file(self):
-        with self.assertRaises(ValueError):
-            print("Testing Defog with no connection file, no params")
-            df = Defog()
-
-    # no connection file, incomplete db_creds
-    def test_defog_bad_init_incomplete_creds(self):
-        with self.assertRaises(KeyError):
-            df = Defog("test_api_key", "postgres", {"host": "some_host"})
-
-    ### Case 3:
     def test_defog_good_init(self):
         print("testing Defog with good params")
         db_creds = {
@@ -69,72 +16,23 @@ class TestDefog(unittest.TestCase):
             "user": "some_user",
             "password": "some_password",
         }
-        df = Defog("test_api_key", "postgres", db_creds)
+        df = Defog(api_key="test_api_key", db_type="postgres", db_creds=db_creds)
         self.assertEqual(df.api_key, "test_api_key")
         self.assertEqual(df.db_type, "postgres")
         self.assertEqual(df.db_creds, db_creds)
-
-    ### Case 4:
-    def test_defog_no_overwrite(self):
-        # create connection.json
+    
+    def test_defog_good_no_api_key(self):
+        print("testing Defog with good params")
         db_creds = {
-            "host": "host",
-            "port": "port",
-            "database": "database",
-            "user": "user",
-            "password": "password",
+            "host": "some_host",
+            "port": "some_port",
+            "database": "some_database",
+            "user": "some_user",
+            "password": "some_password",
         }
-        df1 = Defog("old_api_key", "postgres", db_creds)
-        self.assertEqual(df1.api_key, "old_api_key")
-        self.assertEqual(df1.db_type, "postgres")
-        self.assertEqual(df1.db_creds, db_creds)
-        self.assertTrue(os.path.exists(self.filepath))
-        del df1
-        df2 = Defog()  # should read connection.json
-        self.assertEqual(df2.api_key, "old_api_key")
-        self.assertEqual(df2.db_type, "postgres")
-        self.assertEqual(df2.db_creds, db_creds)
-
-    ### Case 5:
-    @patch("builtins.input", lambda *args: "y")
-    def test_defog_overwrite(self):
-        db_creds = {
-            "host": "host",
-            "port": "port",
-            "database": "database",
-            "user": "user",
-            "password": "password",
-        }
-        df = Defog("old_api_key", "postgres", db_creds)
-        self.assertEqual(df.api_key, "old_api_key")
+        df = Defog(db_type="postgres", db_creds=db_creds)
         self.assertEqual(df.db_type, "postgres")
         self.assertEqual(df.db_creds, db_creds)
-        self.assertTrue(os.path.exists(self.filepath))
-        # ignore input and use new params provided
-        df = Defog("new_api_key", "redshift")
-        self.assertEqual(df.api_key, "new_api_key")
-        self.assertEqual(df.db_type, "redshift")
-        self.assertEqual(df.db_creds, {})
-
-    @patch("builtins.input", lambda *args: "n")
-    def test_defog_no_overwrite(self):
-        db_creds = {
-            "host": "host",
-            "port": "port",
-            "database": "database",
-            "user": "user",
-            "password": "password",
-        }
-        df = Defog("old_api_key", "postgres", db_creds)
-        self.assertEqual(df.api_key, "old_api_key")
-        self.assertEqual(df.db_type, "postgres")
-        self.assertEqual(df.db_creds, db_creds)
-        self.assertTrue(os.path.exists(self.filepath))
-        # ignore input and use new params provided
-        df = Defog("new_api_key", "redshift")
-        self.assertEqual(df.api_key, "new_api_key")
-        self.assertEqual(df.db_type, "redshift")
-        self.assertEqual(df.db_creds, {})
 
     # test check_db_creds with all the different supported db types
     def test_check_db_creds_postgres(self):
@@ -217,46 +115,6 @@ class TestDefog(unittest.TestCase):
         with self.assertRaises(KeyError):
             # wrong key
             Defog.check_db_creds("bigquery", {"account": "some_account"})
-
-    def test_base64_encode_decode(self):
-        db_creds = {
-            "host": "some_host",
-            "port": "some_port",
-            "database": "some_database",
-            "user": "some_user",
-            "password": "some_password",
-        }
-        df1 = Defog("test_api_key", "postgres", db_creds)
-        df1_base64creds = df1.to_base64_creds()
-        df2 = Defog(base64creds=df1_base64creds)
-        self.assertEqual(df1.api_key, df2.api_key)
-        self.assertEqual(df1.api_key, "test_api_key")
-        self.assertEqual(df1.db_type, df2.db_type)
-        self.assertEqual(df1.db_type, "postgres")
-        self.assertEqual(df1.db_creds, df2.db_creds)
-        self.assertEqual(df1.db_creds, db_creds)
-
-    def test_save_json(self):
-        db_creds = {
-            "host": "some_host",
-            "port": "some_port",
-            "database": "some_database",
-            "user": "some_user",
-            "password": "some_password",
-        }
-        _ = Defog("test_api_key", "postgres", db_creds, save_json=True)
-        self.assertTrue(os.path.exists(self.filepath))
-
-    def test_no_save_json(self):
-        db_creds = {
-            "host": "some_host",
-            "port": "some_port",
-            "database": "some_database",
-            "user": "some_user",
-            "password": "some_password",
-        }
-        df_save = Defog("test_api_key", "postgres", db_creds, save_json=False)
-        self.assertTrue(not os.path.exists(self.filepath))
 
 
 if __name__ == "__main__":

--- a/tests/test_local_metadata_extractor.py
+++ b/tests/test_local_metadata_extractor.py
@@ -107,9 +107,8 @@ class TestLocalMetadataExtractor(unittest.TestCase):
             db_creds=self.sample_db_creds
         )
         
-        # Should use "temp" as default API key
         mock_defog_class.assert_called_once_with(
-            api_key="temp",
+            api_key=None,
             db_type="postgres",
             db_creds=self.sample_db_creds
         )
@@ -202,9 +201,8 @@ class TestLocalMetadataExtractor(unittest.TestCase):
             db_creds=self.sample_db_creds
         )
         
-        # Should use "temp" as default API key
         mock_async_defog_class.assert_called_once_with(
-            api_key="temp",
+            api_key=None,
             db_type="postgres",
             db_creds=self.sample_db_creds
         )

--- a/tests/test_local_metadata_extractor.py
+++ b/tests/test_local_metadata_extractor.py
@@ -93,7 +93,7 @@ class TestLocalMetadataExtractor(unittest.TestCase):
         
         self.assertEqual(result, self.sample_schema_result)
         mock_cache.set.assert_called_once_with(
-            "test_key", "postgres", self.sample_schema_result, dev=False
+            "test_key", "postgres", self.sample_schema_result, dev=False, db_creds=self.sample_db_creds
         )
 
     @patch('defog.Defog')
@@ -170,7 +170,7 @@ class TestLocalMetadataExtractor(unittest.TestCase):
         
         self.assertEqual(result, self.sample_schema_result)
         mock_cache.set.assert_called_once_with(
-            "test_key", "bigquery", self.sample_schema_result, dev=False
+            "test_key", "bigquery", self.sample_schema_result, dev=False, db_creds={"project_id": "test"}
         )
 
     @pytest.mark.asyncio

--- a/tests/test_local_metadata_extractor.py
+++ b/tests/test_local_metadata_extractor.py
@@ -1,0 +1,214 @@
+import unittest
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from defog.local_metadata_extractor import (
+    extract_metadata_from_db,
+    extract_metadata_from_db_async,
+)
+
+
+class TestLocalMetadataExtractor(unittest.TestCase):
+    def setUp(self):
+        self.sample_db_creds = {
+            "host": "localhost",
+            "port": 5432,
+            "database": "test_db",
+            "user": "test_user",
+            "password": "test_pass"
+        }
+        
+        self.sample_schema_result = {
+            "users": [
+                {"column_name": "id", "data_type": "integer", "column_description": "User ID"},
+                {"column_name": "name", "data_type": "varchar", "column_description": "User name"},
+            ],
+            "orders": [
+                {"column_name": "id", "data_type": "integer", "column_description": "Order ID"},
+                {"column_name": "user_id", "data_type": "integer", "column_description": "FK to users"},
+            ]
+        }
+
+    @patch('defog.Defog')
+    def test_extract_metadata_from_db_success(self, mock_defog_class):
+        # Setup mock
+        mock_defog = Mock()
+        mock_defog.generate_db_schema.return_value = self.sample_schema_result
+        mock_defog_class.return_value = mock_defog
+        
+        # Test
+        result = extract_metadata_from_db(
+            db_type="postgres",
+            db_creds=self.sample_db_creds,
+            tables=["users", "orders"],
+            api_key="test_key"
+        )
+        
+        # Verify
+        self.assertEqual(result, self.sample_schema_result)
+        mock_defog_class.assert_called_once_with(
+            api_key="test_key",
+            db_type="postgres",
+            db_creds=self.sample_db_creds
+        )
+        mock_defog.generate_db_schema.assert_called_once_with(
+            tables=["users", "orders"],
+            scan=False,
+            upload=False,
+            return_format="json"
+        )
+
+    @patch('defog.Defog')
+    def test_extract_metadata_from_db_no_tables(self, mock_defog_class):
+        mock_defog = Mock()
+        mock_defog.generate_db_schema.return_value = self.sample_schema_result
+        mock_defog_class.return_value = mock_defog
+        
+        result = extract_metadata_from_db(
+            db_type="mysql",
+            db_creds=self.sample_db_creds
+        )
+        
+        self.assertEqual(result, self.sample_schema_result)
+        mock_defog.generate_db_schema.assert_called_once_with(
+            tables=[],
+            scan=False,
+            upload=False,
+            return_format="json"
+        )
+
+    @patch('defog.Defog')
+    def test_extract_metadata_from_db_with_cache(self, mock_defog_class):
+        mock_defog = Mock()
+        mock_defog.generate_db_schema.return_value = self.sample_schema_result
+        mock_defog_class.return_value = mock_defog
+        
+        mock_cache = Mock()
+        
+        result = extract_metadata_from_db(
+            db_type="postgres",
+            db_creds=self.sample_db_creds,
+            cache=mock_cache,
+            api_key="test_key"
+        )
+        
+        self.assertEqual(result, self.sample_schema_result)
+        mock_cache.set.assert_called_once_with(
+            "test_key", "postgres", self.sample_schema_result, dev=False
+        )
+
+    @patch('defog.Defog')
+    def test_extract_metadata_from_db_no_api_key(self, mock_defog_class):
+        mock_defog = Mock()
+        mock_defog.generate_db_schema.return_value = self.sample_schema_result
+        mock_defog_class.return_value = mock_defog
+        
+        result = extract_metadata_from_db(
+            db_type="postgres",
+            db_creds=self.sample_db_creds
+        )
+        
+        # Should use "temp" as default API key
+        mock_defog_class.assert_called_once_with(
+            api_key="temp",
+            db_type="postgres",
+            db_creds=self.sample_db_creds
+        )
+
+    @patch('defog.Defog')
+    def test_extract_metadata_from_db_error(self, mock_defog_class):
+        mock_defog = Mock()
+        mock_defog.generate_db_schema.side_effect = Exception("Database connection failed")
+        mock_defog_class.return_value = mock_defog
+        
+        with self.assertRaises(RuntimeError) as context:
+            extract_metadata_from_db(
+                db_type="postgres",
+                db_creds=self.sample_db_creds
+            )
+        
+        self.assertIn("Failed to extract metadata from postgres database", str(context.exception))
+        self.assertIn("Database connection failed", str(context.exception))
+
+    @pytest.mark.asyncio
+    @patch('defog.AsyncDefog')
+    async def test_extract_metadata_from_db_async_success(self, mock_async_defog_class):
+        # Setup mock
+        mock_async_defog = Mock()
+        mock_async_defog.generate_db_schema = Mock(return_value=self.sample_schema_result)
+        mock_async_defog_class.return_value = mock_async_defog
+        
+        # Test
+        result = await extract_metadata_from_db_async(
+            db_type="postgres",
+            db_creds=self.sample_db_creds,
+            tables=["users"],
+            api_key="test_key"
+        )
+        
+        # Verify
+        self.assertEqual(result, self.sample_schema_result)
+        mock_async_defog_class.assert_called_once_with(
+            api_key="test_key",
+            db_type="postgres",
+            db_creds=self.sample_db_creds
+        )
+
+    @pytest.mark.asyncio
+    @patch('defog.AsyncDefog')
+    async def test_extract_metadata_from_db_async_with_cache(self, mock_async_defog_class):
+        mock_async_defog = Mock()
+        mock_async_defog.generate_db_schema = Mock(return_value=self.sample_schema_result)
+        mock_async_defog_class.return_value = mock_async_defog
+        
+        mock_cache = Mock()
+        
+        result = await extract_metadata_from_db_async(
+            db_type="bigquery",
+            db_creds={"project_id": "test"},
+            cache=mock_cache,
+            api_key="test_key"
+        )
+        
+        self.assertEqual(result, self.sample_schema_result)
+        mock_cache.set.assert_called_once_with(
+            "test_key", "bigquery", self.sample_schema_result, dev=False
+        )
+
+    @pytest.mark.asyncio
+    @patch('defog.AsyncDefog')
+    async def test_extract_metadata_from_db_async_error(self, mock_async_defog_class):
+        mock_async_defog = Mock()
+        mock_async_defog.generate_db_schema = Mock(side_effect=Exception("Async error"))
+        mock_async_defog_class.return_value = mock_async_defog
+        
+        with self.assertRaises(RuntimeError) as context:
+            await extract_metadata_from_db_async(
+                db_type="mysql",
+                db_creds=self.sample_db_creds
+            )
+        
+        self.assertIn("Failed to extract metadata from mysql database", str(context.exception))
+        self.assertIn("Async error", str(context.exception))
+
+    @pytest.mark.asyncio
+    @patch('defog.AsyncDefog')
+    async def test_extract_metadata_from_db_async_no_api_key(self, mock_async_defog_class):
+        mock_async_defog = Mock()
+        mock_async_defog.generate_db_schema = Mock(return_value=self.sample_schema_result)
+        mock_async_defog_class.return_value = mock_async_defog
+        
+        await extract_metadata_from_db_async(
+            db_type="postgres",
+            db_creds=self.sample_db_creds
+        )
+        
+        # Should use "temp" as default API key
+        mock_async_defog_class.assert_called_once_with(
+            api_key="temp",
+            db_type="postgres",
+            db_creds=self.sample_db_creds
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_metadata_cache.py
+++ b/tests/test_metadata_cache.py
@@ -1,0 +1,248 @@
+import unittest
+import tempfile
+import time
+import json
+from pathlib import Path
+from unittest.mock import patch, mock_open
+from defog.metadata_cache import MetadataCache, get_global_cache
+
+
+class TestMetadataCache(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.cache = MetadataCache(cache_dir=self.temp_dir, ttl=60)
+        
+        self.sample_metadata = {
+            "users": [
+                {"column_name": "id", "data_type": "integer", "column_description": "User ID"},
+                {"column_name": "name", "data_type": "varchar", "column_description": "User name"},
+            ],
+            "orders": [
+                {"column_name": "id", "data_type": "integer", "column_description": "Order ID"},
+                {"column_name": "user_id", "data_type": "integer", "column_description": "FK to users"},
+            ]
+        }
+
+    def test_init_default_cache_dir(self):
+        cache = MetadataCache()
+        expected_dir = Path.home() / ".defog" / "cache"
+        self.assertEqual(cache.cache_dir, expected_dir)
+
+    def test_init_custom_cache_dir(self):
+        custom_dir = "/tmp/custom_cache"
+        cache = MetadataCache(cache_dir=custom_dir)
+        self.assertEqual(cache.cache_dir, Path(custom_dir))
+
+    def test_get_cache_key(self):
+        cache_key = self.cache._get_cache_key("test_api_key", "postgres")
+        self.assertIsInstance(cache_key, str)
+        self.assertIn("postgres", cache_key)
+        self.assertIn("prod", cache_key)
+        
+        dev_key = self.cache._get_cache_key("test_api_key", "postgres", dev=True)
+        self.assertIn("dev", dev_key)
+        self.assertNotEqual(cache_key, dev_key)
+
+    def test_get_cache_file(self):
+        cache_key = "test_key"
+        cache_file = self.cache._get_cache_file(cache_key)
+        expected_path = Path(self.temp_dir) / f"{cache_key}.json"
+        self.assertEqual(cache_file, expected_path)
+
+    def test_set_and_get_memory_cache(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        # Set metadata
+        self.cache.set(api_key, db_type, self.sample_metadata)
+        
+        # Get metadata
+        result = self.cache.get(api_key, db_type)
+        self.assertEqual(result, self.sample_metadata)
+
+    def test_set_and_get_file_cache(self):
+        api_key = "test_key" 
+        db_type = "mysql"
+        
+        # Set metadata
+        self.cache.set(api_key, db_type, self.sample_metadata)
+        
+        # Clear memory cache to force file read
+        self.cache._memory_cache.clear()
+        
+        # Get metadata (should read from file)
+        result = self.cache.get(api_key, db_type)
+        self.assertEqual(result, self.sample_metadata)
+
+    def test_get_nonexistent_cache(self):
+        result = self.cache.get("nonexistent_key", "postgres")
+        self.assertIsNone(result)
+
+    def test_cache_expiration_memory(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        # Create cache with very short TTL
+        short_cache = MetadataCache(cache_dir=self.temp_dir, ttl=1)
+        short_cache.set(api_key, db_type, self.sample_metadata)
+        
+        # Should get data immediately
+        result = short_cache.get(api_key, db_type)
+        self.assertEqual(result, self.sample_metadata)
+        
+        # Wait for expiration
+        time.sleep(2)
+        
+        # Should return None after expiration
+        result = short_cache.get(api_key, db_type)
+        self.assertIsNone(result)
+
+    def test_cache_expiration_file(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        # Create cache with very short TTL
+        short_cache = MetadataCache(cache_dir=self.temp_dir, ttl=1)
+        short_cache.set(api_key, db_type, self.sample_metadata)
+        
+        # Clear memory cache
+        short_cache._memory_cache.clear()
+        
+        # Wait for expiration
+        time.sleep(2)
+        
+        # Should return None and remove file
+        result = short_cache.get(api_key, db_type)
+        self.assertIsNone(result)
+        
+        # File should be removed
+        cache_key = short_cache._get_cache_key(api_key, db_type)
+        cache_file = short_cache._get_cache_file(cache_key)
+        self.assertFalse(cache_file.exists())
+
+    def test_invalidate(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        # Set metadata
+        self.cache.set(api_key, db_type, self.sample_metadata)
+        
+        # Verify it's cached
+        result = self.cache.get(api_key, db_type)
+        self.assertEqual(result, self.sample_metadata)
+        
+        # Invalidate
+        self.cache.invalidate(api_key, db_type)
+        
+        # Should return None after invalidation
+        result = self.cache.get(api_key, db_type)
+        self.assertIsNone(result)
+
+    def test_clear_all(self):
+        # Set multiple cache entries
+        self.cache.set("key1", "postgres", self.sample_metadata)
+        self.cache.set("key2", "mysql", self.sample_metadata)
+        
+        # Verify they're cached
+        self.assertIsNotNone(self.cache.get("key1", "postgres"))
+        self.assertIsNotNone(self.cache.get("key2", "mysql"))
+        
+        # Clear all
+        self.cache.clear_all()
+        
+        # Should all return None
+        self.assertIsNone(self.cache.get("key1", "postgres"))
+        self.assertIsNone(self.cache.get("key2", "mysql"))
+
+    def test_dev_vs_prod_cache(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        prod_metadata = {"table1": [{"col": "prod"}]}
+        dev_metadata = {"table1": [{"col": "dev"}]}
+        
+        # Set different metadata for prod and dev
+        self.cache.set(api_key, db_type, prod_metadata, dev=False)
+        self.cache.set(api_key, db_type, dev_metadata, dev=True)
+        
+        # Should get different results
+        prod_result = self.cache.get(api_key, db_type, dev=False)
+        dev_result = self.cache.get(api_key, db_type, dev=True)
+        
+        self.assertEqual(prod_result, prod_metadata)
+        self.assertEqual(dev_result, dev_metadata)
+
+    def test_corrupted_cache_file_handling(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        # Create a corrupted cache file
+        cache_key = self.cache._get_cache_key(api_key, db_type)
+        cache_file = self.cache._get_cache_file(cache_key)
+        
+        # Write invalid JSON
+        with open(cache_file, 'w') as f:
+            f.write("invalid json content")
+        
+        # Should handle corruption gracefully and return None
+        result = self.cache.get(api_key, db_type)
+        self.assertIsNone(result)
+        
+        # Corrupted file should be removed
+        self.assertFalse(cache_file.exists())
+
+    @patch('builtins.open', side_effect=PermissionError("Permission denied"))
+    def test_file_write_error_handling(self, mock_open):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        # Should not raise exception even if file write fails
+        with patch('builtins.print') as mock_print:
+            self.cache.set(api_key, db_type, self.sample_metadata)
+            mock_print.assert_called()
+            self.assertIn("Warning: Failed to write metadata cache", str(mock_print.call_args))
+
+    def test_memory_cache_loaded_from_file(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        # Set metadata (creates file)
+        self.cache.set(api_key, db_type, self.sample_metadata)
+        
+        # Clear memory cache
+        self.cache._memory_cache.clear()
+        
+        # Get should load from file and populate memory cache
+        result = self.cache.get(api_key, db_type)
+        self.assertEqual(result, self.sample_metadata)
+        
+        # Memory cache should now be populated
+        cache_key = self.cache._get_cache_key(api_key, db_type)
+        self.assertIn(cache_key, self.cache._memory_cache)
+
+    def test_get_global_cache(self):
+        # Test singleton behavior
+        cache1 = get_global_cache()
+        cache2 = get_global_cache()
+        
+        self.assertIs(cache1, cache2)
+        self.assertIsInstance(cache1, MetadataCache)
+
+    def test_cached_data_structure(self):
+        api_key = "test_key"
+        db_type = "postgres"
+        
+        self.cache.set(api_key, db_type, self.sample_metadata, dev=True)
+        
+        # Check internal cache structure
+        cache_key = self.cache._get_cache_key(api_key, db_type, dev=True)
+        cached_data = self.cache._memory_cache[cache_key]
+        
+        self.assertEqual(cached_data['metadata'], self.sample_metadata)
+        self.assertEqual(cached_data['db_type'], db_type)
+        self.assertEqual(cached_data['dev'], True)
+        self.assertIsInstance(cached_data['timestamp'], float)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -147,7 +147,7 @@ class ExecuteQueryOnceTestCase(unittest.TestCase):
         mock_requests_post.assert_called_with(
             "https://api.defog.ai/retry_query_after_error",
             json=json_req,
-            verify=False,
+            
         )
 
         # check that err logs are populated

--- a/tests/test_sql_generator.py
+++ b/tests/test_sql_generator.py
@@ -1,0 +1,262 @@
+import unittest
+import pytest
+from unittest.mock import Mock, patch, AsyncMock
+from defog.llm.sql_generator import (
+    format_schema_for_prompt,
+    build_sql_generation_prompt,
+    generate_sql_query_local,
+    generate_sql_query_local_sync,
+)
+from defog.llm.llm_providers import LLMProvider
+from defog.llm.config import LLMConfig
+
+
+class TestSQLGenerator(unittest.TestCase):
+    def setUp(self):
+        self.sample_metadata = {
+            "users": [
+                {"column_name": "id", "data_type": "integer", "column_description": "User ID"},
+                {"column_name": "name", "data_type": "varchar", "column_description": "User name"},
+                {"column_name": "email", "data_type": "varchar", "column_description": "Email address"},
+            ],
+            "orders": [
+                {"column_name": "id", "data_type": "integer", "column_description": "Order ID"},
+                {"column_name": "user_id", "data_type": "integer", "column_description": "Foreign key to users"},
+                {"column_name": "amount", "data_type": "decimal", "column_description": "Order amount"},
+                {"column_name": "created_at", "data_type": "timestamp", "column_description": "Order creation time"},
+            ]
+        }
+
+    def test_format_schema_for_prompt(self):
+        result = format_schema_for_prompt(self.sample_metadata)
+        
+        self.assertIn("Table: users", result)
+        self.assertIn("Table: orders", result)
+        self.assertIn("- id (integer): User ID", result)
+        self.assertIn("- email (varchar): Email address", result)
+        self.assertIn("- amount (decimal): Order amount", result)
+
+    def test_format_schema_for_prompt_no_description(self):
+        metadata = {
+            "simple_table": [
+                {"column_name": "col1", "data_type": "int"},
+                {"column_name": "col2", "data_type": "varchar", "column_description": ""},
+            ]
+        }
+        result = format_schema_for_prompt(metadata)
+        
+        self.assertIn("- col1 (int)", result)
+        self.assertNotIn("- col1 (int):", result)  # No colon when no description
+
+    def test_build_sql_generation_prompt_basic(self):
+        question = "How many users are there?"
+        messages = build_sql_generation_prompt(
+            question=question,
+            table_metadata=self.sample_metadata,
+            db_type="postgres"
+        )
+        
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0]["role"], "system")
+        self.assertEqual(messages[1]["role"], "user")
+        self.assertEqual(messages[1]["content"], question)
+        
+        system_content = messages[0]["content"]
+        self.assertIn("postgres", system_content)
+        self.assertIn("Table: users", system_content)
+        self.assertIn("Table: orders", system_content)
+
+    def test_build_sql_generation_prompt_with_glossary(self):
+        question = "How many active users?"
+        glossary = "Active users: users who logged in within the last 30 days"
+        
+        messages = build_sql_generation_prompt(
+            question=question,
+            table_metadata=self.sample_metadata,
+            db_type="mysql",
+            glossary=glossary
+        )
+        
+        system_content = messages[0]["content"]
+        self.assertIn("mysql", system_content)
+        self.assertIn("Business Glossary:", system_content)
+        self.assertIn(glossary, system_content)
+
+    def test_build_sql_generation_prompt_with_hard_filters(self):
+        question = "Show all orders"
+        hard_filters = "WHERE deleted_at IS NULL"
+        
+        messages = build_sql_generation_prompt(
+            question=question,
+            table_metadata=self.sample_metadata,
+            db_type="postgres",
+            hard_filters=hard_filters
+        )
+        
+        system_content = messages[0]["content"]
+        self.assertIn("Always apply these filters:", system_content)
+        self.assertIn(hard_filters, system_content)
+
+    def test_build_sql_generation_prompt_with_context(self):
+        question = "What about orders from yesterday?"
+        previous_context = [
+            {"role": "user", "content": "Show me all users"},
+            {"role": "assistant", "content": "SELECT * FROM users"}
+        ]
+        
+        messages = build_sql_generation_prompt(
+            question=question,
+            table_metadata=self.sample_metadata,
+            db_type="postgres",
+            previous_context=previous_context
+        )
+        
+        self.assertEqual(len(messages), 4)  # system + 2 context + current question
+        self.assertEqual(messages[1]["role"], "user")
+        self.assertEqual(messages[1]["content"], "Show me all users")
+        self.assertEqual(messages[2]["role"], "assistant")
+        self.assertEqual(messages[2]["content"], "SELECT * FROM users")
+        self.assertEqual(messages[3]["role"], "user")
+        self.assertEqual(messages[3]["content"], question)
+
+    @pytest.mark.asyncio
+    @patch('defog.llm.sql_generator.chat_async')
+    async def test_generate_sql_query_local_success(self, mock_chat):
+        # Mock the first chat call (SQL generation)
+        mock_response = Mock()
+        mock_response.content = "SELECT COUNT(*) FROM users"
+        
+        # Mock the second chat call (reason generation)
+        mock_reason_response = Mock()
+        mock_reason_response.content = "This query counts the total number of users in the database."
+        
+        mock_chat.side_effect = [mock_response, mock_reason_response]
+        
+        result = await generate_sql_query_local(
+            question="How many users are there?",
+            table_metadata=self.sample_metadata,
+            db_type="postgres"
+        )
+        
+        self.assertTrue(result["ran_successfully"])
+        self.assertEqual(result["query_generated"], "SELECT COUNT(*) FROM users")
+        self.assertEqual(result["query_db"], "postgres")
+        self.assertIn("counts the total number", result["reason_for_query"])
+        self.assertIsNone(result["error_message"])
+        
+        # Verify context was updated
+        self.assertEqual(len(result["previous_context"]), 2)
+        self.assertEqual(result["previous_context"][0]["role"], "user")
+        self.assertEqual(result["previous_context"][1]["role"], "assistant")
+
+    @pytest.mark.asyncio
+    @patch('defog.llm.sql_generator.chat_async')
+    async def test_generate_sql_query_local_with_markdown_cleanup(self, mock_chat):
+        # Mock response with markdown formatting
+        mock_response = Mock()
+        mock_response.content = "```sql\nSELECT * FROM orders\n```"
+        
+        mock_reason_response = Mock()
+        mock_reason_response.content = "Shows all orders"
+        
+        mock_chat.side_effect = [mock_response, mock_reason_response]
+        
+        result = await generate_sql_query_local(
+            question="Show all orders",
+            table_metadata=self.sample_metadata,
+            db_type="postgres"
+        )
+        
+        self.assertEqual(result["query_generated"], "SELECT * FROM orders")
+
+    @pytest.mark.asyncio
+    @patch('defog.llm.sql_generator.chat_async')
+    async def test_generate_sql_query_local_with_existing_context(self, mock_chat):
+        mock_response = Mock()
+        mock_response.content = "SELECT * FROM users WHERE id = 1"
+        
+        mock_reason_response = Mock()
+        mock_reason_response.content = "Gets user with ID 1"
+        
+        mock_chat.side_effect = [mock_response, mock_reason_response]
+        
+        existing_context = [
+            {"role": "user", "content": "Show all users"},
+            {"role": "assistant", "content": "SELECT * FROM users"}
+        ]
+        
+        result = await generate_sql_query_local(
+            question="Show user with ID 1",
+            table_metadata=self.sample_metadata,
+            db_type="postgres",
+            previous_context=existing_context
+        )
+        
+        # Context should include existing + new
+        self.assertEqual(len(result["previous_context"]), 4)
+
+    @pytest.mark.asyncio
+    @patch('defog.llm.sql_generator.chat_async')
+    async def test_generate_sql_query_local_error_handling(self, mock_chat):
+        mock_chat.side_effect = Exception("API Error")
+        
+        result = await generate_sql_query_local(
+            question="How many users?",
+            table_metadata=self.sample_metadata,
+            db_type="postgres"
+        )
+        
+        self.assertFalse(result["ran_successfully"])
+        self.assertIsNone(result["query_generated"])
+        self.assertEqual(result["error_message"], "API Error")
+        self.assertEqual(result["query_db"], "postgres")
+
+    @patch('asyncio.run')
+    def test_generate_sql_query_local_sync(self, mock_run):
+        mock_result = {"query_generated": "SELECT * FROM users", "ran_successfully": True}
+        mock_run.return_value = mock_result
+        
+        result = generate_sql_query_local_sync(
+            question="Show users",
+            table_metadata=self.sample_metadata,
+            db_type="postgres"
+        )
+        
+        self.assertEqual(result, mock_result)
+        mock_run.assert_called_once()
+
+    def test_generate_sql_query_local_with_custom_config(self):
+        # Test that custom config is passed through properly
+        with patch('defog.llm.sql_generator.chat_async') as mock_chat:
+            mock_response = Mock()
+            mock_response.content = "SELECT 1"
+            mock_reason_response = Mock()
+            mock_reason_response.content = "Test query"
+            mock_chat.side_effect = [mock_response, mock_reason_response]
+            
+            custom_config = LLMConfig(default_temperature=0.5)
+            
+            import asyncio
+            asyncio.run(generate_sql_query_local(
+                question="Test question",
+                table_metadata=self.sample_metadata,
+                db_type="postgres",
+                provider=LLMProvider.OPENAI,
+                model="gpt-4",
+                temperature=0.7,
+                config=custom_config
+            ))
+            
+            # Verify chat_async was called with correct parameters
+            self.assertEqual(mock_chat.call_count, 2)
+            
+            # Check first call (SQL generation)
+            first_call = mock_chat.call_args_list[0]
+            self.assertEqual(first_call[1]['provider'], LLMProvider.OPENAI)
+            self.assertEqual(first_call[1]['model'], "gpt-4")
+            self.assertEqual(first_call[1]['temperature'], 0.7)
+            self.assertEqual(first_call[1]['config'], custom_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

> [!NOTE]
> Instead of routing SQL generation queries through api.defog.ai, we now give users the ability to run these queries completely locally

- Added local metadata extraction functionality to extract table schemas directly from databases
- Implemented SQL generation capabilities with LLM provider support
- Added comprehensive test coverage for new features

## Changes
- Support for direct LLM usage for SQL generation with configurable provider and model
- Metadata extraction from databases when table metadata is not provided
- Schema caching implementation to improve performance
- Removal of unnecessary `verify=False` parameters

## Tests
- Added 724 lines of test coverage across 3 new test files:
  - `test_local_metadata_extractor.py`: Tests for metadata extraction functionality
  - `test_metadata_cache.py`: Tests for schema caching implementation
  - `test_sql_generator.py`: Tests for SQL generation capabilities