### PR TITLE
Add verbose parameter to defog.llm tools for optional rich logging

### DIFF
--- a/defog/llm/citations.py
+++ b/defog/llm/citations.py
@@ -1,5 +1,5 @@
 from defog.llm.llm_providers import LLMProvider
-from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger
+from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger, NoOpToolProgressTracker, NoOpSubTaskLogger
 import os
 import asyncio
 
@@ -36,166 +36,170 @@ async def citations_tool(
     model: str,
     provider: LLMProvider,
     max_tokens: int = 16000,
+    verbose: bool = True,
 ):
     """
     Use this tool to get an answer to a well-cited answer to a question,
     given a list of documents.
     """
-    async with ToolProgressTracker(
+    tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
+    logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
+    
+    async with tracker_class(
         "Citations Tool", f"Generating citations for {len(documents)} documents"
     ) as tracker:
-        subtask_logger = SubTaskLogger()
+        subtask_logger = logger_class()
         subtask_logger.log_provider_info(
             provider.value if hasattr(provider, "value") else str(provider), model
         )
 
-    if provider in [LLMProvider.OPENAI, LLMProvider.OPENAI.value]:
-        from openai import AsyncOpenAI
+        if provider in [LLMProvider.OPENAI, LLMProvider.OPENAI.value]:
+            from openai import AsyncOpenAI
 
-        client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+            client = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
-        # create an ephemeral vector store
-        store = await client.vector_stores.create()
-        store_id = store.id
+            # create an ephemeral vector store
+            store = await client.vector_stores.create()
+            store_id = store.id
 
-        # Upload all documents in parallel
-        tracker.update(10, "Uploading documents to vector store")
-        subtask_logger.log_subtask("Starting document uploads", "processing")
+            # Upload all documents in parallel
+            tracker.update(10, "Uploading documents to vector store")
+            subtask_logger.log_subtask("Starting document uploads", "processing")
 
-        upload_tasks = []
-        for idx, document in enumerate(documents, 1):
-            subtask_logger.log_document_upload(
-                document["document_name"], idx, len(documents)
-            )
-            upload_tasks.append(
-                upload_document_to_openai_vector_store(document, store_id)
-            )
+            upload_tasks = []
+            for idx, document in enumerate(documents, 1):
+                subtask_logger.log_document_upload(
+                    document["document_name"], idx, len(documents)
+                )
+                upload_tasks.append(
+                    upload_document_to_openai_vector_store(document, store_id)
+                )
 
-        await asyncio.gather(*upload_tasks)
-        tracker.update(40, "Documents uploaded")
+            await asyncio.gather(*upload_tasks)
+            tracker.update(40, "Documents uploaded")
 
-        # keep polling until the vector store is ready
-        is_ready = False
-        while not is_ready:
-            store = await client.vector_stores.files.list(vector_store_id=store_id)
-            total_completed = sum(
-                1 for file in store.data if file.status == "completed"
-            )
-            is_ready = total_completed == len(documents)
+            # keep polling until the vector store is ready
+            is_ready = False
+            while not is_ready:
+                store = await client.vector_stores.files.list(vector_store_id=store_id)
+                total_completed = sum(
+                    1 for file in store.data if file.status == "completed"
+                )
+                is_ready = total_completed == len(documents)
 
-            # Update progress based on indexing status
-            progress = 40 + (total_completed / len(documents) * 40)  # 40-80% range
-            tracker.update(
-                progress, f"Indexing {total_completed}/{len(documents)} files"
-            )
-            subtask_logger.log_vector_store_status(total_completed, len(documents))
+                # Update progress based on indexing status
+                progress = 40 + (total_completed / len(documents) * 40)  # 40-80% range
+                tracker.update(
+                    progress, f"Indexing {total_completed}/{len(documents)} files"
+                )
+                subtask_logger.log_vector_store_status(total_completed, len(documents))
 
-            if not is_ready:
-                await asyncio.sleep(1)
+                if not is_ready:
+                    await asyncio.sleep(1)
 
-        # get the answer
-        tracker.update(80, "Generating citations")
-        subtask_logger.log_subtask("Querying with file search", "processing")
+            # get the answer
+            tracker.update(80, "Generating citations")
+            subtask_logger.log_subtask("Querying with file search", "processing")
 
-        response = await client.responses.create(
-            model=model,
-            input=question,
-            tools=[
-                {
-                    "type": "file_search",
-                    "vector_store_ids": [store_id],
-                }
-            ],
-            tool_choice="required",
-            instructions=instructions,
-            max_output_tokens=max_tokens,
-        )
-
-        # convert the response to a list of blocks
-        # similar to a subset of the Anthropic citations API
-        blocks = []
-        for part in response.output:
-            if part.type == "message":
-                contents = part.content
-                for item in contents:
-                    if item.type == "output_text":
-                        blocks.append(
-                            {
-                                "text": item.text,
-                                "type": "text",
-                                "citations": [
-                                    {"document_title": i.filename}
-                                    for i in item.annotations
-                                ],
-                            }
-                        )
-        tracker.update(95, "Processing results")
-        subtask_logger.log_result_summary(
-            "Citations",
-            {"blocks_generated": len(blocks), "documents_processed": len(documents)},
-        )
-
-        return blocks
-
-    elif provider in [LLMProvider.ANTHROPIC, LLMProvider.ANTHROPIC.value]:
-        from anthropic import AsyncAnthropic
-
-        client = AsyncAnthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
-
-        document_contents = []
-        for document in documents:
-            document_contents.append(
-                {
-                    "type": "document",
-                    "source": {
-                        "type": "text",
-                        "media_type": "text/plain",
-                        "data": document["document_content"],
-                    },
-                    "title": document["document_name"],
-                    "citations": {"enabled": True},
-                }
-            )
-
-        # Create content messages with citations enabled for individual tool calls
-        tracker.update(50, "Preparing document contents")
-        subtask_logger.log_subtask(
-            f"Processing {len(documents)} documents for Anthropic", "processing"
-        )
-
-        messages = [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": question},
-                    # Add all individual document contents
-                    *document_contents,
+            response = await client.responses.create(
+                model=model,
+                input=question,
+                tools=[
+                    {
+                        "type": "file_search",
+                        "vector_store_ids": [store_id],
+                    }
                 ],
-            }
-        ]
+                tool_choice="required",
+                instructions=instructions,
+                max_output_tokens=max_tokens,
+            )
 
