### PR TITLE
Fix OpenAI Responses API tool spec format issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.4.26"
+version = "1.4.27"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Fixes two related bugs in the OpenAI provider where Chat Completions-style tool specs (`{"type": "function", "function": {"name": ...}}`) were being sent to the Responses API, which expects a flat format (`{"type": "function", "name": ...}`). This caused `"Missing required parameter: tools[0].name"` errors.

**Root cause:** The base class `update_tools_with_budget` rebuilds tool specs using `get_function_specs`, which returns Chat Completions format. The OpenAI provider was only flattening specs during initial `build_request_params`, but not after the base class re-built them mid-loop when tool budgets changed.

**Changes:**

- **Extract `_flatten_tool_specs` static method** — Moves the inline flattening logic from `build_request_params` into a reusable static method. This converts nested Chat Completions-style tool specs to the flat format required by the Responses API.

- **Override `update_tools_with_budget`** — Calls `super()` to let the base class handle budget logic, then re-flattens the tool specs it produced. This ensures specs stay in Responses API format even after budget-driven tool list changes mid-conversation.

- **Strip tool params from final structured output call** — When `response_format` is set, the final API call is for structured output, not tool use. Tool-related keys (`tools`, `tool_choice`, `parallel_tool_calls`) are now stripped from this call. This prevents stale or un-flattened tool specs from causing the same `tools[0].name` error on the final completion.

- **Version bump** to 1.4.27.

## Test plan

- [x] Verify `chat_async` with OpenAI models + tools + tool budgets no longer raises `"Missing required parameter: tools[0].name"`
- [x] Verify `chat_async` with OpenAI models + tools + `response_format` completes structured output successfully after tool calls
- [x] Verify basic tool calling (no budget) still works as before
- [x] Run `PYTHONPATH=. python -m pytest tests/` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)