### PR TITLE
Add image data extraction support to HTML data extractor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,9 @@
 # Updating documenting
 - After you implement or change code, always remember to check if you need to update documentation. Documentation is in `README.md` and in the `docs/` folder
 
+# Reviewing PRs
+- Be honest, technically focused, and blunt. Pay special attention to security issues.
+
 # Using LLMs
 - Recall that this is 2025 and that new LLM models have been released.
   - Claude 4 Sonnet and Claude 4 Opus are now valid models
@@ -15,3 +18,4 @@
 # Testing
 - Remember to run all tests with `python3.12 -m pytest ...`. This is to ensure you are using the correct version of python and pytest
 - Add `PYTHONPATH=.` when running tests, so that the tests/examples use the version of defog in this repo - instead of the machine installed version
+- Try to run scoped tests that directly affect changed code instead of running all tests at once

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A comprehensive Python toolkit for AI-powered data operations - from natural lan
 
 - 🤖 **Cross-provider LLM operations** - Unified interface for OpenAI, Anthropic, Gemini, and Together AI
 - 📊 **SQL Agent** - Convert natural language to SQL with automatic table filtering for large databases
-- 🔍 **Data extraction** - Extract structured data from PDFs, images, and HTML
+- 🔍 **Data extraction** - Extract structured data from PDFs, images, HTML, and even images embedded in HTML
 - 🛠️ **Advanced AI tools** - Code interpreter, web search, YouTube transcription, document citations
 - 🎭 **Agent orchestration** - Hierarchical task delegation and multi-agent coordination
 - 💾 **Memory management** - Automatic conversation compactification for long contexts

--- a/defog/llm/html_data_extractor.py
+++ b/defog/llm/html_data_extractor.py
@@ -315,7 +315,9 @@ Extract RAW DATA values, not descriptions. Each datapoint should yield MULTIPLE 
 
         return str(soup)
 
-    def _extract_image_urls(self, html_content: str, base_url: Optional[str] = None) -> Dict[str, str]:
+    def _extract_image_urls(
+        self, html_content: str, base_url: Optional[str] = None
+    ) -> Dict[str, str]:
         """
         Extract image URLs from HTML content, resolving relative URLs if base_url is provided.
 
@@ -344,7 +346,11 @@ Extract RAW DATA values, not descriptions. Each datapoint should yield MULTIPLE 
                     resolved_url = urljoin(base_url, src)
 
                 # Use original src as key for easy lookup in location hints
-                image_urls[src] = {"url": resolved_url, "context": context, "element": str(img)}
+                image_urls[src] = {
+                    "url": resolved_url,
+                    "context": context,
+                    "element": str(img),
+                }
 
         return image_urls
 

--- a/docs/data-extraction.md
+++ b/docs/data-extraction.md
@@ -263,7 +263,7 @@ dashboard_data = await extract_image_data(
 
 ## HTML Data Extraction
 
-Extract structured data from HTML content including tables, lists, product information, and more.
+Extract structured data from HTML content including tables, lists, product information, and even data from images embedded in the HTML.
 
 ### Basic Usage
 
@@ -301,7 +301,8 @@ extractor = HTMLDataExtractor(
     analysis_provider="openai",
     analysis_model="gpt-4",
     extraction_provider="gemini",
-    extraction_model="gemini-2.5-pro"
+    extraction_model="gemini-2.5-pro",
+    enable_image_extraction=True  # Enable extraction from images in HTML
 )
 
 # Extract from complex e-commerce page
@@ -371,6 +372,30 @@ form_html = """
 </form>
 """
 survey_data = await extract_html_data(form_html, focus_areas=["survey results"])
+
+# HTML with embedded images (charts, graphs, tables as images)
+html_with_images = """
+<div class="report">
+    <h2>Sales Analysis</h2>
+    <img src="https://example.com/sales-chart.png" 
+         alt="Bar chart showing monthly sales data">
+    <p>Sales increased by 25% this quarter.</p>
+    
+    <h2>Regional Distribution</h2>
+    <img src="https://example.com/regional-pie-chart.png"
+         alt="Pie chart showing sales by region">
+</div>
+"""
+
+# Extract data from both HTML content and embedded images
+data_with_images = await extract_html_data(
+    html_with_images, 
+    focus_areas=["sales data", "regional distribution"],
+    enable_image_extraction=True  # This is True by default
+)
+
+# The extractor will identify images as potential data sources
+# and extract structured data from charts, graphs, and image-based tables
 ```
 
 ## Common Patterns

--- a/docs/data-extraction.md
+++ b/docs/data-extraction.md
@@ -396,6 +396,26 @@ data_with_images = await extract_html_data(
 
 # The extractor will identify images as potential data sources
 # and extract structured data from charts, graphs, and image-based tables
+
+# Handle relative image URLs with base_url parameter
+html_with_relative_images = """
+<div class="dashboard">
+    <img src="/charts/sales-2024.png" alt="Sales chart">
+    <img src="./images/revenue.png" alt="Revenue graph">
+    <img src="../data/metrics.png" alt="Key metrics">
+</div>
+"""
+
+data_with_base_url = await extract_html_data(
+    html_with_relative_images,
+    base_url="https://example.com/reports/2024/",  # Base URL for resolving relative paths
+    focus_areas=["charts", "metrics"]
+)
+
+# The extractor will resolve:
+# - "/charts/sales-2024.png" → "https://example.com/charts/sales-2024.png"
+# - "./images/revenue.png" → "https://example.com/reports/2024/images/revenue.png"
+# - "../data/metrics.png" → "https://example.com/reports/data/metrics.png"
 ```
 
 ## Common Patterns

--- a/tests/test_html_data_extractor.py
+++ b/tests/test_html_data_extractor.py
@@ -72,6 +72,51 @@ SAMPLE_HTML = {
     </body>
     </html>
     """,