-        tracker.update(70, "Generating citations")
-        subtask_logger.log_subtask("Calling Anthropic API with citations", "processing")
+            # convert the response to a list of blocks
+            # similar to a subset of the Anthropic citations API
+            blocks = []
+            for part in response.output:
+                if part.type == "message":
+                    contents = part.content
+                    for item in contents:
+                        if item.type == "output_text":
+                            blocks.append(
+                                {
+                                    "text": item.text,
+                                    "type": "text",
+                                    "citations": [
+                                        {"document_title": i.filename}
+                                        for i in item.annotations
+                                    ],
+                                }
+                            )
+            tracker.update(95, "Processing results")
+            subtask_logger.log_result_summary(
+                "Citations",
+                {"blocks_generated": len(blocks), "documents_processed": len(documents)},
+            )
 
-        response = await client.messages.create(
-            model=model,
-            messages=messages,
-            system=instructions,
-            max_tokens=max_tokens,
-        )
+            return blocks
 
-        tracker.update(90, "Processing results")
-        response_with_citations = [item.to_dict() for item in response.content]
+        elif provider in [LLMProvider.ANTHROPIC, LLMProvider.ANTHROPIC.value]:
+            from anthropic import AsyncAnthropic
 
-        subtask_logger.log_result_summary(
-            "Citations",
-            {
-                "content_blocks": len(response_with_citations),
-                "documents_processed": len(documents),
-            },
-        )
+            client = AsyncAnthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
 
