### PR TITLE
Fix Anthropic web search thinking + tool_choice conflict

### DIFF
--- a/defog/llm/web_search.py
+++ b/defog/llm/web_search.py
@@ -170,6 +170,8 @@ async def web_search_tool(
 
             # Add reasoning effort for claude-3-7 and claude-4 models
             if reasoning_effort and ("3-7" in model or "-4-" in model):
+                # "any" tool_choice conflicts with thinking, use "auto" instead
+                request_params["tool_choice"] = {"type": "auto"}
                 request_params["temperature"] = 1.0
                 budget_tokens_map = {
                     "low": 2048,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.4.30"
+version = "1.4.31"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.4.30"
+version = "1.4.31"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- When `reasoning_effort` is set for Anthropic web search, `tool_choice={"type": "any"}` conflicts with extended thinking, causing a 400 error
- Changed `tool_choice` to `{"type": "auto"}` when thinking is enabled, so both features can coexist

Fixes #236

## Test plan
- [x] Verified Anthropic web search with `reasoning_effort` no longer returns 400
- [x] `ruff check` and `ruff format` pass
- [x] Existing test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)