### PR TITLE
Remove unsupported MongoDB and Elasticsearch from data extraction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,10 +3,6 @@ repos:
   # Ruff version.
   rev: v0.12.0
   hooks:
-    # Run the linter.
-    - id: ruff-check
-      types_or: [ python, pyi ]
-      args: ["--fix"]
     # Run the formatter.
     - id: ruff-format
       types_or: [ python, pyi ]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A comprehensive Python toolkit for AI-powered data operations - from natural lan
 
 - 🤖 **Cross-provider LLM operations** - Unified interface for OpenAI, Anthropic, Gemini, and Together AI
 - 📊 **SQL Agent** - Convert natural language to SQL with automatic table filtering for large databases
-- 🔍 **Data extraction** - Extract structured data from PDFs, images, HTML, and even images embedded in HTML
+- 🔍 **Data extraction** - Extract structured data from PDFs, images, HTML, text documents, and even images embedded in HTML
 - 🛠️ **Advanced AI tools** - Code interpreter, web search, YouTube transcription, document citations
 - 🎭 **Agent orchestration** - Hierarchical task delegation and multi-agent coordination
 - 💾 **Memory management** - Automatic conversation compactification for long contexts

--- a/defog/__init__.py
+++ b/defog/__init__.py
@@ -114,17 +114,9 @@ class BaseDefog:
                 raise KeyError("db_creds must contain a 'user' key.")
             if "password" not in db_creds:
                 raise KeyError("db_creds must contain a 'password' key.")
-        elif db_type == "mongo":
-            if "connection_string" not in db_creds:
-                raise KeyError("db_creds must contain a 'connection_string' key.")
         elif db_type == "bigquery":
             if "json_key_path" not in db_creds:
                 raise KeyError("db_creds must contain a 'json_key_path' key.")
-        elif db_type == "elastic":
-            if "host" not in db_creds:
-                raise KeyError("db_creds must contain a 'host' key.")
-            if "api_key" not in db_creds:
-                raise KeyError("db_creds must contain a 'api_key' key.")
         elif db_type == "sqlite":
             if "database" not in db_creds:
                 raise KeyError("db_creds must contain a 'database' key.")

--- a/defog/llm/__init__.py
+++ b/defog/llm/__init__.py
@@ -16,6 +16,7 @@ from .pdf_processor import analyze_pdf, PDFAnalysisInput, ClaudePDFProcessor
 from .pdf_data_extractor import PDFDataExtractor, extract_pdf_data
 from .image_data_extractor import ImageDataExtractor, extract_image_data
 from .html_data_extractor import HTMLDataExtractor, extract_html_data
