### PR TITLE
feat: When generating a database schema, save LLM generated table and column descriptions in the database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
   - Claude 4 Sonnet and Claude 4 Opus are now valid models
   - OpenAI's gpt-4.1, o3, and o4-mini are now valid models
   - Gemini's 2.5 flash and 2.5 pro are now valid models
+- Recall that you should consider using the `chat_async` function and its associated parameters (including `response_format`, `reasoning_effort`, and `tools`) - instead of using LLM clients directly or rolling your JSON parsing functions for structure outputs
 
 # Testing
 - Remember to run all tests with `python3.12 -m pytest ...`. This is to ensure you are using the correct version of python and pytest

--- a/defog/generate_schema.py
+++ b/defog/generate_schema.py
@@ -85,10 +85,8 @@ def generate_postgres_schema(
                         setattr(config, key, value)
             
             # Run async documentation
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
             try:
-                documentation = loop.run_until_complete(
+                documentation = asyncio.run(
                     document_schema_for_defog(
                         "postgres", 
                         self.db_creds, 
@@ -97,8 +95,22 @@ def generate_postgres_schema(
                     )
                 )
                 print(f"Schema documentation completed for {len(documentation)} tables.")
-            finally:
-                loop.close()
+            except RuntimeError:
+                # If we're already in an event loop, use the loop management approach
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    documentation = loop.run_until_complete(
+                        document_schema_for_defog(
+                            "postgres", 
+                            self.db_creds, 
+                            tables, 
+                            config
+                        )
+                    )
+                    print(f"Schema documentation completed for {len(documentation)} tables.")
+                finally:
+                    loop.close()
         except Exception as e:
             print(f"Warning: Schema documentation failed: {e}")
 
@@ -998,10 +1010,8 @@ def generate_duckdb_schema(
                         setattr(config, key, value)
             
             # Run async documentation
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
             try:
-                documentation = loop.run_until_complete(
+                documentation = asyncio.run(
                     document_schema_for_defog(
                         "duckdb", 
                         self.db_creds, 
@@ -1010,8 +1020,22 @@ def generate_duckdb_schema(
                     )
                 )
                 print(f"Schema documentation completed for {len(documentation)} tables.")
-            finally:
-                loop.close()
+            except RuntimeError:
+                # If we're already in an event loop, use the loop management approach
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    documentation = loop.run_until_complete(
+                        document_schema_for_defog(
+                            "duckdb", 
+                            self.db_creds, 
+                            tables, 
+                            config
+                        )
+                    )
+                    print(f"Schema documentation completed for {len(documentation)} tables.")
+                finally:
+                    loop.close()
         except Exception as e:
             print(f"Warning: Schema documentation failed: {e}")
 

--- a/defog/schema_documenter.py
+++ b/defog/schema_documenter.py
@@ -45,6 +45,16 @@ def _validate_sql_identifier(identifier: str) -> str:
     Raises:
         ValueError: If identifier contains invalid characters
     """
+    # Length check (255 bytes is reasonable for most databases)
+    if len(identifier.encode('utf-8')) > 255:
+        raise ValueError(f"SQL identifier too long: {len(identifier.encode('utf-8'))} bytes (max 255)")
+    
+    # Reject zero-width and invisible characters
+    invisible_chars = ['\u200b', '\u200c', '\u200d', '\ufeff', '\u2060']
+    for char in invisible_chars:
+        if char in identifier:
+            raise ValueError(f"SQL identifier contains invisible/zero-width characters")
+    
     # Handle quoted identifiers (double quotes)
     if identifier.startswith('"') and identifier.endswith('"'):
         # For quoted identifiers, we're more permissive but still check for truly dangerous patterns

--- a/defog/schema_documenter.py
+++ b/defog/schema_documenter.py
@@ -1,0 +1,747 @@
+"""
+LLM-powered database schema documentation system.
+
+This module provides functionality to automatically generate table and column
+descriptions using LLMs by analyzing database structure and sample data,
+then storing these descriptions as database comments.
+"""
+
+import asyncio
+import json
+import logging
+from typing import Dict, List, Optional, Tuple, Any, Union
+from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
+import re
+import time
+
+# Import LLM providers
+from defog.llm.providers.anthropic_provider import AnthropicProvider
+from defog.llm.providers.openai_provider import OpenAIProvider
+from defog.llm.providers.gemini_provider import GeminiProvider
+
+
+@dataclass
+class DocumentationConfig:
+    """Configuration for schema documentation generation."""
+    provider: str = "anthropic"  # anthropic, openai, gemini
+    model: str = "claude-sonnet-4-20250514"
+    sample_size: int = 100
+    min_confidence_score: float = 0.7
+    include_data_patterns: bool = True
+    dry_run: bool = False
+    concurrent_requests: int = 3
+    rate_limit_delay: float = 1.0
+
+
+@dataclass
+class TableDocumentation:
+    """Documentation for a database table."""
+    table_name: str
+    table_description: Optional[str] = None
+    table_confidence: float = 0.0
+    column_descriptions: Dict[str, str] = None
+    column_confidences: Dict[str, float] = None
+    existing_table_comment: Optional[str] = None
+    existing_column_comments: Dict[str, str] = None
+
+    def __post_init__(self):
+        if self.column_descriptions is None:
+            self.column_descriptions = {}
+        if self.column_confidences is None:
+            self.column_confidences = {}
+        if self.existing_column_comments is None:
+            self.existing_column_comments = {}
+
+
+class SchemaDocumenter:
+    """Main class for LLM-powered database schema documentation."""
+
+    def __init__(
+        self,
+        db_type: str,
+        db_creds: Dict,
+        config: Optional[DocumentationConfig] = None
+    ):
+        self.db_type = db_type.lower()
+        self.db_creds = db_creds
+        self.config = config or DocumentationConfig()
+        self.logger = logging.getLogger(__name__)
+        
+        # Validate database type
+        if self.db_type not in ["postgres", "duckdb"]:
+            raise ValueError(f"Database type '{db_type}' not supported. Use 'postgres' or 'duckdb'.")
+        
+        # Initialize LLM provider
+        self.llm_provider = self._init_llm_provider()
+
+    def _init_llm_provider(self):
+        """Initialize the appropriate LLM provider."""
+        if self.config.provider == "anthropic":
+            return AnthropicProvider()
+        elif self.config.provider == "openai":
+            return OpenAIProvider()  
+        elif self.config.provider == "gemini":
+            return GeminiProvider()
+        else:
+            raise ValueError(f"Unsupported LLM provider: {self.config.provider}")
+
+    def _get_connection(self):
+        """Get database connection based on db_type."""
+        if self.db_type == "postgres":
+            try:
+                import psycopg2
+                return psycopg2.connect(**self.db_creds)
+            except ImportError:
+                raise ImportError("psycopg2 not installed. Please install it with `pip install psycopg2-binary`.")
+        elif self.db_type == "duckdb":
+            try:
+                import duckdb
+                database_path = self.db_creds.get("database", ":memory:")
+                return duckdb.connect(database_path)
+            except ImportError:
+                raise ImportError("duckdb not installed. Please install it with `pip install duckdb`.")
+
+    def _get_existing_comments(self, conn, table_name: str) -> Tuple[Optional[str], Dict[str, str]]:
+        """Retrieve existing table and column comments."""
+        if self.db_type == "postgres":
+            return self._get_postgres_comments(conn, table_name)
+        elif self.db_type == "duckdb":
+            return self._get_duckdb_comments(conn, table_name)
+
+    def _get_postgres_comments(self, conn, table_name: str) -> Tuple[Optional[str], Dict[str, str]]:
+        """Get existing comments for Postgres table and columns."""
+        cursor = conn.cursor()
+        
+        # Parse schema and table name
+        if "." in table_name:
+            schema, table = table_name.split(".", 1)
+        else:
+            schema, table = "public", table_name
+
+        # Get table comment
+        cursor.execute("""
+            SELECT obj_description(c.oid, 'pg_class') as table_comment
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE c.relname = %s AND n.nspname = %s
+        """, (table, schema))
+        
+        result = cursor.fetchone()
+        table_comment = result[0] if result and result[0] else None
+
+        # Get column comments
+        cursor.execute("""
+            SELECT 
+                column_name,
+                col_description(
+                    FORMAT('%%s.%%s', table_schema, table_name)::regclass::oid, 
+                    ordinal_position
+                ) AS column_comment
+            FROM information_schema.columns 
+            WHERE table_name = %s AND table_schema = %s
+            AND col_description(
+                FORMAT('%%s.%%s', table_schema, table_name)::regclass::oid, 
+                ordinal_position
+            ) IS NOT NULL
+        """, (table, schema))
+        
+        column_comments = {row[0]: row[1] for row in cursor.fetchall()}
+        cursor.close()
+        
+        return table_comment, column_comments
+
+    def _get_duckdb_comments(self, conn, table_name: str) -> Tuple[Optional[str], Dict[str, str]]:
+        """Get existing comments for DuckDB table and columns."""
+        # DuckDB comment support is limited, return empty for now
+        # This can be enhanced when DuckDB adds better comment support
+        return None, {}
+
+    def _analyze_table_structure(self, conn, table_name: str) -> Dict[str, Any]:
+        """Analyze table structure and sample data."""
+        cursor = conn.cursor()
+        
+        # Get column information
+        if self.db_type == "postgres":
+            columns_info = self._get_postgres_columns(cursor, table_name)
+        elif self.db_type == "duckdb":
+            columns_info = self._get_duckdb_columns(cursor, table_name)
+        
+        # Get sample data
+        sample_data = self._get_sample_data(cursor, table_name, columns_info)
+        
+        # Analyze data patterns
+        data_patterns = {}
+        if self.config.include_data_patterns:
+            data_patterns = self._analyze_data_patterns(sample_data, columns_info)
+        
+        cursor.close()
+        
+        return {
+            "columns": columns_info,
+            "sample_data": sample_data,
+            "data_patterns": data_patterns,
+            "row_count": self._get_row_count(conn, table_name)
+        }
+
+    def _get_postgres_columns(self, cursor, table_name: str) -> List[Dict]:
+        """Get column information for Postgres."""
+        if "." in table_name:
+            schema, table = table_name.split(".", 1)
+        else:
+            schema, table = "public", table_name
+
+        cursor.execute("""
+            SELECT 
+                column_name,
+                data_type,
+                is_nullable,
+                column_default,
+                character_maximum_length,
+                numeric_precision,
+                numeric_scale
+            FROM information_schema.columns 
+            WHERE table_name = %s AND table_schema = %s
+            ORDER BY ordinal_position
+        """, (table, schema))
+        
+        return [
+            {
+                "name": row[0],
+                "type": row[1],
+                "nullable": row[2] == "YES",
+                "default": row[3],
+                "max_length": row[4],
+                "precision": row[5],
+                "scale": row[6]
+            }
+            for row in cursor.fetchall()
+        ]
+
+    def _get_duckdb_columns(self, cursor, table_name: str) -> List[Dict]:
+        """Get column information for DuckDB."""
+        if "." in table_name:
+            schema_name, table_only = table_name.split(".", 1)
+            query = f"""
+                SELECT column_name, data_type, is_nullable, column_default
+                FROM information_schema.columns 
+                WHERE table_schema = '{schema_name}' AND table_name = '{table_only}'
+                ORDER BY ordinal_position
+            """
+        else:
+            query = f"""
+                SELECT column_name, data_type, is_nullable, column_default
+                FROM information_schema.columns 
+                WHERE table_name = '{table_name}' AND table_schema = 'main'
+                ORDER BY ordinal_position
+            """
+        
+        cursor.execute(query)
+        
+        return [
+            {
+                "name": row[0],
+                "type": row[1], 
+                "nullable": row[2] == "YES",
+                "default": row[3],
+                "max_length": None,
+                "precision": None,
+                "scale": None
+            }
+            for row in cursor.fetchall()
+        ]
+
+    def _get_sample_data(self, cursor, table_name: str, columns_info: List[Dict]) -> Dict[str, List]:
+        """Get sample data for analysis."""
+        column_names = [col["name"] for col in columns_info]
+        column_list = ", ".join(f'"{name}"' for name in column_names)
+        
+        try:
+            query = f'SELECT {column_list} FROM "{table_name}" LIMIT {self.config.sample_size}'
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            
+            # Organize data by column
+            sample_data = {col_name: [] for col_name in column_names}
+            for row in rows:
+                for i, col_name in enumerate(column_names):
+                    if i < len(row) and row[i] is not None:
+                        sample_data[col_name].append(row[i])
+            
+            return sample_data
+        except Exception as e:
+            self.logger.warning(f"Could not retrieve sample data for {table_name}: {e}")
+            return {col_name: [] for col_name in column_names}
+
+    def _get_row_count(self, conn, table_name: str) -> int:
+        """Get approximate row count for the table."""
+        cursor = conn.cursor()
+        try:
+            cursor.execute(f'SELECT COUNT(*) FROM "{table_name}"')
+            result = cursor.fetchone()
+            return result[0] if result else 0
+        except Exception:
+            return 0
+        finally:
+            cursor.close()
+
+    def _analyze_data_patterns(self, sample_data: Dict[str, List], columns_info: List[Dict]) -> Dict[str, Dict]:
+        """Analyze patterns in the sample data."""
+        patterns = {}
+        
+        for col_info in columns_info:
+            col_name = col_info["name"]
+            col_data = sample_data.get(col_name, [])
+            
+            if not col_data:
+                continue
+                
+            col_patterns = {}
+            
+            # String patterns
+            if col_info["type"].lower() in ["text", "varchar", "character varying", "string"]:
+                col_patterns.update(self._analyze_string_patterns(col_data))
+            
+            # Numeric patterns
+            elif col_info["type"].lower() in ["integer", "bigint", "decimal", "numeric", "real", "double"]:
+                col_patterns.update(self._analyze_numeric_patterns(col_data))
+            
+            # Date/time patterns
+            elif "date" in col_info["type"].lower() or "time" in col_info["type"].lower():
+                col_patterns.update(self._analyze_datetime_patterns(col_data))
+            
+            # General patterns
+            col_patterns.update(self._analyze_general_patterns(col_data))
+            
+            if col_patterns:
+                patterns[col_name] = col_patterns
+        
+        return patterns
+
+    def _analyze_string_patterns(self, data: List) -> Dict:
+        """Analyze patterns in string data."""
+        patterns = {}
+        
+        if not data:
+            return patterns
+        
+        # Email pattern
+        email_count = sum(1 for item in data if self._is_email(str(item)))
+        if email_count / len(data) > 0.8:
+            patterns["email"] = True
+        
+        # URL pattern
+        url_count = sum(1 for item in data if self._is_url(str(item)))
+        if url_count / len(data) > 0.8:
+            patterns["url"] = True
+        
+        # UUID pattern
+        uuid_count = sum(1 for item in data if self._is_uuid(str(item)))
+        if uuid_count / len(data) > 0.8:
+            patterns["uuid"] = True
+        
+        # Phone number pattern
+        phone_count = sum(1 for item in data if self._is_phone(str(item)))
+        if phone_count / len(data) > 0.8:
+            patterns["phone"] = True
+        
+        # Categories (limited unique values)
+        unique_values = set(str(item) for item in data)
+        if len(unique_values) <= 20 and len(unique_values) < len(data) * 0.5:
+            patterns["categorical"] = True
+            patterns["categories"] = list(unique_values)[:10]  # Limit to 10 examples
+        
+        return patterns
+
+    def _analyze_numeric_patterns(self, data: List) -> Dict:
+        """Analyze patterns in numeric data."""
+        patterns = {}
+        
+        if not data:
+            return patterns
+        
+        # Check if values look like IDs (sequential, unique)
+        try:
+            numeric_data = [float(item) for item in data if item is not None]
+            if len(set(numeric_data)) == len(numeric_data):  # All unique
+                patterns["unique"] = True
+                if all(x == int(x) for x in numeric_data):  # All integers
+                    patterns["id_like"] = True
+        except (ValueError, TypeError):
+            pass
+        
+        return patterns
+
+    def _analyze_datetime_patterns(self, data: List) -> Dict:
+        """Analyze patterns in datetime data."""
+        return {"datetime": True}
+
+    def _analyze_general_patterns(self, data: List) -> Dict:
+        """Analyze general patterns in data."""
+        patterns = {}
+        
+        if not data:
+            return patterns
+        
+        # Null percentage
+        null_count = sum(1 for item in data if item is None or str(item).strip() == "")
+        if null_count > 0:
+            patterns["null_percentage"] = round(null_count / len(data) * 100, 1)
+        
+        return patterns
+
+    # Pattern matching utility functions
+    def _is_email(self, text: str) -> bool:
+        email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
+        return bool(re.match(email_pattern, text.strip()))
+
+    def _is_url(self, text: str) -> bool:
+        url_pattern = r'^https?://[^\s/$.?#].[^\s]*$'
+        return bool(re.match(url_pattern, text.strip()))
+
+    def _is_uuid(self, text: str) -> bool:
+        uuid_pattern = r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$'
+        return bool(re.match(uuid_pattern, text.strip()))
+
+    def _is_phone(self, text: str) -> bool:
+        phone_pattern = r'^[\+]?[1-9][\d\s\-\(\)]{7,15}$'
+        return bool(re.match(phone_pattern, text.strip()))
+
+    async def _generate_description(self, table_name: str, analysis: Dict[str, Any]) -> Dict[str, Any]:
+        """Generate LLM-based descriptions for table and columns."""
+        prompt = self._build_documentation_prompt(table_name, analysis)
+        
+        try:
+            # Make async call to LLM
+            response = await self.llm_provider.generate_async(
+                messages=[{"role": "user", "content": prompt}],
+                model=self.config.model,
+                max_tokens=2000,
+                temperature=0.1
+            )
+            
+            # Parse the structured response
+            return self._parse_llm_response(response)
+            
+        except Exception as e:
+            self.logger.error(f"Error generating description for {table_name}: {e}")
+            return {"error": str(e)}
+
+    def _build_documentation_prompt(self, table_name: str, analysis: Dict[str, Any]) -> str:
+        """Build the prompt for LLM to generate documentation."""
+        columns = analysis["columns"]
+        sample_data = analysis.get("sample_data", {})
+        patterns = analysis.get("data_patterns", {})
+        row_count = analysis.get("row_count", 0)
+
+        prompt = f"""You are a database documentation expert. Analyze the following table and generate clear, concise descriptions.
+
+TABLE: {table_name}
+ROW COUNT: {row_count:,}
+
+COLUMNS:
+"""
+        
+        for col in columns:
+            col_name = col["name"]
+            col_type = col["type"]
+            nullable = "NULL" if col["nullable"] else "NOT NULL"
+            
+            prompt += f"\n- {col_name} ({col_type}, {nullable})"
+            
+            # Add pattern information
+            if col_name in patterns:
+                col_patterns = patterns[col_name]
+                if "email" in col_patterns:
+                    prompt += " [EMAIL ADDRESSES]"
+                elif "url" in col_patterns:
+                    prompt += " [URLs]"
+                elif "uuid" in col_patterns:
+                    prompt += " [UUIDs]"
+                elif "phone" in col_patterns:
+                    prompt += " [PHONE NUMBERS]"
+                elif "id_like" in col_patterns:
+                    prompt += " [ID/SEQUENCE]"
+                elif "categorical" in col_patterns:
+                    categories = col_patterns.get("categories", [])
+                    prompt += f" [CATEGORICAL: {', '.join(map(str, categories[:5]))}...]"
+            
+            # Add sample values
+            if col_name in sample_data and sample_data[col_name]:
+                samples = sample_data[col_name][:3]  # First 3 samples
+                sample_str = ", ".join(f"'{s}'" for s in samples if s is not None)
+                if sample_str:
+                    prompt += f" [SAMPLES: {sample_str}]"
+
+        prompt += f"""
+
+Please provide documentation in the following JSON format:
+
+{{
+    "table_description": "A clear, concise description of what this table stores and its purpose (1-2 sentences)",
+    "table_confidence": 0.85,
+    "columns": {{
+        "column_name": {{
+            "description": "Clear description of what this column stores",
+            "confidence": 0.90
+        }},
+        ...
+    }}
+}}
+
+Guidelines:
+- Keep descriptions concise but informative
+- Focus on business purpose, not technical details
+- Use confidence scores between 0.5-1.0 based on how clear the purpose is
+- Avoid generic descriptions like "stores data" or "contains values"
+- For ID columns, mention what entity they identify
+- For categorical columns, explain what the categories represent
+- For timestamp columns, explain when the event occurred
+"""
+
+        return prompt
+
+    def _parse_llm_response(self, response: str) -> Dict[str, Any]:
+        """Parse the LLM's structured JSON response."""
+        try:
+            # Extract JSON from response (handle markdown code blocks)
+            json_match = re.search(r'```(?:json)?\n?(.*?)\n?```', response, re.DOTALL)
+            if json_match:
+                json_str = json_match.group(1)
+            else:
+                json_str = response
+            
+            # Parse JSON
+            parsed = json.loads(json_str)
+            
+            # Validate structure
+            if "table_description" not in parsed or "columns" not in parsed:
+                raise ValueError("Invalid response structure")
+            
+            return parsed
+            
+        except (json.JSONDecodeError, ValueError) as e:
+            self.logger.error(f"Failed to parse LLM response: {e}")
+            return {
+                "table_description": "Auto-generated documentation failed",
+                "table_confidence": 0.0,
+                "columns": {},
+                "error": str(e)
+            }
+
+    async def document_schema(self, tables: Optional[List[str]] = None) -> Dict[str, TableDocumentation]:
+        """Main method to document database schema."""
+        conn = self._get_connection()
+        
+        try:
+            # Get tables to document
+            if not tables:
+                tables = self._get_all_tables(conn)
+            
+            # Document each table concurrently
+            semaphore = asyncio.Semaphore(self.config.concurrent_requests)
+            tasks = []
+            
+            for table_name in tables:
+                task = self._document_single_table(semaphore, conn, table_name)
+                tasks.append(task)
+            
+            # Wait for all tasks to complete
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            
+            # Process results
+            documentation = {}
+            for i, result in enumerate(results):
+                if isinstance(result, Exception):
+                    self.logger.error(f"Failed to document table {tables[i]}: {result}")
+                else:
+                    documentation[tables[i]] = result
+            
+            return documentation
+            
+        finally:
+            conn.close()
+
+    async def _document_single_table(
+        self, 
+        semaphore: asyncio.Semaphore, 
+        conn, 
+        table_name: str
+    ) -> TableDocumentation:
+        """Document a single table with rate limiting."""
+        async with semaphore:
+            # Rate limiting
+            if self.config.rate_limit_delay > 0:
+                await asyncio.sleep(self.config.rate_limit_delay)
+            
+            # Get existing comments first
+            existing_table_comment, existing_column_comments = self._get_existing_comments(conn, table_name)
+            
+            # Analyze table structure
+            analysis = self._analyze_table_structure(conn, table_name)
+            
+            # Generate new descriptions using LLM
+            llm_result = await self._generate_description(table_name, analysis)
+            
+            # Create documentation object
+            doc = TableDocumentation(
+                table_name=table_name,
+                existing_table_comment=existing_table_comment,
+                existing_column_comments=existing_column_comments
+            )
+            
+            # Only use LLM-generated descriptions if no existing comments
+            if not existing_table_comment and "table_description" in llm_result:
+                doc.table_description = llm_result["table_description"]
+                doc.table_confidence = llm_result.get("table_confidence", 0.0)
+            
+            if "columns" in llm_result:
+                for col_name, col_info in llm_result["columns"].items():
+                    # Only use LLM description if no existing comment
+                    if col_name not in existing_column_comments:
+                        doc.column_descriptions[col_name] = col_info.get("description", "")
+                        doc.column_confidences[col_name] = col_info.get("confidence", 0.0)
+            
+            return doc
+
+    def _get_all_tables(self, conn) -> List[str]:
+        """Get all tables in the database."""
+        cursor = conn.cursor()
+        
+        if self.db_type == "postgres":
+            cursor.execute("""
+                SELECT table_schema || '.' || table_name as full_table_name
+                FROM information_schema.tables 
+                WHERE table_type = 'BASE TABLE'
+                AND table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+            """)
+        elif self.db_type == "duckdb":
+            cursor.execute("""
+                SELECT table_schema || '.' || table_name as full_table_name
+                FROM information_schema.tables 
+                WHERE table_type = 'BASE TABLE'
+                AND table_schema NOT IN ('information_schema', 'pg_catalog')
+            """)
+        
+        tables = [row[0] for row in cursor.fetchall()]
+        cursor.close()
+        
+        return tables
+
+    async def apply_documentation(
+        self, 
+        documentation: Dict[str, TableDocumentation]
+    ) -> Dict[str, Dict[str, bool]]:
+        """Apply the generated documentation to the database."""
+        if self.config.dry_run:
+            self.logger.info("DRY RUN: Would apply the following documentation:")
+            self._log_documentation_preview(documentation)
+            return {}
+        
+        conn = self._get_connection()
+        results = {}
+        
+        try:
+            for table_name, doc in documentation.items():
+                table_results = {"table": False, "columns": {}}
+                
+                # Apply table comment
+                if doc.table_description and doc.table_confidence >= self.config.min_confidence_score:
+                    success = self._apply_table_comment(conn, table_name, doc.table_description)
+                    table_results["table"] = success
+                
+                # Apply column comments
+                for col_name, description in doc.column_descriptions.items():
+                    confidence = doc.column_confidences.get(col_name, 0.0)
+                    if confidence >= self.config.min_confidence_score:
+                        success = self._apply_column_comment(conn, table_name, col_name, description)
+                        table_results["columns"][col_name] = success
+                
+                results[table_name] = table_results
+            
+            conn.commit()
+            
+        except Exception as e:
+            conn.rollback()
+            self.logger.error(f"Error applying documentation: {e}")
+            raise
+        finally:
+            conn.close()
+        
+        return results
+
+    def _apply_table_comment(self, conn, table_name: str, description: str) -> bool:
+        """Apply table comment to database."""
+        cursor = conn.cursor()
+        
+        try:
+            if self.db_type == "postgres":
+                cursor.execute(f'COMMENT ON TABLE "{table_name}" IS %s', (description,))
+            elif self.db_type == "duckdb":
+                # DuckDB comment support is limited, log for now
+                self.logger.info(f"Would set table comment for {table_name}: {description}")
+            
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to set table comment for {table_name}: {e}")
+            return False
+        finally:
+            cursor.close()
+
+    def _apply_column_comment(self, conn, table_name: str, column_name: str, description: str) -> bool:
+        """Apply column comment to database."""
+        cursor = conn.cursor()
+        
+        try:
+            if self.db_type == "postgres":
+                cursor.execute(f'COMMENT ON COLUMN "{table_name}"."{column_name}" IS %s', (description,))
+            elif self.db_type == "duckdb":
+                # DuckDB comment support is limited, log for now
+                self.logger.info(f"Would set column comment for {table_name}.{column_name}: {description}")
+            
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to set column comment for {table_name}.{column_name}: {e}")
+            return False
+        finally:
+            cursor.close()
+
+    def _log_documentation_preview(self, documentation: Dict[str, TableDocumentation]):
+        """Log documentation preview for dry run."""
+        for table_name, doc in documentation.items():
+            self.logger.info(f"\nTable: {table_name}")
+            
+            if doc.table_description:
+                self.logger.info(f"  Table Description: {doc.table_description}")
+                self.logger.info(f"  Table Confidence: {doc.table_confidence}")
+            
+            if doc.existing_table_comment:
+                self.logger.info(f"  Existing Table Comment: {doc.existing_table_comment}")
+            
+            for col_name, description in doc.column_descriptions.items():
+                confidence = doc.column_confidences.get(col_name, 0.0)
+                self.logger.info(f"    Column {col_name}: {description} (confidence: {confidence})")
+            
+            for col_name, comment in doc.existing_column_comments.items():
+                self.logger.info(f"    Existing comment for {col_name}: {comment}")
+
+
+# Utility function for integration with existing Defog workflow
+async def document_schema_for_defog(
+    db_type: str,
+    db_creds: Dict,
+    tables: Optional[List[str]] = None,
+    config: Optional[DocumentationConfig] = None
+) -> Dict[str, TableDocumentation]:
+    """
+    Utility function to document schema and return documentation.
+    Designed for integration with existing Defog generate_db_schema workflow.
+    """
+    documenter = SchemaDocumenter(db_type, db_creds, config)
+    documentation = await documenter.document_schema(tables)
+    
+    # Apply documentation to database
+    if not config or not config.dry_run:
+        await documenter.apply_documentation(documentation)
+    
+    return documentation

--- a/examples/schema_documentation_example.py
+++ b/examples/schema_documentation_example.py
@@ -1,0 +1,219 @@
+"""
+Example usage of the LLM-powered schema documentation feature.
+
+This example demonstrates how to use the schema documentation functionality
+to automatically generate table and column descriptions using LLMs.
+"""
+
+import asyncio
+import os
+from defog.schema_documenter import SchemaDocumenter, DocumentationConfig
+from defog import Defog
+
+
+def main():
+    """Main example function."""
+    print("=" * 60)
+    print("LLM-Powered Database Schema Documentation Example")
+    print("=" * 60)
+    
+    # Example 1: Using with existing Defog workflow
+    print("\n1. Integration with existing Defog workflow:")
+    print("-" * 50)
+    
+    # Initialize Defog (example with Postgres)
+    postgres_creds = {
+        "host": "localhost",
+        "port": 5432,
+        "database": "your_database",
+        "user": "your_user",
+        "password": "your_password"
+    }
+    
+    try:
+        defog = Defog(
+            db_type="postgres",
+            db_creds=postgres_creds,
+            api_key="your_defog_api_key"  # Optional for local use
+        )
+        
+        # Generate schema with LLM documentation
+        print("Generating schema with LLM-powered documentation...")
+        schema = defog.generate_db_schema(
+            tables=[],  # Empty list = all tables
+            upload=False,  # Don't upload to Defog servers for this example
+            self_document=True,  # Enable LLM documentation
+            documentation_config={
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-20250514",
+                "min_confidence_score": 0.8,
+                "sample_size": 50,
+                "dry_run": False  # Set to True for testing without actual changes
+            }
+        )
+        
+        print("Schema generation completed!")
+        print(f"Found {len(schema)} tables with documentation.")
+        
+        # Display sample output
+        for table_name, table_info in list(schema.items())[:2]:  # Show first 2 tables
+            print(f"\nTable: {table_name}")
+            if isinstance(table_info, dict) and "table_description" in table_info:
+                print(f"  Description: {table_info['table_description']}")
+                print(f"  Columns: {len(table_info.get('columns', []))}")
+            
+    except Exception as e:
+        print(f"Note: This example requires a real database connection: {e}")
+    
+    
+    # Example 2: Standalone usage with advanced configuration
+    print("\n2. Advanced standalone usage:")
+    print("-" * 50)
+    
+    # Create advanced configuration
+    config = DocumentationConfig(
+        provider="anthropic",  # or "openai", "gemini"
+        model="claude-sonnet-4-20250514",
+        sample_size=100,
+        min_confidence_score=0.7,
+        include_data_patterns=True,
+        dry_run=True,  # Safe mode - don't actually modify database
+        concurrent_requests=3,
+        rate_limit_delay=1.0
+    )
+    
+    try:
+        # Initialize documenter
+        documenter = SchemaDocumenter("postgres", postgres_creds, config)
+        
+        # Run async documentation
+        async def run_documentation():
+            print("Running async schema documentation...")
+            
+            # Document specific tables
+            documentation = await documenter.document_schema(
+                tables=["users", "orders", "products"]
+            )
+            
+            print(f"Documentation generated for {len(documentation)} tables:")
+            
+            for table_name, doc in documentation.items():
+                print(f"\n  Table: {table_name}")
+                if doc.table_description:
+                    print(f"    Description: {doc.table_description}")
+                    print(f"    Confidence: {doc.table_confidence:.2f}")
+                
+                if doc.existing_table_comment:
+                    print(f"    Existing comment: {doc.existing_table_comment}")
+                
+                for col_name, desc in doc.column_descriptions.items():
+                    confidence = doc.column_confidences.get(col_name, 0.0)
+                    print(f"    Column {col_name}: {desc} (confidence: {confidence:.2f})")
+                
+                for col_name, existing in doc.existing_column_comments.items():
+                    print(f"    Existing comment for {col_name}: {existing}")
+            
+            # Apply documentation to database (in dry_run mode, this just logs)
+            if not config.dry_run:
+                print("\nApplying documentation to database...")
+                results = await documenter.apply_documentation(documentation)
+                print("Application results:", results)
+            else:
+                print("\nDry run mode - documentation would be applied as shown above.")
+            
+            return documentation
+        
+        # Run the async function
+        documentation = asyncio.run(run_documentation())
+        
+    except Exception as e:
+        print(f"Note: This example requires a real database connection: {e}")
+    
+    
+    # Example 3: DuckDB usage
+    print("\n3. DuckDB usage:")
+    print("-" * 50)
+    
+    duckdb_creds = {"database": ":memory:"}  # or path to .duckdb file
+    
+    try:
+        # For demonstration purposes, let's show what the call would look like
+        print("DuckDB schema documentation would work like this:")
+        print("""
+        defog_duckdb = Defog(
+            db_type="duckdb",
+            db_creds={"database": "/path/to/your/database.duckdb"}
+        )
+        
+        schema = defog_duckdb.generate_db_schema(
+            tables=[],
+            self_document=True,
+            documentation_config={
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-20250514"
+            }
+        )
+        """)
+        
+    except Exception as e:
+        print(f"DuckDB example: {e}")
+    
+    
+    # Example 4: Configuration options
+    print("\n4. Configuration options:")
+    print("-" * 50)
+    
+    print("""
+    Available configuration options for DocumentationConfig:
+    
+    provider: "anthropic", "openai", or "gemini"
+        - Choose your preferred LLM provider
+    
+    model: Model name (e.g., "claude-sonnet-4-20250514", "gpt-4.1", "gemini-2.5-pro")
+        - Specific model to use for documentation generation
+    
+    sample_size: int (default: 100)
+        - Number of rows to sample for pattern analysis
+    
+    min_confidence_score: float (default: 0.7)
+        - Minimum confidence required to apply generated descriptions
+    
+    include_data_patterns: bool (default: True)
+        - Whether to analyze data patterns (emails, URLs, etc.)
+    
+    dry_run: bool (default: False)
+        - If True, shows what would be done without making changes
+    
+    concurrent_requests: int (default: 3)
+        - Number of concurrent LLM requests
+    
+    rate_limit_delay: float (default: 1.0)
+        - Delay between requests in seconds
+    """)
+    
+    
+    # Example 5: Error handling and best practices
+    print("\n5. Best practices:")
+    print("-" * 50)
+    
+    print("""
+    Best practices for using schema documentation:
+    
+    1. Start with dry_run=True to preview changes
+    2. Use appropriate confidence thresholds (0.7-0.9)
+    3. Review generated descriptions before applying
+    4. Consider rate limiting for large databases
+    5. Use specific table lists for focused documentation
+    6. Backup your database before applying comments
+    7. Test with sample data first
+    
+    Preservation of existing comments:
+    - The system automatically detects existing table/column comments
+    - Existing comments are never overwritten
+    - Only tables/columns without comments get new descriptions
+    - This ensures your manual documentation is preserved
+    """)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_schema_documenter.py
+++ b/tests/test_schema_documenter.py
@@ -8,13 +8,13 @@ from defog.schema_documenter import (
     SchemaDocumenter,
     DocumentationConfig,
     TableDocumentation,
-    document_schema_for_defog
+    document_schema_for_defog,
 )
 
 
 class TestDocumentationConfig:
     """Test DocumentationConfig class."""
-    
+
     def test_default_config(self):
         """Test default configuration values."""
         config = DocumentationConfig()
@@ -30,7 +30,7 @@ class TestDocumentationConfig:
 
 class TestTableDocumentation:
     """Test TableDocumentation class."""
-    
+
     def test_table_documentation_init(self):
         """Test TableDocumentation initialization."""
         doc = TableDocumentation("test_table")
@@ -45,7 +45,7 @@ class TestTableDocumentation:
 
 class TestSchemaDocumenter:
     """Test SchemaDocumenter class."""
-    
+
     def test_init_postgres(self):
         """Test SchemaDocumenter initialization for Postgres."""
         db_creds = {"host": "localhost", "database": "test"}
@@ -53,19 +53,19 @@ class TestSchemaDocumenter:
         assert documenter.db_type == "postgres"
         assert documenter.db_creds == db_creds
         assert isinstance(documenter.config, DocumentationConfig)
-    
+
     def test_init_duckdb(self):
         """Test SchemaDocumenter initialization for DuckDB."""
         db_creds = {"database": ":memory:"}
         documenter = SchemaDocumenter("duckdb", db_creds)
         assert documenter.db_type == "duckdb"
         assert documenter.db_creds == db_creds
-    
+
     def test_init_unsupported_db(self):
         """Test SchemaDocumenter initialization with unsupported database."""
         with pytest.raises(ValueError, match="Database type 'mysql' not supported"):
             SchemaDocumenter("mysql", {})
-    
+
     def test_init_unsupported_provider(self):
         """Test SchemaDocumenter initialization with unsupported LLM provider."""
         config = DocumentationConfig(provider="unsupported")
@@ -75,50 +75,50 @@ class TestSchemaDocumenter:
 
 class TestPatternAnalysis:
     """Test data pattern analysis functionality."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-    
+
     def test_is_email(self):
         """Test email pattern detection."""
         assert self.documenter._is_email("test@example.com") is True
         assert self.documenter._is_email("user.name+tag@domain.co.uk") is True
         assert self.documenter._is_email("invalid-email") is False
         assert self.documenter._is_email("@example.com") is False
-    
+
     def test_is_url(self):
         """Test URL pattern detection."""
         assert self.documenter._is_url("https://example.com") is True
         assert self.documenter._is_url("http://sub.domain.com/path?query=1") is True
         assert self.documenter._is_url("not-a-url") is False
         assert self.documenter._is_url("ftp://example.com") is False
-    
+
     def test_is_uuid(self):
         """Test UUID pattern detection."""
         assert self.documenter._is_uuid("123e4567-e89b-12d3-a456-426614174000") is True
         assert self.documenter._is_uuid("invalid-uuid") is False
         assert self.documenter._is_uuid("123e4567-e89b-12d3-a456") is False
-    
+
     def test_is_phone(self):
         """Test phone number pattern detection."""
         assert self.documenter._is_phone("+1234567890") is True
         assert self.documenter._is_phone("123-456-7890") is True
         assert self.documenter._is_phone("123") is False
-    
+
     def test_analyze_string_patterns(self):
         """Test string pattern analysis."""
         # Email data
         email_data = ["user1@example.com", "user2@test.org", "user3@domain.net"]
         patterns = self.documenter._analyze_string_patterns(email_data)
         assert patterns.get("email") is True
-        
+
         # Categorical data
         categorical_data = ["red", "blue", "green", "red", "blue"] * 10
         patterns = self.documenter._analyze_string_patterns(categorical_data)
         assert patterns.get("categorical") is True
         assert "categories" in patterns
-    
+
     def test_analyze_numeric_patterns(self):
         """Test numeric pattern analysis."""
         # Unique ID-like data
@@ -126,7 +126,7 @@ class TestPatternAnalysis:
         patterns = self.documenter._analyze_numeric_patterns(id_data)
         assert patterns.get("unique") is True
         assert patterns.get("id_like") is True
-    
+
     def test_analyze_general_patterns(self):
         """Test general pattern analysis."""
         data_with_nulls = ["value1", None, "value2", "", "value3"]
@@ -137,30 +137,27 @@ class TestPatternAnalysis:
 
 class TestLLMIntegration:
     """Test LLM integration functionality."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-    
+
     def test_build_documentation_prompt(self):
         """Test building documentation prompt."""
         table_name = "users"
         analysis = {
             "columns": [
                 {"name": "id", "type": "integer", "nullable": False},
-                {"name": "email", "type": "varchar", "nullable": True}
+                {"name": "email", "type": "varchar", "nullable": True},
             ],
             "sample_data": {
                 "id": [1, 2, 3],
-                "email": ["user1@example.com", "user2@example.com", None]
+                "email": ["user1@example.com", "user2@example.com", None],
             },
-            "data_patterns": {
-                "id": {"id_like": True},
-                "email": {"email": True}
-            },
-            "row_count": 1000
+            "data_patterns": {"id": {"id_like": True}, "email": {"email": True}},
+            "row_count": 1000,
         }
-        
+
         prompt = self.documenter._build_documentation_prompt(table_name, analysis)
         assert "users" in prompt
         assert "1,000" in prompt
@@ -168,11 +165,11 @@ class TestLLMIntegration:
         assert "email (varchar, NULL)" in prompt
         assert "[EMAIL ADDRESSES]" in prompt
         assert "[ID/SEQUENCE]" in prompt
-    
+
     def test_parse_llm_response(self):
         """Test parsing LLM response."""
         # Valid JSON response
-        response = '''```json
+        response = """```json
         {
             "table_description": "Stores user account information",
             "table_confidence": 0.9,
@@ -183,13 +180,13 @@ class TestLLMIntegration:
                 }
             }
         }
-        ```'''
-        
+        ```"""
+
         result = self.documenter._parse_llm_response(response)
         assert result["table_description"] == "Stores user account information"
         assert result["table_confidence"] == 0.9
         assert "id" in result["columns"]
-        
+
         # Invalid JSON response
         invalid_response = "This is not valid JSON"
         result = self.documenter._parse_llm_response(invalid_response)
@@ -199,12 +196,12 @@ class TestLLMIntegration:
 
 class TestPostgresComments:
     """Test Postgres comment functionality."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-    
-    @patch('psycopg2.connect')
+
+    @patch("psycopg2.connect")
     def test_get_postgres_comments(self, mock_connect):
         """Test retrieving existing Postgres comments."""
         # Mock database connection and cursor
@@ -212,27 +209,27 @@ class TestPostgresComments:
         mock_cursor = Mock()
         mock_connect.return_value = mock_conn
         mock_conn.cursor.return_value = mock_cursor
-        
+
         # Mock table comment query
         mock_cursor.fetchone.side_effect = [
             ("Table stores user data",),  # table comment
         ]
-        
+
         # Mock column comments query
         mock_cursor.fetchall.return_value = [
             ("id", "User identifier"),
-            ("email", "User email address")
+            ("email", "User email address"),
         ]
-        
+
         table_comment, column_comments = self.documenter._get_postgres_comments(
             mock_conn, "users"
         )
-        
+
         assert table_comment == "Table stores user data"
         assert column_comments["id"] == "User identifier"
         assert column_comments["email"] == "User email address"
-    
-    @patch('psycopg2.connect')
+
+    @patch("psycopg2.connect")
     def test_apply_postgres_comments(self, mock_connect):
         """Test applying comments to Postgres database."""
         # Mock database connection and cursor
@@ -240,14 +237,14 @@ class TestPostgresComments:
         mock_cursor = Mock()
         mock_connect.return_value = mock_conn
         mock_conn.cursor.return_value = mock_cursor
-        
+
         # Test table comment
         success = self.documenter._apply_table_comment(
             mock_conn, "users", "Stores user information"
         )
         assert success is True
         mock_cursor.execute.assert_called()
-        
+
         # Test column comment
         success = self.documenter._apply_column_comment(
             mock_conn, "users", "email", "User email address"
@@ -257,11 +254,11 @@ class TestPostgresComments:
 
 class TestDuckDBComments:
     """Test DuckDB comment functionality."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
-    
+
     def test_get_duckdb_comments(self):
         """Test retrieving DuckDB comments (limited support)."""
         table_comment, column_comments = self.documenter._get_duckdb_comments(
@@ -273,43 +270,42 @@ class TestDuckDBComments:
 
 class TestAsyncOperations:
     """Test async functionality."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.config = DocumentationConfig(dry_run=True)
-        self.documenter = SchemaDocumenter("postgres", {"host": "localhost"}, self.config)
-    
+        self.documenter = SchemaDocumenter(
+            "postgres", {"host": "localhost"}, self.config
+        )
+
     @pytest.mark.asyncio
     async def test_document_schema_for_defog(self):
         """Test the utility function for Defog integration."""
-        with patch.object(SchemaDocumenter, '_get_connection'), \
-             patch.object(SchemaDocumenter, '_get_all_tables', return_value=["test_table"]), \
-             patch.object(SchemaDocumenter, '_document_single_table') as mock_doc:
-            
+        with patch.object(SchemaDocumenter, "_get_connection"), patch.object(
+            SchemaDocumenter, "_get_all_tables", return_value=["test_table"]
+        ), patch.object(SchemaDocumenter, "_document_single_table") as mock_doc:
+
             mock_doc.return_value = TableDocumentation("test_table")
-            
+
             result = await document_schema_for_defog(
-                "postgres",
-                {"host": "localhost"},
-                None,
-                self.config
+                "postgres", {"host": "localhost"}, None, self.config
             )
-            
+
             assert "test_table" in result
             assert isinstance(result["test_table"], TableDocumentation)
 
 
 class TestSchemaGeneration:
     """Test integration with schema generation."""
-    
+
     def test_preserve_existing_comments(self):
         """Test that existing comments are preserved."""
         doc = TableDocumentation(
             table_name="users",
             existing_table_comment="Existing table description",
-            existing_column_comments={"id": "Existing column description"}
+            existing_column_comments={"id": "Existing column description"},
         )
-        
+
         # When existing comments exist, new descriptions should not override them
         assert doc.existing_table_comment == "Existing table description"
         assert doc.existing_column_comments["id"] == "Existing column description"

--- a/tests/test_schema_documenter.py
+++ b/tests/test_schema_documenter.py
@@ -1,0 +1,319 @@
+"""Tests for the schema documenter functionality."""
+
+import pytest
+import asyncio
+import os
+from unittest.mock import Mock, patch, MagicMock
+from defog.schema_documenter import (
+    SchemaDocumenter,
+    DocumentationConfig,
+    TableDocumentation,
+    document_schema_for_defog
+)
+
+
+class TestDocumentationConfig:
+    """Test DocumentationConfig class."""
+    
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = DocumentationConfig()
+        assert config.provider == "anthropic"
+        assert config.model == "claude-sonnet-4-20250514"
+        assert config.sample_size == 100
+        assert config.min_confidence_score == 0.7
+        assert config.include_data_patterns is True
+        assert config.dry_run is False
+        assert config.concurrent_requests == 3
+        assert config.rate_limit_delay == 1.0
+
+
+class TestTableDocumentation:
+    """Test TableDocumentation class."""
+    
+    def test_table_documentation_init(self):
+        """Test TableDocumentation initialization."""
+        doc = TableDocumentation("test_table")
+        assert doc.table_name == "test_table"
+        assert doc.table_description is None
+        assert doc.table_confidence == 0.0
+        assert doc.column_descriptions == {}
+        assert doc.column_confidences == {}
+        assert doc.existing_table_comment is None
+        assert doc.existing_column_comments == {}
+
+
+class TestSchemaDocumenter:
+    """Test SchemaDocumenter class."""
+    
+    def test_init_postgres(self):
+        """Test SchemaDocumenter initialization for Postgres."""
+        db_creds = {"host": "localhost", "database": "test"}
+        documenter = SchemaDocumenter("postgres", db_creds)
+        assert documenter.db_type == "postgres"
+        assert documenter.db_creds == db_creds
+        assert isinstance(documenter.config, DocumentationConfig)
+    
+    def test_init_duckdb(self):
+        """Test SchemaDocumenter initialization for DuckDB."""
+        db_creds = {"database": ":memory:"}
+        documenter = SchemaDocumenter("duckdb", db_creds)
+        assert documenter.db_type == "duckdb"
+        assert documenter.db_creds == db_creds
+    
+    def test_init_unsupported_db(self):
+        """Test SchemaDocumenter initialization with unsupported database."""
+        with pytest.raises(ValueError, match="Database type 'mysql' not supported"):
+            SchemaDocumenter("mysql", {})
+    
+    def test_init_unsupported_provider(self):
+        """Test SchemaDocumenter initialization with unsupported LLM provider."""
+        config = DocumentationConfig(provider="unsupported")
+        with pytest.raises(ValueError, match="Unsupported LLM provider"):
+            SchemaDocumenter("postgres", {}, config)
+
+
+class TestPatternAnalysis:
+    """Test data pattern analysis functionality."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+    
+    def test_is_email(self):
+        """Test email pattern detection."""
+        assert self.documenter._is_email("test@example.com") is True
+        assert self.documenter._is_email("user.name+tag@domain.co.uk") is True
+        assert self.documenter._is_email("invalid-email") is False
+        assert self.documenter._is_email("@example.com") is False
+    
+    def test_is_url(self):
+        """Test URL pattern detection."""
+        assert self.documenter._is_url("https://example.com") is True
+        assert self.documenter._is_url("http://sub.domain.com/path?query=1") is True
+        assert self.documenter._is_url("not-a-url") is False
+        assert self.documenter._is_url("ftp://example.com") is False
+    
+    def test_is_uuid(self):
+        """Test UUID pattern detection."""
+        assert self.documenter._is_uuid("123e4567-e89b-12d3-a456-426614174000") is True
+        assert self.documenter._is_uuid("invalid-uuid") is False
+        assert self.documenter._is_uuid("123e4567-e89b-12d3-a456") is False
+    
+    def test_is_phone(self):
+        """Test phone number pattern detection."""
+        assert self.documenter._is_phone("+1234567890") is True
+        assert self.documenter._is_phone("123-456-7890") is True
+        assert self.documenter._is_phone("123") is False
+    
+    def test_analyze_string_patterns(self):
+        """Test string pattern analysis."""
+        # Email data
+        email_data = ["user1@example.com", "user2@test.org", "user3@domain.net"]
+        patterns = self.documenter._analyze_string_patterns(email_data)
+        assert patterns.get("email") is True
+        
+        # Categorical data
+        categorical_data = ["red", "blue", "green", "red", "blue"] * 10
+        patterns = self.documenter._analyze_string_patterns(categorical_data)
+        assert patterns.get("categorical") is True
+        assert "categories" in patterns
+    
+    def test_analyze_numeric_patterns(self):
+        """Test numeric pattern analysis."""
+        # Unique ID-like data
+        id_data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        patterns = self.documenter._analyze_numeric_patterns(id_data)
+        assert patterns.get("unique") is True
+        assert patterns.get("id_like") is True
+    
+    def test_analyze_general_patterns(self):
+        """Test general pattern analysis."""
+        data_with_nulls = ["value1", None, "value2", "", "value3"]
+        patterns = self.documenter._analyze_general_patterns(data_with_nulls)
+        assert "null_percentage" in patterns
+        assert patterns["null_percentage"] == 40.0
+
+
+class TestLLMIntegration:
+    """Test LLM integration functionality."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+    
+    def test_build_documentation_prompt(self):
+        """Test building documentation prompt."""
+        table_name = "users"
+        analysis = {
+            "columns": [
+                {"name": "id", "type": "integer", "nullable": False},
+                {"name": "email", "type": "varchar", "nullable": True}
+            ],
+            "sample_data": {
+                "id": [1, 2, 3],
+                "email": ["user1@example.com", "user2@example.com", None]
+            },
+            "data_patterns": {
+                "id": {"id_like": True},
+                "email": {"email": True}
+            },
+            "row_count": 1000
+        }
+        
+        prompt = self.documenter._build_documentation_prompt(table_name, analysis)
+        assert "users" in prompt
+        assert "1,000" in prompt
+        assert "id (integer, NOT NULL)" in prompt
+        assert "email (varchar, NULL)" in prompt
+        assert "[EMAIL ADDRESSES]" in prompt
+        assert "[ID/SEQUENCE]" in prompt
+    
+    def test_parse_llm_response(self):
+        """Test parsing LLM response."""
+        # Valid JSON response
+        response = '''```json
+        {
+            "table_description": "Stores user account information",
+            "table_confidence": 0.9,
+            "columns": {
+                "id": {
+                    "description": "Unique user identifier",
+                    "confidence": 0.95
+                }
+            }
+        }
+        ```'''
+        
+        result = self.documenter._parse_llm_response(response)
+        assert result["table_description"] == "Stores user account information"
+        assert result["table_confidence"] == 0.9
+        assert "id" in result["columns"]
+        
+        # Invalid JSON response
+        invalid_response = "This is not valid JSON"
+        result = self.documenter._parse_llm_response(invalid_response)
+        assert "error" in result
+        assert result["table_confidence"] == 0.0
+
+
+class TestPostgresComments:
+    """Test Postgres comment functionality."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+    
+    @patch('psycopg2.connect')
+    def test_get_postgres_comments(self, mock_connect):
+        """Test retrieving existing Postgres comments."""
+        # Mock database connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_connect.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+        
+        # Mock table comment query
+        mock_cursor.fetchone.side_effect = [
+            ("Table stores user data",),  # table comment
+        ]
+        
+        # Mock column comments query
+        mock_cursor.fetchall.return_value = [
+            ("id", "User identifier"),
+            ("email", "User email address")
+        ]
+        
+        table_comment, column_comments = self.documenter._get_postgres_comments(
+            mock_conn, "users"
+        )
+        
+        assert table_comment == "Table stores user data"
+        assert column_comments["id"] == "User identifier"
+        assert column_comments["email"] == "User email address"
+    
+    @patch('psycopg2.connect')
+    def test_apply_postgres_comments(self, mock_connect):
+        """Test applying comments to Postgres database."""
+        # Mock database connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_connect.return_value = mock_conn
+        mock_conn.cursor.return_value = mock_cursor
+        
+        # Test table comment
+        success = self.documenter._apply_table_comment(
+            mock_conn, "users", "Stores user information"
+        )
+        assert success is True
+        mock_cursor.execute.assert_called()
+        
+        # Test column comment
+        success = self.documenter._apply_column_comment(
+            mock_conn, "users", "email", "User email address"
+        )
+        assert success is True
+
+
+class TestDuckDBComments:
+    """Test DuckDB comment functionality."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
+    
+    def test_get_duckdb_comments(self):
+        """Test retrieving DuckDB comments (limited support)."""
+        table_comment, column_comments = self.documenter._get_duckdb_comments(
+            None, "test_table"
+        )
+        assert table_comment is None
+        assert column_comments == {}
+
+
+class TestAsyncOperations:
+    """Test async functionality."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.config = DocumentationConfig(dry_run=True)
+        self.documenter = SchemaDocumenter("postgres", {"host": "localhost"}, self.config)
+    
+    @pytest.mark.asyncio
+    async def test_document_schema_for_defog(self):
+        """Test the utility function for Defog integration."""
+        with patch.object(SchemaDocumenter, '_get_connection'), \
+             patch.object(SchemaDocumenter, '_get_all_tables', return_value=["test_table"]), \
+             patch.object(SchemaDocumenter, '_document_single_table') as mock_doc:
+            
+            mock_doc.return_value = TableDocumentation("test_table")
+            
+            result = await document_schema_for_defog(
+                "postgres",
+                {"host": "localhost"},
+                None,
+                self.config
+            )
+            
+            assert "test_table" in result
+            assert isinstance(result["test_table"], TableDocumentation)
+
+
+class TestSchemaGeneration:
+    """Test integration with schema generation."""
+    
+    def test_preserve_existing_comments(self):
+        """Test that existing comments are preserved."""
+        doc = TableDocumentation(
+            table_name="users",
+            existing_table_comment="Existing table description",
+            existing_column_comments={"id": "Existing column description"}
+        )
+        
+        # When existing comments exist, new descriptions should not override them
+        assert doc.existing_table_comment == "Existing table description"
+        assert doc.existing_column_comments["id"] == "Existing column description"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -1,0 +1,273 @@
+"""Security tests to verify SQL injection fixes."""
+
+import pytest
+import logging
+from unittest.mock import Mock, patch
+from defog.schema_documenter import (
+    SchemaDocumenter,
+    DocumentationConfig,
+    _validate_sql_identifier
+)
+
+
+class TestSQLInjectionPrevention:
+    """Test SQL injection prevention measures."""
+    
+    def test_validate_sql_identifier_valid_names(self):
+        """Test that valid identifiers pass validation."""
+        valid_identifiers = [
+            "users",
+            "user_table",
+            "schema1.table1",
+            "Table123",
+            "schema.Table_Name_123"
+        ]
+        
+        for identifier in valid_identifiers:
+            result = _validate_sql_identifier(identifier)
+            assert result == identifier
+    
+    def test_validate_sql_identifier_invalid_names(self):
+        """Test that invalid identifiers are rejected."""
+        invalid_identifiers = [
+            "users; DROP TABLE important_data; --",
+            "users' OR '1'='1",
+            'users" UNION SELECT * FROM passwords --',
+            "users--comment",
+            "users/*comment*/",
+            "users + 1",
+            "users * 2",
+            "users / 1",
+            "users \\ path",
+            "users with spaces",
+            "users\ntab",
+            "users\ttab",
+            "SELECT * FROM users",
+            "DROP TABLE users",
+            "INSERT INTO users",
+            "UPDATE users SET",
+            "DELETE FROM users",
+            "ALTER TABLE users",
+            "CREATE TABLE evil",
+            "EXEC sp_evil",
+            "UNION SELECT",
+        ]
+        
+        for identifier in invalid_identifiers:
+            with pytest.raises(ValueError, match="Invalid SQL identifier|contains invalid pattern"):
+                _validate_sql_identifier(identifier)
+    
+    def test_postgres_get_sample_data_injection_prevention(self):
+        """Test that _get_sample_data prevents SQL injection for Postgres."""
+        documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+        
+        # Mock cursor
+        mock_cursor = Mock()
+        
+        # Test with malicious table name
+        malicious_table = "users; DROP TABLE important_data; --"
+        columns_info = [{"name": "id"}, {"name": "email"}]
+        
+        result = documenter._get_sample_data(mock_cursor, malicious_table, columns_info)
+        
+        # Should return empty data due to validation error
+        assert result == {"id": [], "email": []}
+        
+        # Cursor execute should not have been called with malicious SQL
+        mock_cursor.execute.assert_not_called()
+    
+    def test_duckdb_get_sample_data_injection_prevention(self):
+        """Test that _get_sample_data prevents SQL injection for DuckDB."""
+        documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
+        
+        # Mock cursor
+        mock_cursor = Mock()
+        
+        # Test with malicious table name
+        malicious_table = "users; DROP TABLE important_data; --"
+        columns_info = [{"name": "id"}, {"name": "email"}]
+        
+        result = documenter._get_sample_data(mock_cursor, malicious_table, columns_info)
+        
+        # Should return empty data due to validation error
+        assert result == {"id": [], "email": []}
+        
+        # Cursor execute should not have been called with malicious SQL
+        mock_cursor.execute.assert_not_called()
+    
+    def test_duckdb_get_columns_injection_prevention(self):
+        """Test that _get_duckdb_columns prevents SQL injection."""
+        documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
+        
+        # Mock cursor
+        mock_cursor = Mock()
+        
+        # Test with malicious table name
+        malicious_table = "users; DROP TABLE important_data; --"
+        
+        result = documenter._get_duckdb_columns(mock_cursor, malicious_table)
+        
+        # Should return empty list due to validation error
+        assert result == []
+        
+        # Cursor execute should not have been called with malicious SQL
+        mock_cursor.execute.assert_not_called()
+    
+    def test_get_row_count_injection_prevention(self):
+        """Test that _get_row_count prevents SQL injection."""
+        documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+        
+        # Mock connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        
+        # Test with malicious table name
+        malicious_table = "users; DROP TABLE important_data; --"
+        
+        result = documenter._get_row_count(mock_conn, malicious_table)
+        
+        # Should return 0 due to validation error
+        assert result == 0
+    
+    def test_apply_table_comment_injection_prevention(self):
+        """Test that _apply_table_comment prevents SQL injection."""
+        documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+        
+        # Mock connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        
+        # Test with malicious table name
+        malicious_table = "users; DROP TABLE important_data; --"
+        description = "Safe description"
+        
+        result = documenter._apply_table_comment(mock_conn, malicious_table, description)
+        
+        # Should return False due to validation error
+        assert result is False
+        
+        # Cursor execute should not have been called with malicious SQL
+        mock_cursor.execute.assert_not_called()
+    
+    def test_apply_column_comment_injection_prevention(self):
+        """Test that _apply_column_comment prevents SQL injection."""
+        documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+        
+        # Mock connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        
+        # Test with malicious table and column names
+        malicious_table = "users; DROP TABLE important_data; --"
+        malicious_column = "id; DROP TABLE passwords; --"
+        description = "Safe description"
+        
+        result = documenter._apply_column_comment(mock_conn, malicious_table, malicious_column, description)
+        
+        # Should return False due to validation error
+        assert result is False
+        
+        # Cursor execute should not have been called with malicious SQL
+        mock_cursor.execute.assert_not_called()
+    
+    def test_safe_identifiers_work_correctly(self):
+        """Test that safe identifiers work correctly after validation."""
+        documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+        
+        # Mock connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchone.return_value = (42,)
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        
+        # Test with safe table name
+        safe_table = "users"
+        
+        result = documenter._get_row_count(mock_conn, safe_table)
+        
+        # Should work correctly
+        assert result == 42
+        
+        # Cursor execute should have been called with properly quoted identifier
+        mock_cursor.execute.assert_called_once()
+        call_args = mock_cursor.execute.call_args[0][0]
+        assert 'SELECT COUNT(*) FROM "users"' == call_args
+    
+    def test_schema_table_format_validation(self):
+        """Test that schema.table format is handled safely."""
+        documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+        
+        # Mock connection and cursor
+        mock_conn = Mock()
+        mock_cursor = Mock()
+        mock_cursor.fetchone.return_value = (100,)
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        
+        # Test with safe schema.table format
+        safe_table = "public.users"
+        
+        result = documenter._get_row_count(mock_conn, safe_table)
+        
+        # Should work correctly
+        assert result == 100
+        
+        # Cursor execute should have been called with properly quoted identifiers
+        mock_cursor.execute.assert_called_once()
+        call_args = mock_cursor.execute.call_args[0][0]
+        assert 'SELECT COUNT(*) FROM "public"."users"' == call_args
+
+
+class TestParameterizedQueries:
+    """Test that parameterized queries are used where possible."""
+    
+    def test_sample_data_uses_parameterized_limit(self):
+        """Test that sample data query uses parameterized limit."""
+        documenter = SchemaDocumenter("postgres", {"host": "localhost"})
+        
+        # Mock cursor
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [(1, "user1@example.com")]
+        
+        columns_info = [{"name": "id"}, {"name": "email"}]
+        
+        result = documenter._get_sample_data(mock_cursor, "users", columns_info)
+        
+        # Should have called execute with parameterized query
+        mock_cursor.execute.assert_called_once()
+        call_args = mock_cursor.execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        
+        # Query should contain parameter placeholder
+        assert "LIMIT %s" in query
+        # Parameters should contain the sample size
+        assert params == (documenter.config.sample_size,)
+    
+    def test_duckdb_columns_uses_parameterized_query(self):
+        """Test that DuckDB column query uses parameters."""
+        documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
+        
+        # Mock cursor
+        mock_cursor = Mock()
+        mock_cursor.fetchall.return_value = [("id", "INTEGER", "NO", None)]
+        
+        result = documenter._get_duckdb_columns(mock_cursor, "users")
+        
+        # Should have called execute with parameterized query
+        mock_cursor.execute.assert_called_once()
+        call_args = mock_cursor.execute.call_args
+        query = call_args[0][0]
+        params = call_args[0][1]
+        
+        # Query should contain parameter placeholders
+        assert "table_name = ?" in query
+        assert "table_schema = ?" in query
+        # Parameters should contain the table name and schema
+        assert params == ("users", "main")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_write_security.py
+++ b/tests/test_write_security.py
@@ -2,15 +2,12 @@
 
 import pytest
 from unittest.mock import Mock
-from defog.schema_documenter import (
-    SchemaDocumenter,
-    _validate_sql_identifier
-)
+from defog.schema_documenter import SchemaDocumenter, _validate_sql_identifier
 
 
 class TestSQLInjectionPrevention:
     """Test SQL injection prevention measures."""
-    
+
     def test_validate_sql_identifier_valid_names(self):
         """Test that valid identifiers pass validation."""
         valid_identifiers = [
@@ -30,11 +27,11 @@ class TestSQLInjectionPrevention:
             "my_table_123",
             '"my drop table"',
         ]
-        
+
         for identifier in valid_identifiers:
             result = _validate_sql_identifier(identifier)
             assert result == identifier
-    
+
     def test_validate_sql_identifier_invalid_names(self):
         """Test that invalid identifiers are rejected."""
         invalid_identifiers = [
@@ -60,186 +57,192 @@ class TestSQLInjectionPrevention:
             "EXEC sp_evil",
             "UNION SELECT",
         ]
-        
+
         for identifier in invalid_identifiers:
-            with pytest.raises(ValueError, match="Invalid SQL identifier|contains invalid pattern"):
+            with pytest.raises(
+                ValueError, match="Invalid SQL identifier|contains invalid pattern"
+            ):
                 _validate_sql_identifier(identifier)
-    
+
     def test_validate_sql_identifier_length_limit(self):
         """Test that overly long identifiers are rejected."""
         # Test identifier at the limit (255 bytes)
         max_length_identifier = "a" * 255
         result = _validate_sql_identifier(max_length_identifier)
         assert result == max_length_identifier
-        
+
         # Test identifier over the limit
         too_long_identifier = "a" * 256
         with pytest.raises(ValueError, match="SQL identifier too long"):
             _validate_sql_identifier(too_long_identifier)
-        
+
         # Test quoted identifier over the limit
         too_long_quoted = '"' + "a" * 254 + '"'
         with pytest.raises(ValueError, match="SQL identifier too long"):
             _validate_sql_identifier(too_long_quoted)
-        
+
         # Test UTF-8 multi-byte characters
         # Each emoji is 4 bytes, so 64 emojis = 256 bytes
         emoji_identifier = "🎉" * 64
         with pytest.raises(ValueError, match="SQL identifier too long"):
             _validate_sql_identifier(emoji_identifier)
-    
+
     def test_validate_sql_identifier_zero_width_chars(self):
         """Test that zero-width and invisible characters are rejected."""
         # Zero-width space
         with pytest.raises(ValueError, match="invisible/zero-width characters"):
             _validate_sql_identifier("users\u200btable")
-        
+
         # Zero-width non-joiner
         with pytest.raises(ValueError, match="invisible/zero-width characters"):
             _validate_sql_identifier("users\u200ctable")
-        
+
         # Zero-width joiner
         with pytest.raises(ValueError, match="invisible/zero-width characters"):
             _validate_sql_identifier("users\u200dtable")
-        
+
         # Zero-width no-break space (BOM)
         with pytest.raises(ValueError, match="invisible/zero-width characters"):
             _validate_sql_identifier("\ufeffusers")
-        
+
         # Word joiner
         with pytest.raises(ValueError, match="invisible/zero-width characters"):
             _validate_sql_identifier("users\u2060table")
-        
+
         # Also test in quoted identifiers
         with pytest.raises(ValueError, match="invisible/zero-width characters"):
             _validate_sql_identifier('"users\u200btable"')
-    
+
     def test_postgres_get_sample_data_injection_prevention(self):
         """Test that _get_sample_data prevents SQL injection for Postgres."""
         documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-        
+
         # Mock cursor
         mock_cursor = Mock()
-        
+
         # Test with malicious table name
         malicious_table = "users; DROP TABLE important_data; --"
         columns_info = [{"name": "id"}, {"name": "email"}]
-        
+
         result = documenter._get_sample_data(mock_cursor, malicious_table, columns_info)
-        
+
         # Should return empty data due to validation error
         assert result == {"id": [], "email": []}
-        
+
         # Cursor execute should not have been called with malicious SQL
         mock_cursor.execute.assert_not_called()
-    
+
     def test_duckdb_get_sample_data_injection_prevention(self):
         """Test that _get_sample_data prevents SQL injection for DuckDB."""
         documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
-        
+
         # Mock cursor
         mock_cursor = Mock()
-        
+
         # Test with malicious table name
         malicious_table = "users; DROP TABLE important_data; --"
         columns_info = [{"name": "id"}, {"name": "email"}]
-        
+
         result = documenter._get_sample_data(mock_cursor, malicious_table, columns_info)
-        
+
         # Should return empty data due to validation error
         assert result == {"id": [], "email": []}
-        
+
         # Cursor execute should not have been called with malicious SQL
         mock_cursor.execute.assert_not_called()
-    
+
     def test_duckdb_get_columns_injection_prevention(self):
         """Test that _get_duckdb_columns prevents SQL injection."""
         documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
-        
+
         # Mock cursor
         mock_cursor = Mock()
-        
+
         # Test with malicious table name
         malicious_table = "users; DROP TABLE important_data; --"
-        
+
         result = documenter._get_duckdb_columns(mock_cursor, malicious_table)
-        
+
         # Should return empty list due to validation error
         assert result == []
-        
+
         # Cursor execute should not have been called with malicious SQL
         mock_cursor.execute.assert_not_called()
-    
+
     def test_get_row_count_injection_prevention(self):
         """Test that _get_row_count prevents SQL injection."""
         documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-        
+
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=None)
-        
+
         # Test with malicious table name
         malicious_table = "users; DROP TABLE important_data; --"
-        
+
         result = documenter._get_row_count(mock_conn, malicious_table)
-        
+
         # Should return 0 due to validation error
         assert result == 0
-    
+
     def test_apply_table_comment_injection_prevention(self):
         """Test that _apply_table_comment prevents SQL injection."""
         documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-        
+
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=None)
-        
+
         # Test with malicious table name
         malicious_table = "users; DROP TABLE important_data; --"
         description = "Safe description"
-        
-        result = documenter._apply_table_comment(mock_conn, malicious_table, description)
-        
+
+        result = documenter._apply_table_comment(
+            mock_conn, malicious_table, description
+        )
+
         # Should return False due to validation error
         assert result is False
-        
+
         # Cursor execute should not have been called with malicious SQL
         mock_cursor.execute.assert_not_called()
-    
+
     def test_apply_column_comment_injection_prevention(self):
         """Test that _apply_column_comment prevents SQL injection."""
         documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-        
+
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=None)
-        
+
         # Test with malicious table and column names
         malicious_table = "users; DROP TABLE important_data; --"
         malicious_column = "id; DROP TABLE passwords; --"
         description = "Safe description"
-        
-        result = documenter._apply_column_comment(mock_conn, malicious_table, malicious_column, description)
-        
+
+        result = documenter._apply_column_comment(
+            mock_conn, malicious_table, malicious_column, description
+        )
+
         # Should return False due to validation error
         assert result is False
-        
+
         # Cursor execute should not have been called with malicious SQL
         mock_cursor.execute.assert_not_called()
-    
+
     def test_safe_identifiers_work_correctly(self):
         """Test that safe identifiers work correctly after validation."""
         documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-        
+
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
@@ -247,24 +250,24 @@ class TestSQLInjectionPrevention:
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=None)
-        
+
         # Test with safe table name
         safe_table = "users"
-        
+
         result = documenter._get_row_count(mock_conn, safe_table)
-        
+
         # Should work correctly
         assert result == 42
-        
+
         # Cursor execute should have been called with properly quoted identifier
         mock_cursor.execute.assert_called_once()
         call_args = mock_cursor.execute.call_args[0][0]
         assert 'SELECT COUNT(*) FROM "users"' == call_args
-    
+
     def test_schema_table_format_validation(self):
         """Test that schema.table format is handled safely."""
         documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-        
+
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
@@ -272,15 +275,15 @@ class TestSQLInjectionPrevention:
         mock_conn.cursor.return_value = mock_cursor
         mock_cursor.__enter__ = Mock(return_value=mock_cursor)
         mock_cursor.__exit__ = Mock(return_value=None)
-        
+
         # Test with safe schema.table format
         safe_table = "public.users"
-        
+
         result = documenter._get_row_count(mock_conn, safe_table)
-        
+
         # Should work correctly
         assert result == 100
-        
+
         # Cursor execute should have been called with properly quoted identifiers
         mock_cursor.execute.assert_called_once()
         call_args = mock_cursor.execute.call_args[0][0]
@@ -289,46 +292,46 @@ class TestSQLInjectionPrevention:
 
 class TestParameterizedQueries:
     """Test that parameterized queries are used where possible."""
-    
+
     def test_sample_data_uses_parameterized_limit(self):
         """Test that sample data query uses parameterized limit."""
         documenter = SchemaDocumenter("postgres", {"host": "localhost"})
-        
+
         # Mock cursor
         mock_cursor = Mock()
         mock_cursor.fetchall.return_value = [(1, "user1@example.com")]
-        
+
         columns_info = [{"name": "id"}, {"name": "email"}]
-        
+
         result = documenter._get_sample_data(mock_cursor, "users", columns_info)
-        
+
         # Should have called execute with parameterized query
         mock_cursor.execute.assert_called_once()
         call_args = mock_cursor.execute.call_args
         query = call_args[0][0]
         params = call_args[0][1]
-        
+
         # Query should contain parameter placeholder
         assert "LIMIT %s" in query
         # Parameters should contain the sample size
         assert params == (documenter.config.sample_size,)
-    
+
     def test_duckdb_columns_uses_parameterized_query(self):
         """Test that DuckDB column query uses parameters."""
         documenter = SchemaDocumenter("duckdb", {"database": ":memory:"})
-        
+
         # Mock cursor
         mock_cursor = Mock()
         mock_cursor.fetchall.return_value = [("id", "INTEGER", "NO", None)]
-        
+
         result = documenter._get_duckdb_columns(mock_cursor, "users")
-        
+
         # Should have called execute with parameterized query
         mock_cursor.execute.assert_called_once()
         call_args = mock_cursor.execute.call_args
         query = call_args[0][0]
         params = call_args[0][1]
-        
+
         # Query should contain parameter placeholders
         assert "table_name = ?" in query
         assert "table_schema = ?" in query

--- a/tests/test_write_security.py
+++ b/tests/test_write_security.py
@@ -1,11 +1,9 @@
 """Security tests to verify SQL injection fixes."""
 
 import pytest
-import logging
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 from defog.schema_documenter import (
     SchemaDocumenter,
-    DocumentationConfig,
     _validate_sql_identifier
 )
 
@@ -20,7 +18,17 @@ class TestSQLInjectionPrevention:
             "user_table",
             "schema1.table1",
             "Table123",
-            "schema.Table_Name_123"
+            "schema.Table_Name_123",
+            "customer_updates",
+            "dropshipments",
+            "drop_update",
+            '"My Table"',
+            "my_table",
+            "my_drop_table",
+            "my_table_123",
+            "my_drop_table_123",
+            "my_table_123",
+            '"my drop table"',
         ]
         
         for identifier in valid_identifiers:
@@ -120,7 +128,9 @@ class TestSQLInjectionPrevention:
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
-        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = Mock(return_value=None)
         
         # Test with malicious table name
         malicious_table = "users; DROP TABLE important_data; --"
@@ -137,7 +147,9 @@ class TestSQLInjectionPrevention:
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
-        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = Mock(return_value=None)
         
         # Test with malicious table name
         malicious_table = "users; DROP TABLE important_data; --"
@@ -158,7 +170,9 @@ class TestSQLInjectionPrevention:
         # Mock connection and cursor
         mock_conn = Mock()
         mock_cursor = Mock()
-        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = Mock(return_value=None)
         
         # Test with malicious table and column names
         malicious_table = "users; DROP TABLE important_data; --"
@@ -181,7 +195,9 @@ class TestSQLInjectionPrevention:
         mock_conn = Mock()
         mock_cursor = Mock()
         mock_cursor.fetchone.return_value = (42,)
-        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = Mock(return_value=None)
         
         # Test with safe table name
         safe_table = "users"
@@ -204,7 +220,9 @@ class TestSQLInjectionPrevention:
         mock_conn = Mock()
         mock_cursor = Mock()
         mock_cursor.fetchone.return_value = (100,)
-        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_conn.cursor.return_value = mock_cursor
+        mock_cursor.__enter__ = Mock(return_value=mock_cursor)
+        mock_cursor.__exit__ = Mock(return_value=None)
         
         # Test with safe schema.table format
         safe_table = "public.users"


### PR DESCRIPTION
Implements issue #113 refinements:

## Summary

✅ **Don't overwrite existing table/column comments** - System preserves all existing comments
✅ **Include table comments in schema generation** - Enhanced schema output with table descriptions

## Key Features

**Comment Preservation:**
- Automatically detects existing table and column comments before LLM generation
- Only applies LLM descriptions where no existing comments exist
- Ensures manual documentation is never lost

**Table Comments Integration:**
- Enhanced Postgres schema generation to retrieve and include table comments
- Modified schema structure to include table_description field alongside columns
- Updated DuckDB schema generation for consistency

## Usage

```python
# Enable with existing Defog workflow
schema = defog.generate_db_schema(
    tables=[], 
    self_document=True,
    documentation_config={"min_confidence_score": 0.8}
)
```

Generated with [Claude Code](https://claude.ai/code)