+    "html_with_images": """
+    <html>
+    <body>
+        <h1>Business Performance Dashboard</h1>
+        
+        <section class="charts">
+            <h2>Electricity Generation by Source</h2>
+            <img src="https://data.europa.eu/apps/data-visualisation-guide/A%20deep%20dive%20into%20bar%20charts%20047791ead2e848bdb3d0afcd1bf2bd4a/electricity-bars-karim.png" 
+                 alt="Bar chart showing electricity generation by different sources">
+            <p>Data shows renewable energy sources are increasing.</p>
+        </section>
+        
+        <section class="tables">
+            <h2>Product Inventory</h2>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Product</th>
+                        <th>Stock</th>
+                        <th>Price</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Widget Pro</td>
+                        <td>150</td>
+                        <td>$99.99</td>
+                    </tr>
+                    <tr>
+                        <td>Widget Lite</td>
+                        <td>300</td>
+                        <td>$49.99</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+        
+        <section class="data-visualization">
+            <h2>Excel Data Table Example</h2>
+            <img src="https://support.microsoft.com/images/en-us/3dd2b79b-9160-403d-9967-af893d17b580"
+                 alt="Excel table showing financial data">
+        </section>
+    </body>
+    </html>
+    """,
     "mixed_content": """
     <html>
     <head>
@@ -642,6 +687,130 @@ class TestHTMLDataExtractorEdgeCases:
         assert isinstance(result, HTMLDataExtractionResult)
         # Should identify nested product data
         assert result.total_datapoints_identified > 0
+
+
+@pytest.mark.asyncio
+class TestHTMLDataExtractorWithImages:
+    """Tests for HTML data extraction with image support"""
+    
+    async def test_image_extraction_enabled(self):
+        """Test extraction from HTML containing images"""
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            pytest.skip("ANTHROPIC_API_KEY not set")
+            
+        extractor = HTMLDataExtractor(
+            enable_image_extraction=True,
+            analysis_provider="anthropic",
+            analysis_model="claude-sonnet-4-20250514",
+            extraction_provider="anthropic", 
+            extraction_model="claude-sonnet-4-20250514",
+        )
+        
+        # Analyze HTML with images
+        analysis, _ = await extractor.analyze_html_structure(
+            SAMPLE_HTML["html_with_images"]
+        )
+        
+        # Check that images were identified as data sources
+        image_datapoints = [
+            dp for dp in analysis.identified_datapoints 
+            if dp.data_type == "image"
+        ]
+        assert len(image_datapoints) > 0, "No image datapoints identified"
+        
+        # Also check that regular data was identified
+        table_datapoints = [
+            dp for dp in analysis.identified_datapoints
+            if dp.data_type == "table"
+        ]
+        assert len(table_datapoints) > 0, "No table datapoints identified"
+        
+    async def test_image_extraction_disabled(self):
+        """Test that image extraction can be disabled"""
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            pytest.skip("ANTHROPIC_API_KEY not set")
+            
+        extractor = HTMLDataExtractor(
+            enable_image_extraction=False,
+            analysis_provider="anthropic",
+            analysis_model="claude-sonnet-4-20250514",
+        )
+        
+        # Analyze HTML with images
+        analysis, _ = await extractor.analyze_html_structure(
+            SAMPLE_HTML["html_with_images"]
+        )
+        
+        # Check that images were NOT identified as data sources
+        image_datapoints = [
+            dp for dp in analysis.identified_datapoints 
+            if dp.data_type == "image"
+        ]
+        assert len(image_datapoints) == 0, "Images identified when extraction disabled"
+        
+    async def test_mixed_html_and_image_extraction(self):
+        """Test full extraction from HTML with both tables and images"""
+        if not os.getenv("OPENAI_API_KEY"):
+            pytest.skip("OPENAI_API_KEY not set")
+            
+        extractor = HTMLDataExtractor(
+            enable_image_extraction=True,
+            analysis_provider="openai",
+            analysis_model="gpt-4.1",
+            extraction_provider="openai",
+            extraction_model="gpt-4.1",
+            max_parallel_extractions=3,
+        )
+        
+        # Extract all data
+        result = await extractor.extract_all_data(
+            SAMPLE_HTML["html_with_images"]
+        )
+        
+        # Verify results
+        assert isinstance(result, HTMLDataExtractionResult)
+        assert result.total_datapoints_identified > 0
+        
+        # Check we have both successful and potentially failed extractions
+        # (image extractions might fail due to network issues)
+        assert result.successful_extractions + result.failed_extractions == len(result.extraction_results)
+        
+        # Print summary for debugging
+        print(f"\nMixed extraction results:")
+        print(f"  Total identified: {result.total_datapoints_identified}")
+        print(f"  Successful: {result.successful_extractions}")
+        print(f"  Failed: {result.failed_extractions}")
+        
+        for extraction in result.extraction_results:
+            if extraction.success:
+                print(f"  ✓ {extraction.datapoint_name}")
+            else:
+                print(f"  ✗ {extraction.datapoint_name}: {extraction.error}")
+                
+    async def test_image_url_extraction(self):
+        """Test the image URL extraction helper method"""
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            pytest.skip("ANTHROPIC_API_KEY not set")
+            
+        extractor = HTMLDataExtractor(enable_image_extraction=True)
+        
+        # Test URL extraction
+        image_urls = extractor._extract_image_urls(SAMPLE_HTML["html_with_images"])
+        
+        # Should find 2 images
+        assert len(image_urls) == 2
+        
+        # Check that URLs are correctly extracted
+        expected_urls = [
+            "https://data.europa.eu/apps/data-visualisation-guide/A%20deep%20dive%20into%20bar%20charts%20047791ead2e848bdb3d0afcd1bf2bd4a/electricity-bars-karim.png",
+            "https://support.microsoft.com/images/en-us/3dd2b79b-9160-403d-9967-af893d17b580"
+        ]
+        
+        for url in expected_urls:
+            assert url in image_urls
+            assert image_urls[url]['url'] == url
+            assert 'context' in image_urls[url]
+            assert 'element' in image_urls[url]
 
 
 if __name__ == "__main__":

--- a/tests/test_html_data_extractor.py
+++ b/tests/test_html_data_extractor.py
@@ -226,7 +226,7 @@ class TestHTMLDataExtractorUnit:
 @pytest.mark.asyncio
 class TestHTMLDataExtractorE2E:
     """End-to-end tests for HTMLDataExtractor with real API calls
