### PR TITLE
Replace diskcache with async pickle files for conversation cache

### DIFF
--- a/defog/llm/memory/conversation_cache.py
+++ b/defog/llm/memory/conversation_cache.py
@@ -1,16 +1,16 @@
-"""Disk-backed conversation cache for providers without stateful sessions."""
+"""Async file-backed conversation cache for providers without stateful sessions."""
 
+import os
+import pickle
+import re
+import time
 from copy import deepcopy
-import threading
 from pathlib import Path
 from typing import Any, Dict, Hashable, List, Optional, Set, Tuple
 
-from diskcache import Cache
+import aiofiles
 
 from defog import config as defog_config
-
-_CACHE: Optional[Cache] = None
-_CACHE_LOCK = threading.Lock()
 
 
 def _get_cache_directory() -> Path:
@@ -23,27 +23,39 @@ def _get_cache_directory() -> Path:
     return path
 
 
-def get_cache() -> Cache:
-    """Return global disk cache instance."""
-    global _CACHE
-    if _CACHE is None:
-        with _CACHE_LOCK:
-            if _CACHE is None:
-                _CACHE = Cache(str(_get_cache_directory()))
-    return _CACHE
+def _sanitize_filename(response_id: str) -> str:
+    """Replace non-alphanumeric characters (except _ and -) for safe filenames."""
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", response_id)
 
 
-def load_messages(response_id: Optional[str]) -> Optional[List[Dict[str, Any]]]:
+def _get_pickle_path(response_id: str) -> Path:
+    return _get_cache_directory() / f"{_sanitize_filename(response_id)}.pkl"
+
+
+async def load_messages(
+    response_id: Optional[str],
+) -> Optional[List[Dict[str, Any]]]:
     """Load messages for a cached conversation."""
     if not response_id:
         return None
-    data = get_cache().get(response_id)
-    if not data:
+    path = _get_pickle_path(response_id)
+    if not path.exists():
         return None
-    messages = data.get("messages") if isinstance(data, dict) else data
-    if messages is None:
+    try:
+        async with aiofiles.open(path, "rb") as f:
+            raw = await f.read()
+        data = pickle.loads(raw)
+        # Check TTL
+        expire_at = data.get("expire_at") if isinstance(data, dict) else None
+        if expire_at is not None and time.time() > expire_at:
+            path.unlink(missing_ok=True)
+            return None
+        messages = data.get("messages") if isinstance(data, dict) else data
+        if messages is None:
+            return None
+        return deepcopy(messages)
+    except Exception:
         return None
-    return deepcopy(messages)
 
 
 def _message_signature(message: Dict[str, Any]) -> Tuple[str, Hashable]:
