### PR TITLE
Increase Anthropic default max_tokens to 64000

### DIFF
--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -233,7 +233,7 @@ class AnthropicProvider(BaseLLMProvider):
 
         # Anthropic does not allow `None` as a value for max_completion_tokens
         if max_completion_tokens is None:
-            max_completion_tokens = 32000
+            max_completion_tokens = 64000
 
         params = {
             "system": sys_msg,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.4.33"
+version = "1.4.34"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.4.31"
+version = "1.4.34"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Increase default `max_tokens` for Anthropic provider from 32000 to 64000
- Bump version to 1.4.34

## Test plan
- [x] Verify Anthropic API calls use the new 64000 default when no `max_completion_tokens` is specified

🤖 Generated with [Claude Code](https://claude.com/claude-code)