### PR TITLE
Fix server tools + user tools assistant message reconstruction

### DIFF
--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -874,7 +874,12 @@ class AnthropicProvider(BaseLLMProvider):
                                 # echo just thinking + tool_use blocks, which
                                 # is what Anthropic accepts and matches the
                                 # existing tests.
-                                if programmatic_call_present:
+                                has_server_blocks = any(
+                                    getattr(b, "type", "") in ("server_tool_use",) or
+                                    getattr(b, "type", "") in SERVER_TOOL_RESULT_TYPES
+                                    for b in response.content
+                                )
+                                if programmatic_call_present or has_server_blocks:
                                     assistant_content = list(response.content)
                                 else:
                                     assistant_content = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.1"
+version = "1.5.2"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.5.1"
+version = "1.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- When server tools (web_search, etc.) and user tools are used together in a non-programmatic call, the assistant message echo was stripping `server_tool_use` and server tool result blocks — keeping only `thinking` + `tool_use`. This caused the Anthropic API to reject the follow-up request due to malformed message content.
- Now detects server tool blocks in the response and echoes the full content verbatim, matching the `programmatic_call_present` path.
- Version bump to 1.5.2 (already published to PyPI).

Fixes #268

## Test plan
- [x] `test_anthropic_server_tools.py` — all 27 tests pass
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)