### PR TITLE
Add tool output sampling hooks and previews

### DIFF
--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -84,6 +84,8 @@ class BaseLLMProvider(ABC):
         response_format=None,
         post_tool_function: Optional[Callable] = None,
         post_response_hook: Optional[Callable] = None,
+        tool_sample_functions: Optional[Dict[str, Callable]] = None,
+        tool_result_preview_max_tokens: Optional[int] = None,
         **kwargs,
     ) -> Tuple[
         Any, List[Dict[str, Any]], int, int, Optional[int], Optional[Dict[str, int]]
@@ -109,6 +111,8 @@ class BaseLLMProvider(ABC):
         post_tool_function: Optional[Callable] = None,
         post_response_hook: Optional[Callable] = None,
         tool_budget: Optional[Dict[str, int]] = None,
+        tool_sample_functions: Optional[Dict[str, Callable]] = None,
+        tool_result_preview_max_tokens: Optional[int] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with the provider."""
@@ -257,13 +261,23 @@ class BaseLLMProvider(ABC):
         tool_budget: Optional[Dict[str, int]] = None,
         image_result_keys: Optional[List[str]] = None,
         tool_output_max_tokens: Optional[int] = None,
+        tool_sample_functions: Optional[Dict[str, Callable]] = None,
+        tool_result_preview_max_tokens: Optional[int] = None,
     ) -> ToolHandler:
         """Create a ToolHandler instance with optional tool budget, image result keys, and output token limit."""
-        if tool_budget or image_result_keys or tool_output_max_tokens is not None:
+        if (
+            tool_budget
+            or image_result_keys
+            or tool_output_max_tokens is not None
+            or tool_sample_functions
+            or tool_result_preview_max_tokens is not None
+        ):
             return ToolHandler(
                 tool_budget=tool_budget,
                 image_result_keys=image_result_keys,
                 tool_output_max_tokens=tool_output_max_tokens,
+                tool_sample_functions=tool_sample_functions,
+                tool_result_preview_max_tokens=tool_result_preview_max_tokens,
             )
         return self.tool_handler
 

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -117,6 +117,8 @@ async def chat_async(
     citations_instructions: Optional[str] = None,
     parallel_tool_calls: bool = False,
     tool_output_max_tokens: int = 10000,
+    tool_result_preview_max_tokens: Optional[int] = None,
+    tool_sample_functions: Optional[Dict[str, Callable]] = None,
     previous_response_id: Optional[str] = None,
     citations_model: Optional[str] = None,
     citations_provider: Optional[Union[LLMProvider, str]] = None,
@@ -148,6 +150,8 @@ async def chat_async(
         mcp_servers: List of MCP server urls for streamable http servers (e.g., ["http://localhost:8000/mcp", "http://localhost:8001/mcp"])
         image_result_keys: List of keys to check in tool results for image data (e.g., ['image_base64', 'screenshot_data'])
         tool_budget: Dictionary mapping tool names to maximum allowed calls. Tools not in the dictionary have unlimited calls.
+        tool_result_preview_max_tokens: Optional token budget for the tool output preview that is sent back to the LLM. The full tool result is still stored in tool_outputs.
+        tool_sample_functions: Optional mapping of tool name to sampler function (or a single callable) used to downsample tool outputs before returning them to the LLM.
         insert_tool_citations: If True, adds citations to the response using tool outputs as source documents (OpenAI and Anthropic only)
         citations_model: Optional model to use specifically for generating citations. If provided, the provider is inferred from the model name unless citations_provider is set. If not provided, the main model is used.
         citations_provider: Optional provider to use for generating citations. Overrides provider inference from citations_model. Accepts LLMProvider enum or string name. If not provided, the main provider is used.
@@ -295,6 +299,8 @@ async def chat_async(
                 tool_budget=tool_budget,
                 parallel_tool_calls=parallel_tool_calls,
                 tool_output_max_tokens=tool_output_max_tokens,
+                tool_result_preview_max_tokens=tool_result_preview_max_tokens,
+                tool_sample_functions=tool_sample_functions,
                 previous_response_id=previous_response_id,
                 return_tool_outputs_only=insert_tool_citations,
             )

--- a/defog/llm/utils_memory.py
+++ b/defog/llm/utils_memory.py
@@ -42,6 +42,8 @@ async def chat_async_with_memory(
     tool_choice: Optional[str] = None,
     max_retries: Optional[int] = None,
     post_tool_function: Optional[Callable] = None,
+    tool_result_preview_max_tokens: Optional[int] = None,
+    tool_sample_functions: Optional[Dict[str, Callable]] = None,
     config: Optional[LLMConfig] = None,
 ) -> LLMResponse:
     """
@@ -95,6 +97,8 @@ async def chat_async_with_memory(
             tool_choice=tool_choice,
             max_retries=max_retries,
             post_tool_function=post_tool_function,
+            tool_result_preview_max_tokens=tool_result_preview_max_tokens,
+            tool_sample_functions=tool_sample_functions,
             config=config,
         )
 
@@ -161,6 +165,8 @@ async def chat_async_with_memory(
         tool_choice=tool_choice,
         max_retries=max_retries,
         post_tool_function=post_tool_function,
+        tool_result_preview_max_tokens=tool_result_preview_max_tokens,
+        tool_sample_functions=tool_sample_functions,
         config=config,
     )
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -244,8 +244,14 @@ async def chat_async(
     insert_tool_citations: bool = False,
     parallel_tool_calls: bool = False,
     tool_output_max_tokens: int = 10000,
+    tool_result_preview_max_tokens: Optional[int] = None,
+    tool_sample_functions: Optional[Dict[str, Callable]] = None,
+    previous_response_id: Optional[str] = None,
 ) -> LLMResponse
 ```
+
+- `tool_result_preview_max_tokens`: Optional token budget for the tool output preview that is sent back to the LLM. Full tool outputs are still stored on the response object.
+- `tool_sample_functions`: Optional mapping of tool name to a callable (or a single callable) that returns a sampled version of the tool output before it is passed back to the LLM.
 
 ### LLMResponse
 
@@ -265,6 +271,8 @@ class LLMResponse:
     tool_outputs: Optional[List[Dict[str, Any]]] = None
     citations: Optional[List[Dict[str, Any]]] = None
 ```
+
+Each entry in `tool_outputs` contains the full tool `result`, and when sampling/truncation is enabled it also includes a `result_for_llm` preview plus `result_truncated_for_llm` and `sampling_applied` flags.
 
 ### Tool Functions
 

--- a/docs/llm/function-calling.md
+++ b/docs/llm/function-calling.md
@@ -105,3 +105,27 @@ response = await chat_async(
     max_tool_iterations=3,            # Limit recursive calls
 )
 ```
+
+### Keep Tool Outputs Token-Efficient
+
+Pass lightweight previews back to the model while still storing full tool results:
+
+```python
+def sample_query_output(function_name: str, tool_result: dict, **_):
+    # Keep just a small slice of the data
+    return {
+        "rows": tool_result.get("rows", [])[:5],
+        "row_count": len(tool_result.get("rows", [])),
+    }
+
+response = await chat_async(
+    provider=LLMProvider.OPENAI,
+    model="gpt-4o-mini",
+    messages=messages,
+    tools=[execute_database_query],
+    tool_sample_functions={"execute_database_query": sample_query_output},
+    tool_result_preview_max_tokens=2000,  # Trim what gets sent back to the LLM
+)
+```
+
+The assistant receives the sampled/truncated preview, while `response.tool_outputs` always contains the full tool output for logging or follow-up use.


### PR DESCRIPTION
## Summary
- add optional per-tool sampling hooks and preview token limits so models receive trimmed tool outputs while full results remain in tool_outputs
- surface preview metadata (result_for_llm, result_truncated_for_llm, sampling_applied) across OpenAI/Anthropic/Gemini/DeepSeek/Mistral
- document the new knobs and add tests for sampling and truncation utilities

## Usage
```python
from defog.llm.utils import chat_async
from defog.llm.llm_providers import LLMProvider

# sampler can be a dict per tool or a single callable
async def sample_rows(function_name: str, tool_result: dict, **_):
    rows = tool_result.get("rows", [])
    return {"rows": rows[:5], "row_count": len(rows)}

response = await chat_async(
    provider=LLMProvider.OPENAI,
    model="gpt-4o-mini",
    messages=[{"role": "user", "content": "Run the slow SQL"}],
    tools=[run_sql],
    tool_sample_functions={"run_sql": sample_rows},
    tool_result_preview_max_tokens=2000,
)

# response.tool_outputs[0]["result"]  -> full tool output
# response.tool_outputs[0]["result_for_llm"]  -> sampled/trimmed preview sent to model
```

## Testing
- pytest tests/test_tool_output_validation.py

---

Closes https://github.com/defog-ai/defog/issues/196