### PR TITLE
Use adaptive thinking for Opus 4.6, fix model detection for Claude 4

### DIFF
--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -79,6 +79,12 @@ MODEL_COSTS = {
         "cache_creation_input_cost_per1k": 0.00625,
         "output_cost_per1k": 0.025,
     },
+    "claude-opus-4-6": {
+        "input_cost_per1k": 0.005,
+        "cached_input_cost_per1k": 0.00125,
+        "cache_creation_input_cost_per1k": 0.00625,
+        "output_cost_per1k": 0.025,
+    },
     "claude-haiku-4-5": {
         "input_cost_per1k": 0.001,
         "cached_input_cost_per1k": 0.0001,


### PR DESCRIPTION
- Replace budget_tokens with thinking: {type: "adaptive"} and
  output_config.effort for Claude Opus 4.6 (budget_tokens is deprecated)
- Fix extended thinking model detection: use "-4" instead of "-4-" so
  "claude-sonnet-4" (without date suffix) is also matched
- Handle "max" effort level for non-adaptive models by mapping to high
- Add claude-opus-4-6 pricing to model cost table
- Clarify interleaved thinking beta header comments

https://claude.ai/code/session_01C3xfsZg3wtJA8jAaM5bRnB