### PR TITLE
Enable parallel execution for agent and subagent by default

### DIFF
--- a/defog/llm/config/orchestrator_config.py
+++ b/defog/llm/config/orchestrator_config.py
@@ -25,7 +25,7 @@ class ExplorationConfig:
     max_parallel_explorations: int = 3
     exploration_timeout: float = 300.0  # 5 minutes
     enable_learning: bool = True
-    default_strategy: ExplorationStrategy = ExplorationStrategy.ADAPTIVE
+    default_strategy: ExplorationStrategy = ExplorationStrategy.PARALLEL
 
 
 @dataclass

--- a/defog/llm/orchestrator.py
+++ b/defog/llm/orchestrator.py
@@ -29,7 +29,7 @@ class SubAgentTask:
     agent_id: str
     task_description: str
     context: Optional[Dict[str, Any]] = None
-    execution_mode: ExecutionMode = ExecutionMode.SEQUENTIAL
+    execution_mode: ExecutionMode = ExecutionMode.PARALLEL
     dependencies: Optional[List[str]] = None  # IDs of tasks that must complete first
     max_retries: int = 3
     retry_delay: float = 1.0
@@ -45,7 +45,7 @@ class SubAgentPlan:
     system_prompt: str
     task_description: str
     tools: List[str]  # Tool names from available tools
-    execution_mode: ExecutionMode = ExecutionMode.SEQUENTIAL
+    execution_mode: ExecutionMode = ExecutionMode.PARALLEL
     dependencies: Optional[List[str]] = None
 
 


### PR DESCRIPTION
This PR implements the feature requested in issue #129 to enable parallel execution for agents and subagents by default.

## Changes

- Changed `SubAgentTask.execution_mode` default from SEQUENTIAL to PARALLEL
- Changed `SubAgentPlan.execution_mode` default from SEQUENTIAL to PARALLEL
- Changed `ExplorationConfig.default_strategy` from ADAPTIVE to PARALLEL

## Impact

- Improves performance by enabling parallel execution by default
- Maintains backward compatibility as explicit configuration options are preserved
- No breaking changes to existing tests

## Testing

Analyzed existing test suite and confirmed no breaking changes:
- Tests that compare sequential vs parallel execution explicitly set their modes
- No tests rely on the default execution mode being sequential

Closes #129

Generated with [Claude Code](https://claude.ai/code)