### PR TITLE
Add configurable reasoning_effort parameter to agent orchestrator

### DIFF
--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -51,7 +51,7 @@ class AnthropicProvider(BaseLLMProvider):
         else:
             sys_msg = ""
 
-        if reasoning_effort is not None:
+        if reasoning_effort is not None and ("3-7" in model or "-4-" in model):
             temperature = 1.0
             if reasoning_effort == "low":
                 thinking = {


### PR DESCRIPTION
## Summary
- Add configurable `reasoning_effort` parameter to both main agent and subagents in the orchestrator
- Default reasoning effort is set to "medium" for both Agent and AgentOrchestrator classes

## Changes Made
- **Agent class**: Added `reasoning_effort` parameter with default value "medium"
- **AgentOrchestrator class**: Added `reasoning_effort` parameter with default value "medium"  
- **Main agent chat calls**: Pass `reasoning_effort` to all `chat_async` calls in the Agent.process method
- **Planning LLM calls**: Pass `reasoning_effort` to planning chat_async calls
- **Task decomposition calls**: Pass `reasoning_effort` to decomposition chat_async calls
- **Subagent creation**: Created subagents inherit the orchestrator's `reasoning_effort` setting

## Test plan
- [x] Existing orchestrator tests pass
- [x] Linting passes
- [x] Backward compatibility maintained (existing code works with new defaults)
- [x] New reasoning_effort parameter can be configured for both main agent and orchestrator
- [x] Subagents automatically inherit the orchestrator's reasoning_effort setting