-    
+
     Provider distribution across tests:
     - test_simple_table_extraction: Anthropic (claude-sonnet-4)
     - test_product_cards_extraction: OpenAI (gpt-4.1)
@@ -266,7 +266,7 @@ class TestHTMLDataExtractorE2E:
                 data = extraction.extracted_data
                 if hasattr(data, "model_dump"):
                     data = data.model_dump()
-                
+
                 # Should have columns and data for table extraction
                 if "columns" in data and "data" in data:
                     assert len(data["columns"]) > 0
@@ -349,13 +349,13 @@ class TestHTMLDataExtractorE2E:
 
         # Extract as dictionary for easier verification
         dict_result = await extractor.extract_as_dict(SAMPLE_HTML["mixed_content"])
-        
+
         for key, value in dict_result["data"].items():
             print(f"\nDatapoint '{key}':")
             print(f"  Type: {type(value)}")
             if isinstance(value, dict):
                 print(f"  Keys: {list(value.keys())}")
-        
+
         # Should have extracted multiple datapoints
         assert len(dict_result["data"]) >= 2
 
@@ -427,16 +427,16 @@ class TestHTMLDataExtractorEdgeCases:
         """Test extraction from empty HTML"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor()
-        
+
         # Test completely empty string
         result = await extractor.extract_all_data("")
         assert isinstance(result, HTMLDataExtractionResult)
         assert result.total_datapoints_identified == 0
         assert result.successful_extractions == 0
         assert result.failed_extractions == 0
-        
+
         # Test HTML with no content
         empty_html = "<html><body></body></html>"
         result = await extractor.extract_all_data(empty_html)
@@ -447,9 +447,9 @@ class TestHTMLDataExtractorEdgeCases:
         """Test extraction from malformed HTML"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor()