-        return response_with_citations
+            document_contents = []
+            for document in documents:
+                document_contents.append(
+                    {
+                        "type": "document",
+                        "source": {
+                            "type": "text",
+                            "media_type": "text/plain",
+                            "data": document["document_content"],
+                        },
+                        "title": document["document_name"],
+                        "citations": {"enabled": True},
+                    }
+                )
 
-    # This else is outside the context manager, move it inside
-    raise ValueError(f"Provider {provider} not supported for citations tool")
+            # Create content messages with citations enabled for individual tool calls
+            tracker.update(50, "Preparing document contents")
+            subtask_logger.log_subtask(
+                f"Processing {len(documents)} documents for Anthropic", "processing"
+            )
+
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": question},
+                        # Add all individual document contents
+                        *document_contents,
+                    ],
+                }
+            ]
+
+            tracker.update(70, "Generating citations")
+            subtask_logger.log_subtask("Calling Anthropic API with citations", "processing")
+
+            response = await client.messages.create(
+                model=model,
+                messages=messages,
+                system=instructions,
+                max_tokens=max_tokens,
+            )
+
+            tracker.update(90, "Processing results")
+            response_with_citations = [item.to_dict() for item in response.content]
+
+            subtask_logger.log_result_summary(
+                "Citations",
+                {
+                    "content_blocks": len(response_with_citations),
+                    "documents_processed": len(documents),
+                },
+            )
+
+            return response_with_citations
+
+        else:
+            raise ValueError(f"Provider {provider} not supported for citations tool")

--- a/defog/llm/citations.py
+++ b/defog/llm/citations.py
@@ -1,5 +1,10 @@
 from defog.llm.llm_providers import LLMProvider
-from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger, NoOpToolProgressTracker, NoOpSubTaskLogger
+from defog.llm.utils_logging import (
+    ToolProgressTracker,
+    SubTaskLogger,
+    NoOpToolProgressTracker,
+    NoOpSubTaskLogger,
+)
 import os
 import asyncio
 