+from .text_data_extractor import TextDataExtractor, extract_text_data
 
 # Orchestration components
 from .orchestrator import (
@@ -69,6 +70,9 @@ __all__ = [
     # HTML processing
     "HTMLDataExtractor",
     "extract_html_data",
+    # Text processing
+    "TextDataExtractor",
+    "extract_text_data",
     # Orchestration
     "Orchestrator",
     "AgentOrchestrator",  # Backward compatibility

--- a/defog/llm/text_data_extractor.py
+++ b/defog/llm/text_data_extractor.py
@@ -1,0 +1,728 @@
+"""
+Text Data Extractor Agent Orchestrator
+
+This module provides intelligent text analysis to:
+1. Identify interesting datapoints that can be extracted as tabular data
+2. Generate appropriate response_format schemas for each datapoint
+3. Orchestrate parallel extraction of all identified datapoints
+"""
+
+import asyncio
+import logging
+import hashlib
+from typing import Dict, List, Any, Optional, Type, Union
+from pydantic import BaseModel, Field, create_model
+
+from .utils import chat_async
+from .llm_providers import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+# Constants for text processing
+MAX_TEXT_SIZE_MB = 5  # Maximum text size in megabytes
+MAX_TEXT_SIZE_BYTES = MAX_TEXT_SIZE_MB * 1024 * 1024
+
+
+class SchemaField(BaseModel):
+    """Schema field definition for data extraction."""
+
+    name: str = Field(description="Snake_case field name")
+    type: str = Field(description="Data type (string, int, float, etc.)")
+    description: str = Field(description="What the field contains")
+    optional: bool = Field(default=True, description="Whether the field is optional")
+
+
+class DataPointIdentification(BaseModel):
+    """Identified data point in text that can be extracted."""
+
+    name: str = Field(description="Name of the datapoint (e.g., 'economic_indicators')")
+    description: str = Field(description="Description of what this datapoint contains")
+    data_type: str = Field(
+        description="Type of data: 'key_value_pairs', 'list', 'table', 'metrics', 'statements'"
+    )
+    location_hint: str = Field(
+        description="Hint about where in the text this data is located (e.g., section name, pattern description)"
+    )
+    schema_fields: List[SchemaField] = Field(
+        description="List of data fields for extraction."
+    )
+
+
+class TextAnalysisResponse(BaseModel):
+    """Response from text structure analysis."""
+
+    document_type: str = Field(
+        description="Type of document (e.g., 'transcript', 'speech', 'report', 'article', 'policy_document')"
+    )
+    content_description: str = Field(
+        description="Brief description of the text content"
+    )
+    identified_datapoints: List[DataPointIdentification] = Field(
+        description="List of all identified extractable datapoints"
+    )
+
+
+class DataExtractionResult(BaseModel):
+    """Result of extracting a single datapoint."""
+
+    datapoint_name: str
+    success: bool
+    extracted_data: Optional[Any] = None
+    error: Optional[str] = None
+    cost_cents: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+
+
+class TextDataExtractionResult(BaseModel):
+    """Complete result of text data extraction."""
+
+    text_content_hash: str
+    document_type: str
+    total_datapoints_identified: int
+    successful_extractions: int
+    failed_extractions: int
+    extraction_results: List[DataExtractionResult]
+    total_time_ms: int
+    total_cost_cents: float
+    metadata: Dict[str, Any]
+
+
+class TextDataExtractor:
+    """
+    Intelligent text data extractor that identifies and extracts
+    structured data from text strings using parallel agent orchestration.
+    """
+
+    def __init__(
+        self,
+        analysis_provider: Union[str, LLMProvider] = "anthropic",
+        analysis_model: str = "claude-sonnet-4-20250514",
+        extraction_provider: Union[str, LLMProvider] = "anthropic",
+        extraction_model: str = "claude-sonnet-4-20250514",
+        max_parallel_extractions: int = 5,
+        temperature: float = 0.0,
+        max_text_size_mb: int = MAX_TEXT_SIZE_MB,
+        enable_caching: bool = True,
+    ):
+        """
+        Initialize Text Data Extractor.
+
+        Args:
+            analysis_provider: Provider for text analysis
+            analysis_model: Model for text analysis
+            extraction_provider: Provider for data extraction
+            extraction_model: Model for data extraction
+            max_parallel_extractions: Maximum parallel extraction tasks
+            temperature: Sampling temperature
+            max_text_size_mb: Maximum text size in megabytes
+            enable_caching: Whether to enable caching of analysis results
+        """
+        self.analysis_provider = analysis_provider
+        self.analysis_model = analysis_model
+        self.extraction_provider = extraction_provider
+        self.extraction_model = extraction_model
+        self.max_parallel_extractions = max_parallel_extractions
+        self.temperature = temperature
+        self.max_text_size_bytes = max_text_size_mb * 1024 * 1024
+        self.enable_caching = enable_caching
+        self._analysis_cache = {} if enable_caching else None
+
+    async def analyze_text_structure(
+        self, text_content: str, focus_areas: Optional[List[str]] = None
+    ) -> tuple[TextAnalysisResponse, Dict[str, Any]]:
+        """
+        Analyze text to identify extractable datapoints.
+
+        Args:
+            text_content: Text string to analyze
+            focus_areas: Optional list of areas to focus on
+
+        Returns:
+            Tuple of (TextAnalysisResponse with identified datapoints, cost metadata dict)
+        """
+        logger.info(
+            f"Starting text structure analysis, content size: {len(text_content)} chars"
+        )
+        if focus_areas:
+            logger.info(f"Focus areas: {focus_areas}")
+
+        analysis_task = f"""Analyze this text to identify extractable structured data suitable for SQL databases.
+
+Find all structured data patterns:
+- Key-value pairs (metrics, statistics, dates)
+- Numerical data (percentages, amounts, rates)
+- Time-based data (dates, timelines, sequences)
+
+ONLY focus on numerically focused data. Do not focus on general qualitative statements, general questions and answers, or other non-numerical data.
+
+{f"Focus on: {', '.join(focus_areas)}" if focus_areas else ""}
+
+For each datapoint provide:
+- name: snake_case (e.g., 'economic_indicators')
+- data_type: 'key_value_pairs', 'list', 'table', or 'metrics'
+- location_hint: Description of where/how to find this data
+- schema_fields: [{{name, type, description, optional: true}}]
+
+Extract RAW DATA values. Each datapoint should yield MULTIPLE ROWS when applicable."""
+
+        # Prepare message with text content
+        messages = [
+            {
+                "role": "user",
+                "content": f"<text_content>\n{text_content}\n</text_content>\n\n{analysis_task}",
+            }
+        ]
+
+        # Call LLM with structured response
+        logger.info(
+            f"Calling {self.analysis_provider}/{self.analysis_model} for analysis"
+        )
+        start_time = asyncio.get_event_loop().time()
+
+        result = await chat_async(
+            provider=self.analysis_provider,
+            model=self.analysis_model,
+            messages=messages,
+            temperature=self.temperature,
+            response_format=TextAnalysisResponse,
+        )
+
+        analysis_time = asyncio.get_event_loop().time() - start_time
+        logger.info(f"Analysis completed in {analysis_time:.2f} seconds")
+
+        # chat_async returns the response directly
+        if not result.content:
+            raise Exception("Text analysis failed: No response content")
+
+        # Extract cost metadata from LLMResponse
+        cost_metadata = {
+            "cost_cents": result.cost_in_cents or 0.0,
+            "input_tokens": result.input_tokens or 0,
+            "output_tokens": result.output_tokens or 0,
+            "cached_tokens": result.cached_input_tokens or 0,
+        }
+
+        logger.info(
+            f"Analysis identified {len(result.content.identified_datapoints)} datapoints"
+        )
+        logger.info(f"Analysis cost: ${cost_metadata['cost_cents'] / 100:.4f}")
+
+        return result.content, cost_metadata
+
+    def _preprocess_text(self, text_content: str) -> str:
+        """
+        Preprocess text to improve extraction quality.
+
+        Args:
+            text_content: Raw text string
+
+        Returns:
+            Preprocessed text string
+        """
+        # Basic preprocessing while preserving structure
+        # Remove excessive whitespace while keeping paragraph breaks
+        lines = text_content.split("\n")
+        processed_lines = []
+
+        for line in lines:
+            # Trim whitespace from each line
+            line = line.strip()
+            if line:  # Keep non-empty lines
+                processed_lines.append(line)
+            elif (
+                processed_lines and processed_lines[-1]
+            ):  # Keep single empty lines for paragraph breaks
+                processed_lines.append("")
+
+        # Join back with single newlines and strip trailing whitespace
+        result = "\n".join(processed_lines)
+        return result.rstrip()
+
+    def _generate_pydantic_schema(
+        self, datapoint: DataPointIdentification
+    ) -> Type[BaseModel]:
+        """
+        Generate a Pydantic model dynamically based on identified schema fields.
+
+        Args:
+            datapoint: Identified datapoint with schema information
+
+        Returns:
+            Dynamically created Pydantic model
+        """
+        if datapoint.data_type == "table" or datapoint.data_type == "metrics":
+            # For tables and metrics, use columnar format for efficiency
+            column_names = []
+            for field_info in datapoint.schema_fields:
+                field_name = field_info.name.replace(" ", "_").lower()
+                if field_name:
+                    column_names.append(field_name)
+
+            return create_model(
+                datapoint.name,
+                columns=(
+                    List[str],
+                    Field(
+                        default=column_names if column_names else None,
+                        description="Column names for the extracted data",
+                    ),
+                ),
+                data=(
+                    List[List[Optional[Union[str, int, float, bool]]]],
+                    Field(
+                        description="Data as array of arrays (each inner array is a row)"
+                    ),
+                ),
+                row_count=(
+                    Optional[int],
+                    Field(default=None, description="Number of rows extracted"),
+                ),
+            )
+        elif datapoint.data_type == "key_value_pairs":
+            # For key-value pairs, create fields directly from schema
+            field_definitions = {}
+            for field_info in datapoint.schema_fields:
+                field_name = field_info.name.replace(" ", "_").lower()
+                field_type_str = field_info.type.lower()
+                field_description = field_info.description
+
+                # Map string types to Python types
+                type_mapping = {
+                    "string": str,
+                    "str": str,
+                    "text": str,
+                    "int": int,
+                    "integer": int,
+                    "float": float,
+                    "decimal": float,
+                    "number": float,
+                    "bool": bool,
+                    "boolean": bool,
+                    "date": str,
+                    "datetime": str,
+                }
+
+                python_type = type_mapping.get(field_type_str, str)
+                # All fields are optional
+                python_type = Optional[python_type]
+
+                field_definitions[field_name] = (
+                    python_type,
+                    Field(description=field_description),
+                )
+
+            return create_model(datapoint.name, **field_definitions)
+        elif datapoint.data_type == "list":
+            # For lists, create a simple list structure
+            return create_model(
+                datapoint.name,
+                items=(
+                    List[str],
+                    Field(description="List of extracted items"),
+                ),
+                item_count=(
+                    Optional[int],
+                    Field(default=None, description="Number of items extracted"),
+                ),
+            )
+        else:  # statements or other types
+            # For statements and other types, use a flexible format
+            return create_model(
+                datapoint.name,
+                items=(
+                    List[Dict[str, Optional[Union[str, int, float, bool]]]],
+                    Field(description="Extracted structured items"),
+                ),
+                item_count=(
+                    Optional[int],
+                    Field(default=None, description="Number of items extracted"),
+                ),
+            )
+
+    def _aggregate_cost_and_token_metadata(
+        self,
+        analysis_metadata: Dict[str, Any],
+        extraction_results: List[DataExtractionResult],
+    ) -> Dict[str, Any]:
+        """
+        Aggregate cost and token metadata from analysis and extraction results.
+
+        Args:
+            analysis_metadata: Cost metadata from text analysis
+            extraction_results: List of extraction results with individual costs
+
+        Returns:
+            Dictionary with aggregated totals
+        """
+        # Start with analysis costs
+        total_cost = analysis_metadata.get("cost_cents", 0.0)
+        total_input_tokens = analysis_metadata.get("input_tokens", 0)
+        total_output_tokens = analysis_metadata.get("output_tokens", 0)
+        total_cached_tokens = analysis_metadata.get("cached_tokens", 0)
+
+        # Aggregate costs from individual extractions
+        for result in extraction_results:
+            if not isinstance(result, Exception):
+                total_cost += result.cost_cents
+                total_input_tokens += result.input_tokens
+                total_output_tokens += result.output_tokens
+                total_cached_tokens += result.cached_tokens
+
+        return {
+            "total_cost_cents": total_cost,
+            "total_input_tokens": total_input_tokens,
+            "total_output_tokens": total_output_tokens,
+            "total_cached_tokens": total_cached_tokens,
+            "analysis_cost_cents": analysis_metadata.get("cost_cents", 0.0),
+            "extraction_cost_cents": total_cost
+            - analysis_metadata.get("cost_cents", 0.0),
+        }
+
+    async def extract_single_datapoint(
+        self,
+        text_content: str,
+        datapoint: DataPointIdentification,
+        schema: Type[BaseModel],
+    ) -> DataExtractionResult:
+        """
+        Extract a single datapoint from the text.
+
+        Args:
+            text_content: Text string
+            datapoint: Datapoint to extract
+            schema: Pydantic schema for extraction
+
+        Returns:
+            DataExtractionResult
+        """
+        logger.info(
+            f"Starting extraction of datapoint: {datapoint.name} ({datapoint.data_type})"
+        )
+        extraction_task = f"""Extract: {datapoint.name} ({datapoint.data_type})
+Location: {datapoint.location_hint}
+
+For tables/lists: Use columnar format with 'columns' and 'data' arrays.
+For key-value pairs: Extract fields with proper types (numbers without symbols).
+
+Extract RAW VALUES only. Empty fields = null."""
+
+        try:
+            # Prepare message with text
+            messages = [
+                {
+                    "role": "user",
+                    "content": f"<text_content>\n{text_content}\n</text_content>\n\n{extraction_task}",
+                }
+            ]
+
+            # Call LLM directly with schema
+            logger.info(
+                f"Calling {self.extraction_provider}/{self.extraction_model} for extraction"
+            )
+            start_time = asyncio.get_event_loop().time()
+
+            result = await chat_async(
+                provider=self.extraction_provider,
+                model=self.extraction_model,
+                messages=messages,
+                temperature=self.temperature,
+                response_format=schema,
+            )
+
+            extraction_time = asyncio.get_event_loop().time() - start_time
+            logger.info(
+                f"Extraction of {datapoint.name} completed in {extraction_time:.2f} seconds"
+            )
+
+            # chat_async returns the response directly
+            return DataExtractionResult(
+                datapoint_name=datapoint.name,
+                success=True,
+                extracted_data=result.content,
+                cost_cents=result.cost_in_cents or 0.0,
+                input_tokens=result.input_tokens or 0,
+                output_tokens=result.output_tokens or 0,
+                cached_tokens=result.cached_input_tokens or 0,
+            )
+
+        except Exception as e:
+            logger.error(f"Error extracting datapoint {datapoint.name}: {e}")
+            return DataExtractionResult(
+                datapoint_name=datapoint.name,
+                success=False,
+                error=str(e),
+                cost_cents=0.0,
+                input_tokens=0,
+                output_tokens=0,
+                cached_tokens=0,
+            )
+
+    async def extract_all_data(
+        self,
+        text_content: str,
+        focus_areas: Optional[List[str]] = None,
+        datapoint_filter: Optional[List[str]] = None,
+    ) -> TextDataExtractionResult:
+        """
+        Extract all identified datapoints from text in parallel.
+
+        Args:
+            text_content: Text string to process
+            focus_areas: Optional areas to focus analysis on
+            datapoint_filter: Optional list of datapoint names to extract
+
+        Returns:
+            TextDataExtractionResult with all extracted data
+        """
+        start_time = asyncio.get_event_loop().time()
+
+        # Validate text size
+        text_size = len(text_content.encode("utf-8"))
+        if text_size > self.max_text_size_bytes:
+            raise ValueError(
+                f"Text content exceeds maximum size limit of {self.max_text_size_bytes / (1024 * 1024):.2f} MB. "
+                f"Actual size: {text_size / (1024 * 1024):.2f} MB"
+            )
+
+        # Generate a secure hash for the text content
+        content_hash = hashlib.sha256(text_content.encode()).hexdigest()[:16]
+
+        # Preprocess text
+        preprocessed_text = self._preprocess_text(text_content)
+
+        # Check cache if enabled
+        cache_key = f"{content_hash}:{','.join(focus_areas or [])}:{','.join(datapoint_filter or [])}"
+        if self.enable_caching and cache_key in self._analysis_cache:
+            logger.info(f"Using cached analysis for hash: {content_hash}")
+            cached_result = self._analysis_cache[cache_key]
+            return cached_result
+
+        # Step 1: Analyze text structure
+        logger.info(f"Analyzing text structure (hash: {content_hash})")
+        analysis, analysis_cost_metadata = await self.analyze_text_structure(
+            preprocessed_text, focus_areas
+        )
+
+        logger.info("Step 1 - Text Analysis completed:")
+        logger.info(f"  • Identified {len(analysis.identified_datapoints)} datapoints")
+        logger.info(
+            f"  • Cost: ${analysis_cost_metadata.get('cost_cents', 0.0) / 100:.4f}"
+        )
+        logger.info(
+            f"  • Input tokens: {analysis_cost_metadata.get('input_tokens', 0):,}"
+        )
+        logger.info(
+            f"  • Output tokens: {analysis_cost_metadata.get('output_tokens', 0):,}"
+        )
+        logger.info(
+            f"  • Cached tokens: {analysis_cost_metadata.get('cached_tokens', 0):,}"
+        )
+
+        # Filter datapoints if requested
+        datapoints_to_extract = analysis.identified_datapoints
+        if datapoint_filter:
+            datapoints_to_extract = [
+                dp for dp in datapoints_to_extract if dp.name in datapoint_filter
+            ]
+
+        # Step 2: Generate schemas for each datapoint
+        logger.info("Step 2 - Generating schemas for datapoints")
+        schemas = {}
+        for datapoint in datapoints_to_extract:
+            try:
+                schema = self._generate_pydantic_schema(datapoint)
+                schemas[datapoint.name] = schema
+                logger.info(f"Generated schema for {datapoint.name}")
+            except Exception as e:
+                logger.error(f"Failed to generate schema for {datapoint.name}: {e}")
+
+        # Step 3: Extract data in parallel
+        extraction_tasks = []
+        for datapoint in datapoints_to_extract:
+            if datapoint.name in schemas:
+                task = self.extract_single_datapoint(
+                    preprocessed_text, datapoint, schemas[datapoint.name]
+                )
+                extraction_tasks.append(task)
+
+        logger.info(f"Created {len(extraction_tasks)} extraction tasks")
+
+        # Limit concurrency
+        semaphore = asyncio.Semaphore(self.max_parallel_extractions)
+
+        async def extract_with_limit(task):
+            async with semaphore:
+                return await task
+
+        logger.info(
+            f"Step 3 - Starting parallel extraction of {len(extraction_tasks)} datapoints"
+        )
+        logger.info(f"Max parallel extractions: {self.max_parallel_extractions}")
+
+        extraction_start_time = asyncio.get_event_loop().time()
+        extraction_results = await asyncio.gather(
+            *[extract_with_limit(task) for task in extraction_tasks],
+            return_exceptions=True,
+        )
+
+        extraction_duration = asyncio.get_event_loop().time() - extraction_start_time
+        logger.info(f"All extractions completed in {extraction_duration:.2f} seconds")
+
+        logger.info("Step 3 - Individual extraction costs:")
+
+        # Process results
+        final_results = []
+        successful = 0
+        failed = 0
+
+        for result in extraction_results:
+            if isinstance(result, Exception):
+                failed += 1
+                final_results.append(
+                    DataExtractionResult(
+                        datapoint_name="unknown",
+                        success=False,
+                        error=str(result),
+                        cost_cents=0.0,
+                        input_tokens=0,
+                        output_tokens=0,
+                        cached_tokens=0,
+                    )
+                )
+            else:
+                final_results.append(result)
+
+                # Log individual extraction costs
+                if result.cost_cents > 0:
+                    logger.info(
+                        f"  • {result.datapoint_name}: ${result.cost_cents / 100:.4f} "
+                        f"(in:{result.input_tokens:,}, out:{result.output_tokens:,}, "
+                        f"cached:{result.cached_tokens:,}) - {'✅' if result.success else '❌'}"
+                    )
+
+                if result.success:
+                    successful += 1
+                else:
+                    failed += 1
+
+        # Aggregate cost and token metadata using helper method
+        cost_metadata = self._aggregate_cost_and_token_metadata(
+            analysis_cost_metadata, final_results
+        )
+
+        end_time = asyncio.get_event_loop().time()
+
+        # Log final summary
+        logger.info("Text Data Extraction completed:")
+        logger.info(f"  • Total time: {(end_time - start_time):.2f} seconds")
+        logger.info(f"  • Total cost: ${cost_metadata['total_cost_cents'] / 100:.4f}")
+        logger.info(
+            f"  • Analysis cost: ${cost_metadata['analysis_cost_cents'] / 100:.4f}"
+        )
+        logger.info(
+            f"  • Extraction cost: ${cost_metadata['extraction_cost_cents'] / 100:.4f}"
+        )
+        logger.info(
+            f"  • Total tokens: {cost_metadata['total_input_tokens'] + cost_metadata['total_output_tokens']:,} "
+            f"(in:{cost_metadata['total_input_tokens']:,}, out:{cost_metadata['total_output_tokens']:,}, "
+            f"cached:{cost_metadata['total_cached_tokens']:,})"
+        )
+        logger.info(
+            f"  • Success rate: {successful}/{successful + failed} "
+            f"({100 * successful / (successful + failed) if (successful + failed) > 0 else 0:.1f}%)"
+        )
+
+        result = TextDataExtractionResult(
+            text_content_hash=content_hash,
+            document_type=analysis.document_type,
+            total_datapoints_identified=len(analysis.identified_datapoints),
+            successful_extractions=successful,
+            failed_extractions=failed,
+            extraction_results=final_results,
+            total_time_ms=int((end_time - start_time) * 1000),
+            total_cost_cents=cost_metadata["total_cost_cents"],
+            metadata={
+                "content_description": analysis.content_description,
+                "filtered_datapoints": len(datapoints_to_extract),
+                "schemas_generated": len(schemas),
+                "total_input_tokens": cost_metadata["total_input_tokens"],
+                "total_output_tokens": cost_metadata["total_output_tokens"],
+                "total_cached_tokens": cost_metadata["total_cached_tokens"],
+                "analysis_cost_cents": cost_metadata["analysis_cost_cents"],
+                "extraction_cost_cents": cost_metadata["extraction_cost_cents"],
+            },
+        )
+
+        # Cache the result if enabled
+        if self.enable_caching:
+            self._analysis_cache[cache_key] = result
+
+        return result
+
+    async def extract_as_dict(
+        self,
+        text_content: str,
+        focus_areas: Optional[List[str]] = None,
+        datapoint_filter: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """
+        Extract all data and return as a dictionary for easy access.
+
+        Args:
+            text_content: Text string to process
+            focus_areas: Optional areas to focus analysis on
+            datapoint_filter: Optional list of datapoint names to extract
+
+        Returns:
+            Dictionary with datapoint names as keys and extracted data as values
+        """
+        result = await self.extract_all_data(
+            text_content, focus_areas, datapoint_filter
+        )
+
+        extracted_data = {
+            "metadata": {
+                "text_content_hash": result.text_content_hash,
+                "document_type": result.document_type,
+                "content_description": result.metadata.get("content_description", ""),
+                "extraction_summary": {
+                    "total_identified": result.total_datapoints_identified,
+                    "successful": result.successful_extractions,
+                    "failed": result.failed_extractions,
+                    "time_ms": result.total_time_ms,
+                    "cost_cents": result.total_cost_cents,
+                },
+            },
+            "data": {},
+        }
+
+        for extraction in result.extraction_results:
+            if extraction.success and extraction.extracted_data:
+                # Convert Pydantic model to dict if needed
+                data = extraction.extracted_data
+                if hasattr(data, "model_dump"):
+                    data = data.model_dump()
+                extracted_data["data"][extraction.datapoint_name] = data
+
+        return extracted_data
+
+
+# Convenience function for simple usage
+async def extract_text_data(
+    text_content: str, focus_areas: Optional[List[str]] = None, **kwargs
+) -> Dict[str, Any]:
+    """
+    Convenience function to extract all data from text.
+
+    Args:
+        text_content: Text string to process
+        focus_areas: Optional areas to focus on
+        **kwargs: Additional arguments for TextDataExtractor
+
+    Returns:
+        Dictionary with extracted data
+    """
+    extractor = TextDataExtractor(**kwargs)
+    return await extractor.extract_as_dict(text_content, focus_areas)

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,6 @@ Command-line interface documentation:
 
 - **PostgreSQL/MySQL** → [Database Operations](database-operations.md#supported-databases)
 - **BigQuery/Snowflake** → [Cloud Databases](database-operations.md#database-specific-examples)
-- **MongoDB/Elasticsearch** → [NoSQL Support](database-operations.md#supported-databases)
 - **SQLite/DuckDB** → [Local Databases](database-operations.md#supported-databases)
 
 ### By Provider

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -768,7 +768,7 @@ class LLMProvider(Enum):
 DBType = Literal[
     "postgres", "mysql", "bigquery", "snowflake",
     "databricks", "sqlserver", "redshift", "sqlite",
-    "duckdb", "mongo", "elastic"
+    "duckdb"
 ]
 
 class DBCredentials(TypedDict):

--- a/docs/database-operations.md
+++ b/docs/database-operations.md
@@ -29,8 +29,6 @@ The library supports 11 database types:
 | Redshift | `redshift` | host, port, database, user, password |
 | SQLite | `sqlite` | database (file path) |
 | DuckDB | `duckdb` | database (file path) |
-| MongoDB | `mongo` | connection_string, database |
-| Elasticsearch | `elastic` | host, port, user, password, use_ssl |
 
 ## SQL Agent Tools
 
@@ -236,25 +234,6 @@ colnames, results = await async_execute_query(
     db_type="snowflake",
     db_creds=snow_creds
 )
-
-# MongoDB (aggregation pipeline)
-mongo_creds = {
-    "connection_string": "mongodb://localhost:27017/",
-    "database": "mydb"
-}
-
-pipeline = [
-    {"$match": {"status": "active"}},
-    {"$group": {"_id": "$category", "count": {"$sum": 1}}},
-    {"$limit": 10}
-]
-
-colnames, results = await async_execute_query(
-    query=json.dumps(pipeline),
-    db_type="mongo",
-    db_creds=mongo_creds
-)
-```
 
 ## Schema Documentation
 

--- a/docs/text_data_extractor.md
+++ b/docs/text_data_extractor.md
@@ -1,0 +1,271 @@
+# Text Data Extractor
+
+The Text Data Extractor is an intelligent agent orchestrator that analyzes plain text documents (transcripts, speeches, reports, etc.) to identify and extract structured data suitable for SQL databases.
+
+## Features
+
+- **Automatic Data Point Discovery**: Identifies extractable data patterns in text
+- **Parallel Extraction**: Processes multiple data points concurrently
+- **Smart Schema Generation**: Creates appropriate Pydantic schemas for each data type
+- **Multiple Data Types Support**:
+  - Q&A pairs (interviews, press conferences)
+  - Key-value pairs (statistics, metrics)
+  - Lists (topics, recommendations)
+  - Tables (structured data within text)
+  - Statements (policy decisions, quotes)
+- **Cost-Effective**: Uses efficient prompting and caching
+
+## Installation
+
+The Text Data Extractor is included in the defog package:
+
+```bash
+pip install defog
+```
+
+## Basic Usage
+
+```python
+import asyncio
+from defog.llm import TextDataExtractor
+
+async def main():
+    # Initialize the extractor
+    extractor = TextDataExtractor()
+    
+    # Your text content
+    text_content = """
+    Transcript of Press Conference
+    
+    REPORTER: What is the current inflation rate?
+    SPEAKER: The inflation rate is currently at 2.3%, slightly above our 2% target.
+    
+    Key Economic Indicators:
+    - GDP Growth: 2.5%
+    - Unemployment: 4.2%
+    """
+    
+    # Extract all data
+    result = await extractor.extract_as_dict(text_content)
+    
+    # Access extracted data
+    print(result['data'])
+
+asyncio.run(main())
+```
+
+## Advanced Usage
+
+### Focusing on Specific Areas
+
+```python
+# Focus extraction on specific types of data
+result = await extractor.extract_as_dict(
+    text_content,
+    focus_areas=["Q&A exchanges", "economic indicators", "policy decisions"]
+)
+```
+
+### Filtering Specific Datapoints
+
+```python
+# First, analyze to see what's available
+analysis, _ = await extractor.analyze_text_structure(text_content)
+print("Available datapoints:", [dp.name for dp in analysis.identified_datapoints])
+
+# Then extract only specific ones
+result = await extractor.extract_all_data(
+    text_content,
+    datapoint_filter=["qa_exchanges", "economic_metrics"]
+)
+```
+
+### Custom Configuration
+
+```python
+extractor = TextDataExtractor(
+    analysis_provider="anthropic",
+    analysis_model="claude-sonnet-4-20250514",
+    extraction_provider="openai",
+    extraction_model="gpt-4.1",
+    max_parallel_extractions=10,
+    temperature=0.0,
+    enable_caching=True
+)
+```
+
+## Data Types and Schemas
+
+### Q&A Pairs
+Extracts question-answer exchanges with speaker identification:
+```python
+{
+    "exchanges": [
+        {
+            "questioner": "REPORTER",
+            "question": "What is the inflation outlook?",
+            "answer": "We expect inflation to moderate over the next year..."
+        }
+    ],
+    "total_exchanges": 5
+}
+```
+
+### Key-Value Pairs
+Extracts metrics, statistics, and labeled values:
+```python
+{
+    "gdp_growth": 2.5,
+    "unemployment_rate": 4.2,
+    "inflation_rate": 2.3,
+    "interest_rate": "4.25-4.5%"
+}
+```
+
+### Lists
+Extracts enumerated items, topics, or points:
+```python
+{
+    "items": [
+        "Implement new regulatory framework",
+        "Review monetary policy stance",
+        "Monitor inflation indicators"
+    ],
+    "item_count": 3
+}
+```
+
+### Tables
+Extracts tabular data in columnar format:
+```python
+{
+    "columns": ["quarter", "revenue", "growth"],
+    "data": [
+        ["Q1 2024", 1500000, 5.2],
+        ["Q2 2024", 1650000, 10.0]
+    ],
+    "row_count": 2
+}
+```
+
+## Example: Processing a Policy Speech Transcript
+
+```python
+import asyncio
+from defog.llm import extract_text_data
+
+async def analyze_speech():
+    # Read transcript
+    with open("fed_speech.txt", "r") as f:
+        transcript = f.read()
+    
+    # Extract with focus areas
+    result = await extract_text_data(
+        transcript,
+        focus_areas=[
+            "monetary policy decisions",
+            "economic forecasts",
+            "Q&A exchanges",
+            "key statistics"
+        ]
+    )
+    
+    # Process results
+    print(f"Document type: {result['metadata']['document_type']}")
+    print(f"Extracted {len(result['data'])} datapoints")
+    
+    # Save to JSON
+    import json
+    with open("speech_analysis.json", "w") as f:
+        json.dump(result, f, indent=2)
+
+asyncio.run(analyze_speech())
+```
+
+## Performance Optimization
+
+1. **Enable Caching**: Reuses analysis results for repeated documents
+   ```python
+   extractor = TextDataExtractor(enable_caching=True)
+   ```
+
+2. **Adjust Parallelism**: Control concurrent extractions
+   ```python
+   extractor = TextDataExtractor(max_parallel_extractions=10)
+   ```
+
+3. **Use Focused Extraction**: Specify areas to reduce analysis scope
+   ```python
+   result = await extractor.extract_as_dict(
+       text_content,
+       focus_areas=["Q&A only"]
+   )
+   ```
+
+## Cost Management
+
+The extractor tracks costs for transparency:
+
+```python
+result = await extractor.extract_all_data(text_content)
+print(f"Total cost: ${result.total_cost_cents / 100:.4f}")
+print(f"Analysis cost: ${result.metadata['analysis_cost_cents'] / 100:.4f}")
+print(f"Extraction cost: ${result.metadata['extraction_cost_cents'] / 100:.4f}")
+```
+
+## Integration with Other Extractors
+
+The Text Data Extractor follows the same pattern as other Defog extractors:
+
+```python
+from defog.llm import (
+    TextDataExtractor,
+    PDFDataExtractor,
+    HTMLDataExtractor,
+    ImageDataExtractor
+)
+
+# All extractors share similar interfaces
+text_extractor = TextDataExtractor()
+pdf_extractor = PDFDataExtractor()
+html_extractor = HTMLDataExtractor()
+image_extractor = ImageDataExtractor()
+
+# Extract from different sources
+text_data = await text_extractor.extract_as_dict(text_content)
+pdf_data = await pdf_extractor.extract_as_dict(pdf_url)
+html_data = await html_extractor.extract_as_dict(html_content)
+image_data = await image_extractor.extract_as_dict(image_url)
+```
+
+## Error Handling
+
+```python
+try:
+    result = await extractor.extract_all_data(text_content)
+    
+    # Check individual extraction results
+    for extraction in result.extraction_results:
+        if not extraction.success:
+            print(f"Failed to extract {extraction.datapoint_name}: {extraction.error}")
+            
+except ValueError as e:
+    print(f"Text too large: {e}")
+except Exception as e:
+    print(f"Extraction failed: {e}")
+```
+
+## Best Practices
+
+1. **Preprocess Text**: The extractor handles basic preprocessing, but you may want to clean your text first
+2. **Use Focus Areas**: Specify what you're looking for to improve accuracy and reduce costs
+3. **Monitor Costs**: Track extraction costs, especially for large documents
+4. **Cache Results**: Enable caching for documents you'll process multiple times
+5. **Validate Output**: Always validate extracted data matches your expectations
+
+## Limitations
+
+- Maximum text size: 5MB by default (configurable)
+- Best suited for structured text with clear patterns
+- May struggle with highly unstructured or creative text
+- Costs scale with document size and complexity

--- a/examples/text_data_extractor_example.py
+++ b/examples/text_data_extractor_example.py
@@ -1,0 +1,111 @@
+"""
+Example of using TextDataExtractor to extract structured data from text documents
+"""
+
+import asyncio
+import json
+import logging
+from defog.llm.text_data_extractor import TextDataExtractor
+
+# Set up logging to see what's happening
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+async def main():
+    # Read the example text file
+    logger.info("Reading example.txt")
+    with open("example.txt", "r") as f:
+        text_content = f.read()
+
+    logger.info(f"Loaded text content: {len(text_content)} characters")
+
+    # Initialize the extractor
+    logger.info("Initializing TextDataExtractor")
+    extractor = TextDataExtractor(
+        analysis_provider="anthropic",
+        analysis_model="claude-sonnet-4-20250514",
+        extraction_provider="anthropic",
+        extraction_model="claude-sonnet-4-20250514",
+        max_parallel_extractions=5,
+        temperature=0.0,
+    )
+
+    print("🔍 Analyzing text document...")
+    print("-" * 60)
+
+    logger.info("Starting extraction process")
+
+    # Extract all data with focus on Q&A and economic indicators
+    result = await extractor.extract_as_dict(
+        text_content,
+        focus_areas=["economic indicators", "policy decisions"],
+    )
+
+    # Print metadata
+    print(f"📄 Document Type: {result['metadata']['document_type']}")
+    print(f"📝 Description: {result['metadata']['content_description']}")
+    print("\n📊 Extraction Summary:")
+    summary = result["metadata"]["extraction_summary"]
+    print(f"  • Total datapoints identified: {summary['total_identified']}")
+    print(f"  • Successful extractions: {summary['successful']}")
+    print(f"  • Failed extractions: {summary['failed']}")
+    print(f"  • Time taken: {summary['time_ms']}ms")
+    print(f"  • Total cost: ${summary['cost_cents'] / 100:.4f}")
+
+    # Print extracted data
+    print("\n🎯 Extracted Data:")
+    print("-" * 60)
+
+    for datapoint_name, data in result["data"].items():
+        print(f"\n📌 {datapoint_name}:")
+
+        # Pretty print the data based on its structure
+        if isinstance(data, dict):
+            if "exchanges" in data:  # Q&A pairs
+                print(f"  Found {len(data.get('exchanges', []))} Q&A exchanges")
+                for i, exchange in enumerate(
+                    data.get("exchanges", [])[:3]
+                ):  # Show first 3
+                    print(f"\n  Exchange {i + 1}:")
+                    print(f"    Questioner: {exchange.get('questioner', 'N/A')}")
+                    print(f"    Question: {exchange.get('question', 'N/A')[:100]}...")
+                    print(f"    Answer: {exchange.get('answer', 'N/A')[:100]}...")
+                if len(data.get("exchanges", [])) > 3:
+                    print(
+                        f"  ... and {len(data.get('exchanges', [])) - 3} more exchanges"
+                    )
+
+            elif "columns" in data and "data" in data:  # Table format
+                print(f"  Columns: {', '.join(data['columns'])}")
+                print(f"  Rows: {len(data['data'])}")
+                # Show first few rows
+                for i, row in enumerate(data["data"][:3]):
+                    print(f"  Row {i + 1}: {row}")
+                if len(data["data"]) > 3:
+                    print(f"  ... and {len(data['data']) - 3} more rows")
+
+            elif "items" in data:  # List format
+                print(f"  Found {data.get('item_count', len(data['items']))} items")
+                for i, item in enumerate(data["items"][:5]):  # Show first 5
+                    print(f"  • {item}")
+                if len(data["items"]) > 5:
+                    print(f"  ... and {len(data['items']) - 5} more items")
+
+            else:  # Key-value pairs
+                for key, value in list(data.items())[:5]:  # Show first 5
+                    print(f"  • {key}: {value}")
+                if len(data) > 5:
+                    print(f"  ... and {len(data) - 5} more fields")
+
+    # Save full results to JSON
+    output_file = "text_extraction_results.json"
+    with open(output_file, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"\n💾 Full results saved to {output_file}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_async_defog.py
+++ b/tests/test_async_defog.py
@@ -102,13 +102,6 @@ class TestAsyncDefog(unittest.TestCase):
         with self.assertRaises(KeyError):
             AsyncDefog.check_db_creds("snowflake", {"account": "some_account"})
 
-    def test_check_db_creds_mongo(self):
-        db_creds = {"connection_string": "some_connection_string"}
-        AsyncDefog.check_db_creds("mongo", db_creds)
-        AsyncDefog.check_db_creds("mongo", {})
-        with self.assertRaises(KeyError):
-            AsyncDefog.check_db_creds("mongo", {"account": "some_account"})
-
     def test_check_db_creds_sqlserver(self):
         db_creds = {
             "server": "some_server",

--- a/tests/test_defog.py
+++ b/tests/test_defog.py
@@ -84,14 +84,6 @@ class TestDefog(unittest.TestCase):
             # incomplete keys
             Defog.check_db_creds("snowflake", {"account": "some_account"})
 
-    def test_check_db_creds_mongo(self):
-        db_creds = {"connection_string": "some_connection_string"}
-        Defog.check_db_creds("mongo", db_creds)
-        Defog.check_db_creds("mongo", {})
-        with self.assertRaises(KeyError):
-            # wrong key
-            Defog.check_db_creds("mongo", {"account": "some_account"})
-
     def test_check_db_creds_sqlserver(self):
         db_creds = {
             "server": "some_server",

--- a/tests/test_text_data_extractor.py
+++ b/tests/test_text_data_extractor.py
@@ -1,0 +1,380 @@
+"""
+Tests for TextDataExtractor
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from defog.llm.text_data_extractor import (
+    TextDataExtractor,
+    TextAnalysisResponse,
+    DataPointIdentification,
+    SchemaField,
+    extract_text_data,
+)
+
+
+@pytest.fixture
+def sample_text():
+    """Sample text content for testing."""
+    return """
+    TRANSCRIPT: Federal Reserve Press Conference
+    
+    CHAIR POWELL: Good afternoon. The economy remains strong with unemployment at 4.2%.
+    Inflation has moderated to 2.3% but remains above our 2% target.
+    
+    REPORTER: What is the Fed's stance on interest rates?
+    CHAIR POWELL: We've decided to keep rates unchanged at 4.25-4.5%.
+    
+    REPORTER: When might we see rate cuts?
+    CHAIR POWELL: We're monitoring the data closely. It depends on inflation trends.
+    
+    Key Economic Indicators:
+    - GDP Growth: 2.5%
+    - Unemployment Rate: 4.2%
+    - Core PCE Inflation: 2.6%
+    - Federal Funds Rate: 4.25-4.5%
+    """
+
+
+@pytest.fixture
+def mock_analysis_response():
+    """Mock response from text analysis."""
+    return TextAnalysisResponse(
+        document_type="transcript",
+        content_description="Federal Reserve press conference transcript with Q&A",
+        identified_datapoints=[
+            DataPointIdentification(
+                name="qa_exchanges",
+                description="Question and answer exchanges between reporters and Chair",
+                data_type="qa_pairs",
+                location_hint="Q&A section with REPORTER and CHAIR POWELL labels",
+                schema_fields=[
+                    SchemaField(
+                        name="questioner", type="string", description="Person asking"
+                    ),
+                    SchemaField(
+                        name="question", type="string", description="Question text"
+                    ),
+                    SchemaField(
+                        name="answer", type="string", description="Answer text"
+                    ),
+                ],
+            ),
+            DataPointIdentification(
+                name="economic_indicators",
+                description="Key economic metrics mentioned",
+                data_type="key_value_pairs",
+                location_hint="Key Economic Indicators section",
+                schema_fields=[
+                    SchemaField(
+                        name="gdp_growth", type="float", description="GDP growth rate"
+                    ),
+                    SchemaField(
+                        name="unemployment_rate",
+                        type="float",
+                        description="Unemployment rate",
+                    ),
+                    SchemaField(
+                        name="core_pce_inflation",
+                        type="float",
+                        description="Core PCE inflation",
+                    ),
+                    SchemaField(
+                        name="federal_funds_rate",
+                        type="string",
+                        description="Fed funds rate",
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_text_data_extractor_initialization():
+    """Test TextDataExtractor initialization."""
+    extractor = TextDataExtractor(
+        analysis_provider="anthropic",
+        analysis_model="claude-sonnet-4-20250514",
+        max_parallel_extractions=3,
+        temperature=0.5,
+    )
+
+    assert extractor.analysis_provider == "anthropic"
+    assert extractor.analysis_model == "claude-sonnet-4-20250514"
+    assert extractor.max_parallel_extractions == 3
+    assert extractor.temperature == 0.5
+    assert extractor.enable_caching is True
+
+
+@pytest.mark.asyncio
+async def test_analyze_text_structure(sample_text, mock_analysis_response):
+    """Test text structure analysis."""
+    extractor = TextDataExtractor()
+
+    # Mock the chat_async call
+    mock_result = MagicMock()
+    mock_result.content = mock_analysis_response
+    mock_result.cost_in_cents = 1.5
+    mock_result.input_tokens = 1000
+    mock_result.output_tokens = 500
+    mock_result.cached_input_tokens = 0
+
+    with patch("defog.llm.text_data_extractor.chat_async", return_value=mock_result):
+        analysis, cost_metadata = await extractor.analyze_text_structure(
+            sample_text, focus_areas=["Q&A exchanges"]
+        )
+
+    assert analysis.document_type == "transcript"
+    assert len(analysis.identified_datapoints) == 2
+    assert analysis.identified_datapoints[0].name == "qa_exchanges"
+    assert cost_metadata["cost_cents"] == 1.5
+    assert cost_metadata["input_tokens"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_extract_single_datapoint(sample_text, mock_analysis_response):
+    """Test extracting a single datapoint."""
+    extractor = TextDataExtractor()
+    datapoint = mock_analysis_response.identified_datapoints[0]  # qa_exchanges
+    schema = extractor._generate_pydantic_schema(datapoint)
+
+    # Mock the extraction result
+    mock_qa_data = {
+        "exchanges": [
+            {
+                "questioner": "REPORTER",
+                "question": "What is the Fed's stance on interest rates?",
+                "answer": "We've decided to keep rates unchanged at 4.25-4.5%.",
+            },
+            {
+                "questioner": "REPORTER",
+                "question": "When might we see rate cuts?",
+                "answer": "We're monitoring the data closely. It depends on inflation trends.",
+            },
+        ],
+        "total_exchanges": 2,
+    }
+
+    mock_result = MagicMock()
+    mock_result.content = mock_qa_data
+    mock_result.cost_in_cents = 0.8
+    mock_result.input_tokens = 500
+    mock_result.output_tokens = 200
+    mock_result.cached_input_tokens = 100
+
+    with patch("defog.llm.text_data_extractor.chat_async", return_value=mock_result):
+        result = await extractor.extract_single_datapoint(
+            sample_text, datapoint, schema
+        )
+
+    assert result.success is True
+    assert result.datapoint_name == "qa_exchanges"
+    assert result.extracted_data == mock_qa_data
+    assert result.cost_cents == 0.8
+
+
+@pytest.mark.asyncio
+async def test_extract_all_data(sample_text, mock_analysis_response):
+    """Test extracting all datapoints."""
+    extractor = TextDataExtractor()
+
+    # Mock the analysis response
+    mock_analysis_result = MagicMock()
+    mock_analysis_result.content = mock_analysis_response
+    mock_analysis_result.cost_in_cents = 1.5
+    mock_analysis_result.input_tokens = 1000
+    mock_analysis_result.output_tokens = 500
+    mock_analysis_result.cached_input_tokens = 0
+
+    # Mock extraction results
+    mock_qa_data = {
+        "exchanges": [
+            {
+                "questioner": "REPORTER",
+                "question": "What is the Fed's stance on interest rates?",
+                "answer": "We've decided to keep rates unchanged at 4.25-4.5%.",
+            },
+        ],
+        "total_exchanges": 1,
+    }
+
+    mock_indicators_data = {
+        "gdp_growth": 2.5,
+        "unemployment_rate": 4.2,
+        "core_pce_inflation": 2.6,
+        "federal_funds_rate": "4.25-4.5%",
+    }
+
+    mock_extraction_results = [
+        MagicMock(
+            content=mock_qa_data,
+            cost_in_cents=0.8,
+            input_tokens=500,
+            output_tokens=200,
+            cached_input_tokens=100,
+        ),
+        MagicMock(
+            content=mock_indicators_data,
+            cost_in_cents=0.6,
+            input_tokens=400,
+            output_tokens=150,
+            cached_input_tokens=50,
+        ),
+    ]
+
+    with patch("defog.llm.text_data_extractor.chat_async") as mock_chat:
+        # First call for analysis, subsequent calls for extraction
+        mock_chat.side_effect = [mock_analysis_result] + mock_extraction_results
+
+        result = await extractor.extract_all_data(sample_text)
+
+    assert result.document_type == "transcript"
+    assert result.total_datapoints_identified == 2
+    assert result.successful_extractions == 2
+    assert result.failed_extractions == 0
+    assert result.total_cost_cents == pytest.approx(2.9)  # 1.5 + 0.8 + 0.6
+    assert len(result.extraction_results) == 2
+
+
+@pytest.mark.asyncio
+async def test_extract_as_dict(sample_text):
+    """Test extracting data as dictionary."""
+    extractor = TextDataExtractor()
+
+    # Create a minimal mock that returns the expected structure
+    mock_result = MagicMock()
+    mock_result.text_content_hash = "abc123"
+    mock_result.document_type = "transcript"
+    mock_result.total_datapoints_identified = 2
+    mock_result.successful_extractions = 2
+    mock_result.failed_extractions = 0
+    mock_result.total_time_ms = 1500
+    mock_result.total_cost_cents = 2.9
+    mock_result.metadata = {"content_description": "Test transcript"}
+
+    # Create mock extraction results
+    mock_result.extraction_results = [
+        MagicMock(
+            success=True,
+            datapoint_name="qa_exchanges",
+            extracted_data={"exchanges": [], "total_exchanges": 0},
+        ),
+        MagicMock(
+            success=True,
+            datapoint_name="economic_indicators",
+            extracted_data={"gdp_growth": 2.5},
+        ),
+    ]
+
+    with patch.object(extractor, "extract_all_data", return_value=mock_result):
+        result_dict = await extractor.extract_as_dict(sample_text)
+
+    assert "metadata" in result_dict
+    assert "data" in result_dict
+    assert result_dict["metadata"]["document_type"] == "transcript"
+    assert "qa_exchanges" in result_dict["data"]
+    assert "economic_indicators" in result_dict["data"]
+
+
+@pytest.mark.asyncio
+async def test_convenience_function(sample_text):
+    """Test the convenience function."""
+    # Mock the entire extraction process
+    mock_dict_result = {
+        "metadata": {
+            "document_type": "transcript",
+            "extraction_summary": {
+                "total_identified": 2,
+                "successful": 2,
+                "failed": 0,
+            },
+        },
+        "data": {
+            "qa_exchanges": {"exchanges": [], "total_exchanges": 0},
+            "economic_indicators": {"gdp_growth": 2.5},
+        },
+    }
+
+    with patch(
+        "defog.llm.text_data_extractor.TextDataExtractor.extract_as_dict",
+        return_value=mock_dict_result,
+    ):
+        result = await extract_text_data(sample_text, focus_areas=["Q&A"])
+
+    assert result == mock_dict_result
+
+
+@pytest.mark.asyncio
+async def test_preprocess_text():
+    """Test text preprocessing."""
+    extractor = TextDataExtractor()
+
+    raw_text = """
+    
+    Line 1
+    
+    
+    Line 2
+      Line 3 with spaces  
+    
+    """
+
+    processed = extractor._preprocess_text(raw_text)
+    expected = "Line 1\n\nLine 2\nLine 3 with spaces"
+
+    assert processed == expected
+
+
+@pytest.mark.asyncio
+async def test_caching():
+    """Test caching functionality."""
+    extractor = TextDataExtractor(enable_caching=True)
+
+    # Create mock result
+    mock_result = MagicMock()
+    mock_result.text_content_hash = "abc123"
+    mock_result.document_type = "transcript"
+    mock_result.total_datapoints_identified = 1
+    mock_result.successful_extractions = 1
+    mock_result.failed_extractions = 0
+    mock_result.extraction_results = []
+    mock_result.total_time_ms = 1000
+    mock_result.total_cost_cents = 1.0
+    mock_result.metadata = {}
+
+    # Mock the analysis to return consistent results
+    mock_analysis = TextAnalysisResponse(
+        document_type="transcript", content_description="Test", identified_datapoints=[]
+    )
+
+    mock_analysis_result = MagicMock()
+    mock_analysis_result.content = mock_analysis
+    mock_analysis_result.cost_in_cents = 1.0
+    mock_analysis_result.input_tokens = 100
+    mock_analysis_result.output_tokens = 50
+    mock_analysis_result.cached_input_tokens = 0
+
+    with patch(
+        "defog.llm.text_data_extractor.chat_async", return_value=mock_analysis_result
+    ):
+        # First call should analyze
+        result1 = await extractor.extract_all_data("test content")
+
+        # Second call should use cache
+        result2 = await extractor.extract_all_data("test content")
+
+        # Results should be the same object (cached)
+        assert result1 is result2
+
+
+@pytest.mark.asyncio
+async def test_text_size_validation():
+    """Test text size validation."""
+    extractor = TextDataExtractor(max_text_size_mb=1)
+
+    # Create text larger than 1MB
+    large_text = "a" * (2 * 1024 * 1024)  # 2MB
+
+    with pytest.raises(ValueError, match="Text content exceeds maximum size"):
+        await extractor.extract_all_data(large_text)


### PR DESCRIPTION
## Summary
- Removed MongoDB and Elasticsearch support from data extraction code (as they are unsupported)
- Updated example to use OpenAI's o3 model instead of Claude Sonnet
- Successfully tested text extraction with the new configuration

## Test plan
- [x] Run text_data_extractor_example.py with sample text
- [x] Verify extraction works with OpenAI o3 model
- [x] Confirm no MongoDB/Elasticsearch dependencies remain