### PR TITLE
Fix OpenAI structured output rejection of $ref with sibling keywords

### DIFF
--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -17,6 +17,38 @@ from ..tools.handler import ToolHandler
 logger = logging.getLogger(__name__)
 
 
+def _dereference_schema(schema: dict) -> dict:
+    """Inline all $ref references in a JSON schema.
+
+    OpenAI's structured output rejects $ref with sibling keywords (e.g.
+    description).  Pydantic's model_json_schema() produces exactly that
+    pattern for fields like ``hero: MyModel = Field(description="...")``.
+
+    This function resolves every $ref by replacing it with the referenced
+    definition, preserving any sibling keywords, and removes $defs.
+    """
+    defs = schema.pop("$defs", {})
+    if not defs:
+        return schema
+
+    def _resolve(obj):
+        if isinstance(obj, dict):
+            if "$ref" in obj:
+                ref_name = obj["$ref"].split("/")[-1]
+                resolved = _resolve(dict(defs[ref_name]))
+                # Merge sibling keywords (e.g. description) into the resolved def
+                for k, v in obj.items():
+                    if k != "$ref":
+                        resolved[k] = v
+                return resolved
+            return {k: _resolve(v) for k, v in obj.items()}
+        elif isinstance(obj, list):
+            return [_resolve(v) for v in obj]
+        return obj
+
+    return _resolve(schema)
+
+
 class OpenAIProvider(BaseLLMProvider):
     """OpenAI GPT provider implementation."""
 
@@ -635,8 +667,10 @@ class OpenAIProvider(BaseLLMProvider):
                         "format": {
                             "type": "json_schema",
                             "name": response_format.schema()["title"],
-                            "schema": response_format.model_json_schema()
-                            | {"additionalProperties": False},
+                            "schema": _dereference_schema(
+                                response_format.model_json_schema()
+                                | {"additionalProperties": False}
+                            ),
                         }
                     },
                 )
@@ -766,8 +800,10 @@ class OpenAIProvider(BaseLLMProvider):
                         "format": {
                             "type": "json_schema",
                             "name": response_format.schema()["title"],
-                            "schema": response_format.model_json_schema()
-                            | {"additionalProperties": False},
+                            "schema": _dereference_schema(
+                                response_format.model_json_schema()
+                                | {"additionalProperties": False}
+                            ),
                         }
                     },
                 )


### PR DESCRIPTION
## Summary

- OpenAI's Responses API rejects JSON schemas where `$ref` has sibling keywords like `description`
- Pydantic's `model_json_schema()` produces exactly this pattern for fields like `hero: MyModel = Field(description="...")`
- Adds `_dereference_schema()` to inline all `$ref` references before sending to OpenAI
- Fixes error: `"$ref cannot have keywords {'description'}"`

## Repro

```python
import json
from dotenv import load_dotenv
from openai import OpenAI
from pydantic import BaseModel, Field, ConfigDict

load_dotenv()


class SourceAttribution(BaseModel):
    model_config = ConfigDict(extra="forbid")
    name: str = Field(description="Organization name")
    url: str = Field(description="URL to the source")

class HeroChart(BaseModel):
    model_config = ConfigDict(extra="forbid")
    title: str = Field(description="Claim-based chart title")
    content: str = Field(description="React component code")
    sources: list[SourceAttribution] = Field(description="Data sources")

class StoryResponse(BaseModel):
    model_config = ConfigDict(extra="forbid")
    headline: str = Field(description="Article headline")
    hero: HeroChart = Field(description="The hero chart")  # <-- triggers the bug
    methodology_notes: str = Field(description="Data notes")


client = OpenAI()
schema = StoryResponse.model_json_schema() | {"additionalProperties": False}

# Pydantic generates: {"$ref": "#/$defs/HeroChart", "description": "The hero chart"}
print(json.dumps(schema["properties"]["hero"], indent=2))

response = client.responses.create(
    model="gpt-4.1-nano",
    input=[{"role": "user", "content": "Return a minimal test story."}],
    text={"format": {"type": "json_schema", "name": "StoryResponse", "schema": schema}},
)
# => Error code: 400
# => "$ref cannot have keywords {'description'}"
```

## Fix

`_dereference_schema()` inlines all `$ref` references before sending to OpenAI, resolving `$defs` and merging sibling keywords into the resolved definition.

## Test plan

- [ ] Verify existing OpenAI structured output tests pass
- [ ] Test with a Pydantic model containing nested `$ref` + `description` fields against OpenAI API


🤖 Generated with [Claude Code](https://claude.com/claude-code)