@@ -44,7 +49,7 @@ async def citations_tool(
     """
     tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
     logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
-    
+
     async with tracker_class(
         "Citations Tool", f"Generating citations for {len(documents)} documents"
     ) as tracker:
@@ -136,7 +141,10 @@ async def citations_tool(
             tracker.update(95, "Processing results")
             subtask_logger.log_result_summary(
                 "Citations",
-                {"blocks_generated": len(blocks), "documents_processed": len(documents)},
+                {
+                    "blocks_generated": len(blocks),
+                    "documents_processed": len(documents),
+                },
             )
 
             return blocks
@@ -179,7 +187,9 @@ async def citations_tool(
             ]
 
             tracker.update(70, "Generating citations")
-            subtask_logger.log_subtask("Calling Anthropic API with citations", "processing")
+            subtask_logger.log_subtask(
+                "Calling Anthropic API with citations", "processing"
+            )
 
             response = await client.messages.create(
                 model=model,

--- a/defog/llm/code_interp.py
+++ b/defog/llm/code_interp.py
@@ -1,5 +1,10 @@
 from defog.llm.llm_providers import LLMProvider
-from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger, NoOpToolProgressTracker, NoOpSubTaskLogger
+from defog.llm.utils_logging import (
+    ToolProgressTracker,
+    SubTaskLogger,
+    NoOpToolProgressTracker,
+    NoOpSubTaskLogger,
+)
 import os
 from io import BytesIO
 
@@ -17,7 +22,7 @@ async def code_interpreter_tool(
     """
     tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
     logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
-    
+
     async with tracker_class(
         "Code Interpreter",
         f"Executing code to answer: {question[:50]}{'...' if len(question) > 50 else ''}",

--- a/defog/llm/orchestrator.py
+++ b/defog/llm/orchestrator.py
@@ -128,7 +128,7 @@ class Agent:
 
         # Merge kwargs
         call_kwargs = {**self.kwargs, **kwargs}
-        
+
         # Add reasoning_effort if not already specified in kwargs
         if "reasoning_effort" not in call_kwargs and self.reasoning_effort:
             call_kwargs["reasoning_effort"] = self.reasoning_effort

--- a/defog/llm/sql.py
+++ b/defog/llm/sql.py
@@ -4,7 +4,12 @@ SQL execution tools for local database operations.
 
 from typing import Dict, List, Optional, Any, Union, Tuple
 from defog.llm.llm_providers import LLMProvider
-from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger, NoOpToolProgressTracker, NoOpSubTaskLogger
+from defog.llm.utils_logging import (
+    ToolProgressTracker,
+    SubTaskLogger,
+    NoOpToolProgressTracker,
+    NoOpSubTaskLogger,
+)
 from defog.llm.sql_generator import generate_sql_query_local
 from defog.local_metadata_extractor import extract_metadata_from_db
 from defog.query import async_execute_query
@@ -58,7 +63,7 @@ async def sql_answer_tool(
     """
     tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
     logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
-    
+
     async with tracker_class(
         "SQL Query Answer",
         f"Answering: {question[:50]}{'...' if len(question) > 50 else ''}",
@@ -211,7 +216,7 @@ async def identify_relevant_tables_tool(
     """
     tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
     logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
-    
+
     async with tracker_class(
         "Table Relevance Analysis",
         f"Finding relevant tables for: {question[:50]}{'...' if len(question) > 50 else ''}",

--- a/defog/llm/utils_logging.py
+++ b/defog/llm/utils_logging.py
@@ -499,3 +499,47 @@ class SubTaskLogger:
                     padding=(1, 2),
                 )
             )
+
+
+class NoOpToolProgressTracker:
+    """No-op version of ToolProgressTracker for when verbose=False."""
+
+    def __init__(self, tool_name: str = "", description: str = ""):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    def update(self, progress: float, description: str = None):
+        pass
+
+
+class NoOpSubTaskLogger:
+    """No-op version of SubTaskLogger for when verbose=False."""
+
+    def __init__(self):
+        pass
+
+    def log_subtask(self, message: str, status: str = "info"):
+        pass
+
+    def log_provider_info(self, provider: str, model: str):
+        pass
+
+    def log_document_upload(self, doc_name: str, doc_index: int, total_docs: int):
+        pass
+
+    def log_vector_store_status(self, completed: int, total: int):
+        pass
+
+    def log_search_status(self, query: str, max_results: int = None):
+        pass
+
+    def log_code_execution(self, language: str = "python"):
+        pass
+
+    def log_result_summary(self, result_type: str, details: Dict[str, Any] = None):
+        pass

--- a/defog/llm/web_search.py
+++ b/defog/llm/web_search.py
@@ -1,5 +1,10 @@
 from defog.llm.llm_providers import LLMProvider
-from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger, NoOpToolProgressTracker, NoOpSubTaskLogger
+from defog.llm.utils_logging import (
+    ToolProgressTracker,
+    SubTaskLogger,
+    NoOpToolProgressTracker,
+    NoOpSubTaskLogger,
+)
 import os
 
 
@@ -15,7 +20,7 @@ async def web_search_tool(
     """
     tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
     logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
-    
+
     async with tracker_class(
         "Web Search",
         f"Searching for: {question[:50]}{'...' if len(question) > 50 else ''}",

--- a/defog/llm/web_search.py
+++ b/defog/llm/web_search.py
@@ -1,5 +1,5 @@
 from defog.llm.llm_providers import LLMProvider
-from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger
+from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger, NoOpToolProgressTracker, NoOpSubTaskLogger
 import os
 
 
@@ -8,15 +8,19 @@ async def web_search_tool(
     model: str,
     provider: LLMProvider,
     max_tokens: int = 2048,
+    verbose: bool = True,
 ):
     """
     Search the web for the answer to the question.
     """
-    async with ToolProgressTracker(
+    tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
+    logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
+    
+    async with tracker_class(
         "Web Search",
         f"Searching for: {question[:50]}{'...' if len(question) > 50 else ''}",
     ) as tracker:
-        subtask_logger = SubTaskLogger()
+        subtask_logger = logger_class()
         subtask_logger.log_provider_info(
             provider.value if hasattr(provider, "value") else str(provider), model
         )

--- a/defog/llm/youtube.py
+++ b/defog/llm/youtube.py
@@ -1,5 +1,10 @@
 # converts a youtube video to a detailed, ideally diarized transcript
-from defog.llm.utils_logging import ToolProgressTracker, SubTaskLogger, NoOpToolProgressTracker, NoOpSubTaskLogger
+from defog.llm.utils_logging import (
+    ToolProgressTracker,
+    SubTaskLogger,
+    NoOpToolProgressTracker,
+    NoOpSubTaskLogger,
+)
 import os
 import re
 from urllib.parse import urlparse
@@ -42,7 +47,7 @@ async def get_youtube_summary(
     """
     tracker_class = ToolProgressTracker if verbose else NoOpToolProgressTracker
     logger_class = SubTaskLogger if verbose else NoOpSubTaskLogger
-    
+
     async with tracker_class(
         "YouTube Transcript",
         f"Transcribing video from: {video_url[:50]}{'...' if len(video_url) > 50 else ''}",

--- a/examples/orchestrator_dynamic_example.py
+++ b/examples/orchestrator_dynamic_example.py
@@ -39,7 +39,8 @@ async def web_search(input: WebSearchInput) -> Dict[str, Any]:
     result = await web_search_tool(
         question=input.query,
         model="gpt-4.1",
-        provider="openai"
+        provider="openai",
+        verbose=False
     )
     return {
         "content": result.get("content", ""),
@@ -58,7 +59,8 @@ async def execute_python(input: CodeExecutionInput) -> Dict[str, Any]:
         model="gpt-4.1",
         provider="openai",
         csv_string=input.data,
-        instructions="Execute the provided code and return the output"
+        instructions="Execute the provided code and return the output",
+        verbose=False
     )
     return {
         "output": result.get("output", ""),
@@ -103,7 +105,8 @@ else:
         question="Analyze this data",
         model="claude-3-7-sonnet-latest",
         provider="anthropic",
-        instructions=code
+        instructions=code,
+        verbose=False
     )
     return {"analysis": result.get("output", "")}
 
@@ -137,7 +140,8 @@ else:
         question="Process file content",
         model="claude-3-7-sonnet-latest",
         provider="anthropic",
-        instructions=code
+        instructions=code,
+        verbose=False
     )
     return {"result": result.get("output", "")}
 
@@ -160,11 +164,10 @@ async def cricket_sql_query(input: SQLQueryInput) -> Dict[str, Any]:
             db_creds=db_creds,
             model="claude-sonnet-4-20250514",
             provider=LLMProvider.ANTHROPIC,
-            temperature=0.0
+            temperature=0.0,
+            verbose=False
         )
 
-        print(result)
-        
         if result.get("success"):
             return {
                 "success": True,


### PR DESCRIPTION
## Summary
- Added a `verbose` parameter (default: `True`) to all individual tools in `defog.llm`
- When `verbose=False`, tools use NoOp classes to disable rich-based logging output
- Maintains backward compatibility since `verbose=True` is the default

## Files Modified
- `citations.py`: Added verbose param to `citations_tool()`
- `code_interp.py`: Added verbose param to `code_interpreter_tool()`
- `sql.py`: Added verbose param to `sql_answer_tool()` and `identify_relevant_tables_tool()`
- `web_search.py`: Added verbose param to `web_search_tool()`
- `youtube.py`: Added verbose param to `get_youtube_summary()`
- `utils_logging.py`: Added NoOp classes for silent operation
- `orchestrator.py`: Set verbose=False in internal tool calls
- `examples/`: Updated examples to demonstrate usage

## Test plan
- [x] Test each tool with `verbose=True` (default) - should show rich logging
- [x] Test each tool with `verbose=False` - should run silently
- [x] Verify backward compatibility - existing code continues to work
- [x] Run pytest to ensure no regressions