-        
+
         malformed_htmls = [
             # Unclosed tags
             "<html><body><table><tr><td>Data</table>",
@@ -460,7 +460,7 @@ class TestHTMLDataExtractorEdgeCases:
             # Mixed up tag order
             "<b><i>Bold italic</b></i>",
         ]
-        
+
         for html in malformed_htmls:
             result = await extractor.extract_all_data(html)
             assert isinstance(result, HTMLDataExtractionResult)
@@ -470,27 +470,27 @@ class TestHTMLDataExtractorEdgeCases:
         """Test extraction from large HTML document"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         # Create HTML that exceeds size limit
         large_table = "<html><body><table>"
         for i in range(10000):
             large_table += f"<tr><td>Row {i}</td><td>Data {i}</td></tr>"
         large_table += "</table></body></html>"
-        
+
         extractor = HTMLDataExtractor(max_html_size_mb=0.1)  # Set small limit
-        
+
         with pytest.raises(ValueError) as exc_info:
             await extractor.extract_all_data(large_table)
-        
+
         assert "exceeds maximum size limit" in str(exc_info.value)
 
     async def test_html_with_no_extractable_data(self):
         """Test HTML that contains no structured data"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor()
-        
+
         # HTML with only text and no structure
         text_only_html = """
         <html>
@@ -501,7 +501,7 @@ class TestHTMLDataExtractorEdgeCases:
         </body>
         </html>
         """
-        
+
         result = await extractor.extract_all_data(text_only_html)
         assert isinstance(result, HTMLDataExtractionResult)
         # Might identify some data or might not, but should complete
@@ -511,9 +511,9 @@ class TestHTMLDataExtractorEdgeCases:
         """Test HTML with Unicode and special characters"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor()
-        
+
         unicode_html = """
         <html>
         <body>
@@ -537,11 +537,11 @@ class TestHTMLDataExtractorEdgeCases:
         </body>
         </html>
         """
-        
+
         result = await extractor.extract_all_data(unicode_html)
         assert isinstance(result, HTMLDataExtractionResult)
         assert result.successful_extractions > 0
-        
+
         # Check that Unicode was preserved
         dict_result = await extractor.extract_as_dict(unicode_html)
         assert len(dict_result["data"]) > 0
@@ -550,9 +550,9 @@ class TestHTMLDataExtractorEdgeCases:
         """Test HTML with script tags and inline styles"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor()
-        
+
         html_with_scripts = """
         <html>
         <head>
@@ -583,7 +583,7 @@ class TestHTMLDataExtractorEdgeCases:
         </body>
         </html>
         """
-        
+
         result = await extractor.extract_all_data(html_with_scripts)
         assert isinstance(result, HTMLDataExtractionResult)
         # Should extract data while handling scripts safely
@@ -592,23 +592,25 @@ class TestHTMLDataExtractorEdgeCases:
         """Test that caching works correctly"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor(enable_caching=True)
-        
+
         html = SAMPLE_HTML["simple_table"]
-        
+
         # First extraction
         result1 = await extractor.extract_all_data(html)
         cost1 = result1.total_cost_cents
-        
+
         # Second extraction (should use cache)
         result2 = await extractor.extract_all_data(html)
         cost2 = result2.total_cost_cents
-        
+
         # Results should be the same
         assert result1.html_content_hash == result2.html_content_hash
-        assert result1.total_datapoints_identified == result2.total_datapoints_identified
-        
+        assert (
+            result1.total_datapoints_identified == result2.total_datapoints_identified
+        )
+
         # Second call should be from cache (same total cost)
         assert cost2 == cost1
 
@@ -616,9 +618,9 @@ class TestHTMLDataExtractorEdgeCases:
         """Test that HTML sanitization removes dangerous content"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor()