@@ -100,17 +112,26 @@ def _expand_messages_with_parents(
     return expanded
 
 
-def store_messages(
+async def store_messages(
     response_id: str, messages: List[Dict[str, Any]], expire: Optional[int] = None
 ) -> None:
     """Persist conversation messages under a response id."""
     if not response_id:
         return
     expanded_messages = _expand_messages_with_parents(messages)
-    payload = {"messages": deepcopy(expanded_messages)}
-    get_cache().set(response_id, payload, expire=expire)
+    payload: Dict[str, Any] = {"messages": deepcopy(expanded_messages)}
+    if expire is not None:
+        payload["expire_at"] = time.time() + expire
+    raw = pickle.dumps(payload, protocol=pickle.HIGHEST_PROTOCOL)
+    path = _get_pickle_path(response_id)
+    tmp_path = path.with_suffix(".pkl.tmp")
+    async with aiofiles.open(tmp_path, "wb") as f:
+        await f.write(raw)
+    os.replace(str(tmp_path), str(path))
 
 
-def clear_cache() -> None:
+async def clear_cache() -> None:
     """Clear all cached conversations (primarily for tests)."""
-    get_cache().clear()
+    cache_dir = _get_cache_directory()
+    for p in cache_dir.glob("*.pkl*"):
+        p.unlink(missing_ok=True)

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -831,7 +831,7 @@ class AnthropicProvider(BaseLLMProvider):
         # Filter tools based on budget before building params
         tools = self.filter_tools_by_budget(tools, tool_handler)
 
-        conversation_messages = self.prepare_conversation_messages(
+        conversation_messages = await self.prepare_conversation_messages(
             messages, previous_response_id
         )
 
@@ -893,7 +893,9 @@ class AnthropicProvider(BaseLLMProvider):
             history_for_cache = self.append_assistant_message_to_history(
                 conversation_messages, content
             )
-            self.persist_conversation_history(cache_response_id, history_for_cache)
+            await self.persist_conversation_history(
+                cache_response_id, history_for_cache
+            )
             response_id = cache_response_id
 
         # Calculate cost

--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -373,14 +373,14 @@ class BaseLLMProvider(ABC):
 
         return tools, tool_handler.build_tool_dict(tools)
 
-    def _load_cached_conversation(
+    async def _load_cached_conversation(
         self, previous_response_id: Optional[str]
     ) -> Optional[List[Dict[str, Any]]]:
         """Fetch cached conversation for a response id."""
         if not previous_response_id:
             return None
         try:
-            return load_cached_messages(previous_response_id)
+            return await load_cached_messages(previous_response_id)
         except Exception as exc:
             self.logger.warning(
                 "Failed to load cached conversation for %s: %s",
@@ -412,28 +412,28 @@ class BaseLLMProvider(ABC):
         combined.extend(deepcopy(new_messages[overlap:]))
         return combined
 
-    def prepare_conversation_messages(
+    async def prepare_conversation_messages(
         self,
         messages: List[Dict[str, Any]],
         previous_response_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """Return full conversation including any cached history."""
         base_messages = deepcopy(messages)
-        cached_messages = self._load_cached_conversation(previous_response_id)
+        cached_messages = await self._load_cached_conversation(previous_response_id)
         if cached_messages:
             base_messages = self._merge_cached_and_new_messages(
                 cached_messages, base_messages
             )
         return base_messages
 
-    def persist_conversation_history(
+    async def persist_conversation_history(
         self, response_id: Optional[str], messages: List[Dict[str, Any]]
     ) -> None:
         """Persist conversation history for later continuation."""
         if not response_id or not messages:
             return
         try:
-            store_cached_messages(response_id, messages)
+            await store_cached_messages(response_id, messages)
         except Exception as exc:
             self.logger.warning(
                 "Failed to store conversation history for %s: %s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.4.34"
+version = "1.4.35"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,4 @@ pre-commit
 portalocker
 click
 httpx
-diskcache
 jsonref

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -412,7 +412,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
     async def test_chat_async_conversation_follow_up_with_tools_real(self):
         from defog.llm.memory import conversation_cache
 
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
         async def multiply_numbers(x: float, y: float) -> float:
             """Multiply two numbers via tool call."""
@@ -454,7 +454,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
         assert tool_output["result"] in (261828, 261828.0)
         assert response1.response_id
 
-        cached_first = conversation_cache.load_messages(response1.response_id)
+        cached_first = await conversation_cache.load_messages(response1.response_id)
         assert cached_first is not None
         assert cached_first[-1]["role"] == "assistant"
 
@@ -486,18 +486,18 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
         assert tool_output["name"] == "multiply_numbers"
         assert tool_output["result"] in (21993552, 21993552.0)
 
-        cached_second = conversation_cache.load_messages(response2.response_id)
+        cached_second = await conversation_cache.load_messages(response2.response_id)
         assert cached_second is not None
         assert cached_second[-1]["role"] == "assistant"
         assert cached_second[-1]["content"] == response2.content
 
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
     @skip_if_no_api_key("gemini")
     async def test_chat_async_gemini_follow_up_with_tools_real(self):
         from defog.llm.memory import conversation_cache
 
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
         async def multiply_numbers(x: float, y: float) -> float:
             """Multiply two numbers via tool call."""
@@ -571,19 +571,19 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
         assert tool_output["name"] == "multiply_numbers"
         assert tool_output["result"] in (21993552, 21993552.0)
 
-        # cached_second = conversation_cache.load_messages(response2.response_id)
+        # cached_second = await conversation_cache.load_messages(response2.response_id)
         # assert cached_second is not None
         # assert cached_second[-1]["role"] == "assistant"
         # assert cached_second[-1]["content"] == response2.content
 
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
     async def test_chat_async_conversation_follow_up_with_tools_real_grandparent_cache(
         self,
     ):
         from defog.llm.memory import conversation_cache
 
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
         async def multiply_numbers(x: float, y: float) -> float:
             """Multiply two numbers via tool call."""
@@ -653,7 +653,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
         assert response3.tool_outputs[0]["name"] == "multiply_numbers"
         assert response3.tool_outputs[0]["result"] in (1832796, 1832796.0)
 
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
 
 @pytest.mark.asyncio
@@ -661,7 +661,7 @@ async def test_anthropic_previous_response_uses_conversation_cache(monkeypatch):
     from defog.llm.providers.anthropic_provider import AnthropicProvider
     from defog.llm.memory import conversation_cache
 
-    conversation_cache.clear_cache()
+    await conversation_cache.clear_cache()
     provider = AnthropicProvider(api_key="api-key")
 
     captured_messages = []
@@ -719,7 +719,7 @@ async def test_anthropic_previous_response_uses_conversation_cache(monkeypatch):
         )
         assert response1.response_id is not None
 
-        cached_first = conversation_cache.load_messages(response1.response_id)
+        cached_first = await conversation_cache.load_messages(response1.response_id)
         assert cached_first == base_messages + [
             {"role": "assistant", "content": "First answer"}
         ]
@@ -739,12 +739,12 @@ async def test_anthropic_previous_response_uses_conversation_cache(monkeypatch):
         ]
         assert captured_messages[1] == expected_request_messages
 
-        cached_second = conversation_cache.load_messages(response2.response_id)
+        cached_second = await conversation_cache.load_messages(response2.response_id)
         assert cached_second == expected_request_messages + [
             {"role": "assistant", "content": "Second answer"}
         ]
     finally:
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
 
 @pytest.mark.asyncio
@@ -752,7 +752,7 @@ async def test_gemini_previous_response_uses_conversation_cache(monkeypatch):
     from defog.llm.providers.gemini_provider import GeminiProvider
     from defog.llm.memory import conversation_cache
 
-    conversation_cache.clear_cache()
+    await conversation_cache.clear_cache()
     provider = GeminiProvider(api_key="api-key")
 
     captured_messages = []
@@ -814,7 +814,7 @@ async def test_gemini_previous_response_uses_conversation_cache(monkeypatch):
         )
         assert response1.response_id is not None
 
-        # cached_first = conversation_cache.load_messages(response1.response_id)
+        # cached_first = await conversation_cache.load_messages(response1.response_id)
         # assert cached_first == base_messages + [
         #     {"role": "assistant", "content": "Gemini first"}
         # ]
@@ -832,12 +832,12 @@ async def test_gemini_previous_response_uses_conversation_cache(monkeypatch):
         expected_request_messages = follow_up
         assert captured_messages[1] == expected_request_messages
 
-        # cached_second = conversation_cache.load_messages(response2.response_id)
+        # cached_second = await conversation_cache.load_messages(response2.response_id)
         # assert cached_second == expected_request_messages + [
         #     {"role": "assistant", "content": "Gemini second"}
         # ]
     finally:
-        conversation_cache.clear_cache()
+        await conversation_cache.clear_cache()
 
 
 class TestGeminiSystemInstruction:

--- a/uv.lock
+++ b/uv.lock
@@ -703,7 +703,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.4.34"
+version = "1.4.35"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Closes #241.

- Replaced `diskcache` (SQLite-backed, blocking) with per-conversation pickle files using `aiofiles` for async I/O
- Made `load_messages`, `store_messages`, and `clear_cache` in `conversation_cache.py` async
- Made the 3 calling methods in `base.py` async (`_load_cached_conversation`, `prepare_conversation_messages`, `persist_conversation_history`)
- Added `await` at the 2 call sites in `anthropic_provider.py`
- Removed `diskcache` from `requirements.txt`
- Bumped version to 1.4.35

## Design decisions and tradeoffs

**Why pickle files instead of another DB-backed store (e.g. aiosqlite, valkey)?**
Pickle files are the simplest option that solves the problem. Each conversation is already keyed by a unique `response_id` (format: `{provider}_{uuid_hex}`), which maps naturally to one file per conversation. No external services or additional dependencies needed — `aiofiles` is already a project dependency. For the typical workload (small number of conversations, each a few KB), the overhead of a full database is unnecessary.

**Atomic writes via temp file + `os.replace`**
Writes go to a `.pkl.tmp` file first, then `os.replace()` atomically swaps it into place. This prevents readers from ever seeing a partially-written file during concurrent access. `os.replace` is a single syscall on POSIX and atomic on Windows since Python 3.3.

**`os.replace` and `path.exists()` are synchronous — why not async?**
`os.replace` is a single rename syscall (microseconds). `path.exists()` is a single stat call. Neither blocks meaningfully. The actual file I/O (reading/writing the pickle payload) uses `aiofiles` and is properly async.

**TTL support preserved**
The `expire` parameter on `store_messages` is kept for API compatibility. Expiration is stored as an absolute `expire_at` timestamp inside the pickle payload and checked lazily on read. No caller currently passes `expire`, but the contract is maintained.

**No shared mutable state / no locks needed**
The old implementation used a `threading.Lock` for the singleton `diskcache.Cache` instance. The new implementation has no shared mutable state — each call independently computes a file path and performs atomic file operations.

**Backwards compatibility**
Existing `diskcache` SQLite files in `~/.defog/cache/llm_conversations/` are simply ignored. The new code only reads `.pkl` files. Old files can coexist harmlessly. Cache data is ephemeral by design — losing it just means a conversation can't be continued from a previous `response_id`.

**Scope is narrow — only Anthropic provider affected**
OpenAI and Gemini providers use their respective native conversation chaining APIs (Responses API, Interactions API) and don't use the local conversation cache at all. Only the Anthropic provider calls `prepare_conversation_messages` and `persist_conversation_history`.

## Test plan

- [x] `ruff check` passes on all modified files
- [x] `ruff format` passes on all modified files
- [x] `test_anthropic_previous_response_uses_conversation_cache` — passes (mocked, verifies store/load roundtrip)
- [x] `test_gemini_previous_response_uses_conversation_cache` — passes (mocked)
- [x] `test_chat_async_conversation_follow_up_with_tools_real` — passes (real Anthropic API)
- [x] `test_chat_async_conversation_follow_up_with_tools_real_grandparent_cache` — passes (real Anthropic API, 3-turn conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)