-        
+
         dangerous_html = """
         <html>
         <body>
@@ -638,7 +640,7 @@ class TestHTMLDataExtractorEdgeCases:
         </body>
         </html>
         """
-        
+
         result = await extractor.extract_all_data(dangerous_html)
         assert isinstance(result, HTMLDataExtractionResult)
         # Should complete successfully with sanitized content
@@ -647,9 +649,9 @@ class TestHTMLDataExtractorEdgeCases:
         """Test extraction from deeply nested HTML structures"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor()
-        
+
         nested_html = """
         <html>
         <body>
@@ -682,7 +684,7 @@ class TestHTMLDataExtractorEdgeCases:
         </body>
         </html>
         """
-        
+
         result = await extractor.extract_all_data(nested_html)
         assert isinstance(result, HTMLDataExtractionResult)
         # Should identify nested product data
@@ -692,67 +694,64 @@ class TestHTMLDataExtractorEdgeCases:
 @pytest.mark.asyncio
 class TestHTMLDataExtractorWithImages:
     """Tests for HTML data extraction with image support"""
-    
+
     async def test_image_extraction_enabled(self):
         """Test extraction from HTML containing images"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor(
             enable_image_extraction=True,
             analysis_provider="anthropic",
             analysis_model="claude-sonnet-4-20250514",
-            extraction_provider="anthropic", 
+            extraction_provider="anthropic",
             extraction_model="claude-sonnet-4-20250514",
         )
-        
+
         # Analyze HTML with images
         analysis, _ = await extractor.analyze_html_structure(
             SAMPLE_HTML["html_with_images"]
         )
-        
+
         # Check that images were identified as data sources
         image_datapoints = [
-            dp for dp in analysis.identified_datapoints 
-            if dp.data_type == "image"
+            dp for dp in analysis.identified_datapoints if dp.data_type == "image"
         ]
         assert len(image_datapoints) > 0, "No image datapoints identified"
-        
+
         # Also check that regular data was identified
         table_datapoints = [
-            dp for dp in analysis.identified_datapoints
-            if dp.data_type == "table"
+            dp for dp in analysis.identified_datapoints if dp.data_type == "table"
         ]
         assert len(table_datapoints) > 0, "No table datapoints identified"
-        
+
     async def test_image_extraction_disabled(self):
         """Test that image extraction can be disabled"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor(
             enable_image_extraction=False,
             analysis_provider="anthropic",
             analysis_model="claude-sonnet-4-20250514",
         )
-        
+
         # Analyze HTML with images
         analysis, _ = await extractor.analyze_html_structure(
             SAMPLE_HTML["html_with_images"]
         )
-        
+
         # Check that images were NOT identified as data sources
         image_datapoints = [
-            dp for dp in analysis.identified_datapoints 
-            if dp.data_type == "image"
+            dp for dp in analysis.identified_datapoints if dp.data_type == "image"
         ]
         assert len(image_datapoints) == 0, "Images identified when extraction disabled"
-        
+
     async def test_mixed_html_and_image_extraction(self):
         """Test full extraction from HTML with both tables and images"""
         if not os.getenv("OPENAI_API_KEY"):
             pytest.skip("OPENAI_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor(
             enable_image_extraction=True,
             analysis_provider="openai",
@@ -761,56 +760,56 @@ class TestHTMLDataExtractorWithImages:
             extraction_model="gpt-4.1",
             max_parallel_extractions=3,
         )
-        
+
         # Extract all data
-        result = await extractor.extract_all_data(
-            SAMPLE_HTML["html_with_images"]
-        )
-        
+        result = await extractor.extract_all_data(SAMPLE_HTML["html_with_images"])
+
         # Verify results
         assert isinstance(result, HTMLDataExtractionResult)
         assert result.total_datapoints_identified > 0
-        
+
         # Check we have both successful and potentially failed extractions
         # (image extractions might fail due to network issues)
-        assert result.successful_extractions + result.failed_extractions == len(result.extraction_results)
-        
+        assert result.successful_extractions + result.failed_extractions == len(
+            result.extraction_results
+        )
+
         # Print summary for debugging
         print(f"\nMixed extraction results:")
         print(f"  Total identified: {result.total_datapoints_identified}")
         print(f"  Successful: {result.successful_extractions}")
         print(f"  Failed: {result.failed_extractions}")
-        
+
         for extraction in result.extraction_results:
             if extraction.success:
                 print(f"  ✓ {extraction.datapoint_name}")
             else:
                 print(f"  ✗ {extraction.datapoint_name}: {extraction.error}")
-                
+
     async def test_image_url_extraction(self):
         """Test the image URL extraction helper method"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor(enable_image_extraction=True)
-        
+
         # Test URL extraction
         image_urls = extractor._extract_image_urls(SAMPLE_HTML["html_with_images"])
-        
+
         # Should find 2 images
         assert len(image_urls) == 2
-        
+
         # Check that URLs are correctly extracted
         expected_urls = [
             "https://data.europa.eu/apps/data-visualisation-guide/A%20deep%20dive%20into%20bar%20charts%20047791ead2e848bdb3d0afcd1bf2bd4a/electricity-bars-karim.png",
-            "https://support.microsoft.com/images/en-us/3dd2b79b-9160-403d-9967-af893d17b580"
+            "https://support.microsoft.com/images/en-us/3dd2b79b-9160-403d-9967-af893d17b580",
         ]
-        
+
         for url in expected_urls:
             assert url in image_urls
-            assert image_urls[url]['url'] == url
-            assert 'context' in image_urls[url]
-            assert 'element' in image_urls[url]
+            assert image_urls[url]["url"] == url
+            assert "context" in image_urls[url]
+            assert "element" in image_urls[url]
 
 
 if __name__ == "__main__":

--- a/tests/test_html_data_extractor.py
+++ b/tests/test_html_data_extractor.py
@@ -810,14 +810,14 @@ class TestHTMLDataExtractorWithImages:
             assert image_urls[url]["url"] == url
             assert "context" in image_urls[url]
             assert "element" in image_urls[url]
-            
+
     async def test_relative_url_resolution(self):
         """Test that relative image URLs are resolved correctly"""
         if not os.getenv("ANTHROPIC_API_KEY"):
             pytest.skip("ANTHROPIC_API_KEY not set")
-            
+
         extractor = HTMLDataExtractor(enable_image_extraction=True)
-        
+
         # HTML with relative image URLs
         html_with_relative_urls = """
         <html>
@@ -829,19 +829,31 @@ class TestHTMLDataExtractorWithImages:
         </body>
         </html>
         """
-        
+
         base_url = "https://example.com/reports/2024/"
-        
+
         # Test URL extraction with base_url
         image_urls = extractor._extract_image_urls(html_with_relative_urls, base_url)
-        
+
         # Check that relative URLs are resolved correctly
-        assert image_urls["/images/chart1.png"]["url"] == "https://example.com/images/chart1.png"
-        assert image_urls["./images/chart2.png"]["url"] == "https://example.com/reports/2024/images/chart2.png"
-        assert image_urls["../data/chart3.png"]["url"] == "https://example.com/reports/data/chart3.png"
-        
+        assert (
+            image_urls["/images/chart1.png"]["url"]
+            == "https://example.com/images/chart1.png"
+        )
+        assert (
+            image_urls["./images/chart2.png"]["url"]
+            == "https://example.com/reports/2024/images/chart2.png"
+        )
+        assert (
+            image_urls["../data/chart3.png"]["url"]
+            == "https://example.com/reports/data/chart3.png"
+        )
+
         # Absolute URLs should remain unchanged
-        assert image_urls["https://example.com/absolute-chart.png"]["url"] == "https://example.com/absolute-chart.png"
+        assert (
+            image_urls["https://example.com/absolute-chart.png"]["url"]
+            == "https://example.com/absolute-chart.png"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds the ability to extract structured data from images embedded in HTML documents
- Leverages the existing ImageDataExtractor to process charts, graphs, and image-based tables found in HTML
- Maintains backward compatibility with an optional `enable_image_extraction` parameter (default: True)

## Changes
- **Integration**: Added ImageDataExtractor as a dependency in HTMLDataExtractor
- **Analysis**: Updated HTML analysis prompt to identify `<img>` tags as potential data sources
- **Extraction**: Added logic to extract image URLs and process them through the image extractor
- **Tests**: Added comprehensive test coverage for the new functionality
- **Documentation**: Updated docs to describe image extraction capabilities

## Test Plan
- [x] All existing tests pass
- [x] New tests for image extraction functionality pass
- [x] Tested with various HTML structures containing images
- [x] Verified backward compatibility when image extraction is disabled