### PR TITLE
Fix container_id not passed in non-programmatic tool path

### DIFF
--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -615,9 +615,7 @@ class AnthropicProvider(BaseLLMProvider):
             # the response did not interact with the cache), so we coerce.
             total_input_tokens += getattr(usage_obj, "input_tokens", 0) or 0
             total_output_tokens += getattr(usage_obj, "output_tokens", 0) or 0
-            cached_input_tokens += (
-                getattr(usage_obj, "cache_read_input_tokens", 0) or 0
-            )
+            cached_input_tokens += getattr(usage_obj, "cache_read_input_tokens", 0) or 0
             cache_creation_input_tokens += (
                 getattr(usage_obj, "cache_creation_input_tokens", 0) or 0
             )
@@ -875,8 +873,9 @@ class AnthropicProvider(BaseLLMProvider):
                                 # is what Anthropic accepts and matches the
                                 # existing tests.
                                 has_server_blocks = any(
-                                    getattr(b, "type", "") in ("server_tool_use",) or
-                                    getattr(b, "type", "") in SERVER_TOOL_RESULT_TYPES
+                                    getattr(b, "type", "") in ("server_tool_use",)
+                                    or getattr(b, "type", "")
+                                    in SERVER_TOOL_RESULT_TYPES
                                     for b in response.content
                                 )
                                 if programmatic_call_present or has_server_blocks:
@@ -1080,6 +1079,9 @@ class AnthropicProvider(BaseLLMProvider):
                     tools, tool_dict = self.update_tools_with_budget(
                         tools, tool_handler, request_params
                     )
+
+                    if container_id:
+                        request_params["container"] = container_id
 
                     await self._apply_pre_model_call_hook(
                         request_params,

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -538,18 +538,53 @@ class AnthropicProvider(BaseLLMProvider):
                 return {k: _block_to_dict(v) for k, v in vars(block).items()}
             return str(block)
 
-        def collect_server_tool_blocks(resp) -> None:
-            """Pull server-side tool result blocks out of a response."""
+        async def collect_server_tool_blocks(resp) -> None:
+            """Pull server-side tool result blocks out of a response and
+            call ``post_tool_function`` for each one so callers can observe
+            server-tool activity the same way they observe user-tool activity.
+            """
+            # Build a lookup from tool_use_id → (name, input) so we can
+            # report meaningful names/args to post_tool_function.
+            server_use_map: Dict[str, tuple] = {}
+            for block in getattr(resp, "content", []) or []:
+                if getattr(block, "type", None) == "server_tool_use":
+                    use_id = getattr(block, "id", None)
+                    if use_id:
+                        server_use_map[use_id] = (
+                            getattr(block, "name", "server_tool"),
+                            _block_to_dict(getattr(block, "input", {})),
+                        )
+
             for block in getattr(resp, "content", []) or []:
                 btype = getattr(block, "type", None)
                 if btype in SERVER_TOOL_RESULT_TYPES:
+                    tool_use_id = getattr(block, "tool_use_id", None)
+                    result = _block_to_dict(getattr(block, "content", None))
                     server_tool_outputs.append(
                         {
                             "type": btype,
-                            "tool_use_id": getattr(block, "tool_use_id", None),
-                            "result": _block_to_dict(getattr(block, "content", None)),
+                            "tool_use_id": tool_use_id,
+                            "result": result,
                         }
                     )
+                    if post_tool_function:
+                        tool_name, input_args = server_use_map.get(
+                            tool_use_id, (btype, {})
+                        )
+                        if inspect.iscoroutinefunction(post_tool_function):
+                            await post_tool_function(
+                                function_name=tool_name,
+                                input_args=input_args,
+                                tool_result=result,
+                                tool_id=tool_use_id,
+                            )
+                        else:
+                            post_tool_function(
+                                function_name=tool_name,
+                                input_args=input_args,
+                                tool_result=result,
+                                tool_id=tool_use_id,
+                            )
 
         def collect_server_tool_usage(resp) -> None:
             """Pull cumulative server tool usage counters off response.usage."""
@@ -628,7 +663,7 @@ class AnthropicProvider(BaseLLMProvider):
             consecutive_exceptions = 0
             while True:
                 add_usage(response.usage)
-                collect_server_tool_blocks(response)
+                await collect_server_tool_blocks(response)
                 collect_server_tool_usage(response)
                 collect_container(response)
 
@@ -1119,7 +1154,7 @@ class AnthropicProvider(BaseLLMProvider):
                     break
             if response.usage:
                 add_usage(response.usage)
-            collect_server_tool_blocks(response)
+            await collect_server_tool_blocks(response)
             collect_server_tool_usage(response)
             collect_container(response)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.2"
+version = "1.5.3b1"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_anthropic_server_tools.py
+++ b/tests/test_anthropic_server_tools.py
@@ -461,6 +461,257 @@ class TestProcessResponse:
         )
 
     @pytest.mark.asyncio
+    async def test_non_programmatic_tool_path_passes_container_id(self):
+        """When code_execution creates a container and the model then calls a
+        regular user tool (non-programmatic path), the follow-up API call must
+        include container_id in request_params.
+
+        Regression test for https://github.com/defog-ai/defog/issues/270
+        """
+        provider = AnthropicProvider(api_key="sk-test")
+
+        # First response: code_execution ran (server_tool_use + result),
+        # AND the model calls a regular user tool.  Container is set.
+        srv_code_use = make_block(
+            "server_tool_use",
+            id="srvtoolu_01",
+            name="code_execution",
+            input={"code": "print('hello')"},
+        )
+        ce_result = make_block(
+            "code_execution_tool_result",
+            tool_use_id="srvtoolu_01",
+            content={"stdout": "hello\n"},
+        )
+        text_block = make_block("text", text="Let me call the tool")
+        # Regular tool_use block (NOT from code_execution — no caller attr)
+        regular_tool_use = make_block(
+            "tool_use",
+            id="toolu_regular_01",
+            name="my_tool",
+            input={"x": 7},
+        )
+        first = make_response(
+            [srv_code_use, ce_result, text_block, regular_tool_use],
+            stop_reason="tool_use",
+            container=SimpleNamespace(
+                id="container_xyz", expires_at="2026-06-01T00:00:00Z"
+            ),
+        )
+
+        # Second response: final answer
+        final_text = make_block("text", text="The result is got 7")
+        second = make_response(
+            [final_text],
+            stop_reason="end_turn",
+            container=SimpleNamespace(
+                id="container_xyz", expires_at="2026-06-01T00:00:00Z"
+            ),
+        )
+
+        mock_create = AsyncMock(return_value=second)
+        client = SimpleNamespace(messages=SimpleNamespace(create=mock_create))
+
+        params: Dict[str, Any] = {
+            "messages": [{"role": "user", "content": "run code and call tool"}],
+            "model": "claude-opus-4-6",
+            "tool_choice": {"type": "auto"},
+        }
+        tool_dict = {"my_tool": my_tool}
+        result = await provider.process_response(
+            client=client,
+            response=first,
+            request_params=params,
+            tools=[my_tool],
+            tool_dict=tool_dict,
+            server_tools=[build_code_execution_tool()],
+        )
+
+        (
+            content,
+            tool_outputs,
+            _input,
+            _output,
+            _cached,
+            _cache_create,
+            _details,
+            server_tool_outputs,
+            server_tool_usage,
+            container_id,
+            container_expires_at,
+        ) = result
+
+        # The follow-up API call must include the container
+        assert mock_create.call_count == 1
+        called_with = mock_create.call_args.kwargs
+        assert called_with.get("container") == "container_xyz", (
+            "Non-programmatic tool path must pass container_id in follow-up API call"
+        )
+
+        # Container should be captured in the return tuple
+        assert container_id == "container_xyz"
+        assert container_expires_at == "2026-06-01T00:00:00Z"
+
+        # The tool was executed
+        assert len(tool_outputs) == 1
+        assert tool_outputs[0]["name"] == "my_tool"
+
+        # Final content captured
+        assert "got 7" in content
+
+    @pytest.mark.asyncio
+    async def test_non_programmatic_tool_path_without_container(self):
+        """When there is no container (no code_execution), the non-programmatic
+        tool path should NOT add a container key to request_params."""
+        provider = AnthropicProvider(api_key="sk-test")
+
+        text_block = make_block("text", text="Calling tool")
+        regular_tool_use = make_block(
+            "tool_use",
+            id="toolu_01",
+            name="my_tool",
+            input={"x": 5},
+        )
+        first = make_response(
+            [text_block, regular_tool_use],
+            stop_reason="tool_use",
+            # No container
+        )
+
+        final_text = make_block("text", text="Done: got 5")
+        second = make_response([final_text], stop_reason="end_turn")
+
+        mock_create = AsyncMock(return_value=second)
+        client = SimpleNamespace(messages=SimpleNamespace(create=mock_create))
+
+        params: Dict[str, Any] = {
+            "messages": [{"role": "user", "content": "call tool"}],
+            "model": "claude-opus-4-6",
+            "tool_choice": {"type": "auto"},
+        }
+        tool_dict = {"my_tool": my_tool}
+        result = await provider.process_response(
+            client=client,
+            response=first,
+            request_params=params,
+            tools=[my_tool],
+            tool_dict=tool_dict,
+        )
+
+        content = result[0]
+        assert "got 5" in content
+        # No container should be set
+        called_with = mock_create.call_args.kwargs
+        assert "container" not in called_with
+
+    @pytest.mark.asyncio
+    async def test_container_id_across_pause_then_tool_use(self):
+        """Multi-step scenario: code_execution triggers pause_turn (creating a
+        container), then the resumed response has a regular tool_use. Both
+        follow-up API calls must include the container_id.
+
+        This tests the full sequence that triggers the bug in issue #270:
+        pause_turn → resume → regular tool call.
+        """
+        provider = AnthropicProvider(api_key="sk-test")
+
+        # Response 1: pause_turn with code_execution, container created
+        srv_code_use = make_block(
+            "server_tool_use",
+            id="srvtoolu_01",
+            name="code_execution",
+            input={"code": "import time; time.sleep(5); print('done')"},
+        )
+        first = make_response(
+            [srv_code_use],
+            stop_reason="pause_turn",
+            container=SimpleNamespace(
+                id="container_multi", expires_at="2026-06-01T00:00:00Z"
+            ),
+        )
+
+        # Response 2 (after pause_turn resume): code execution result +
+        # regular tool_use
+        ce_result = make_block(
+            "code_execution_tool_result",
+            tool_use_id="srvtoolu_01",
+            content={"stdout": "done\n"},
+        )
+        text_block = make_block("text", text="Now calling tool")
+        regular_tool = make_block(
+            "tool_use",
+            id="toolu_02",
+            name="my_tool",
+            input={"x": 99},
+        )
+        second = make_response(
+            [ce_result, text_block, regular_tool],
+            stop_reason="tool_use",
+            container=SimpleNamespace(
+                id="container_multi", expires_at="2026-06-01T00:00:00Z"
+            ),
+        )
+
+        # Response 3: final answer
+        final_text = make_block("text", text="Result: got 99")
+        third = make_response(
+            [final_text],
+            stop_reason="end_turn",
+            container=SimpleNamespace(
+                id="container_multi", expires_at="2026-06-01T00:00:00Z"
+            ),
+        )
+
+        mock_create = AsyncMock(side_effect=[second, third])
+        client = SimpleNamespace(messages=SimpleNamespace(create=mock_create))
+
+        params: Dict[str, Any] = {
+            "messages": [{"role": "user", "content": "run code then call tool"}],
+            "model": "claude-opus-4-6",
+            "tool_choice": {"type": "auto"},
+        }
+        tool_dict = {"my_tool": my_tool}
+        result = await provider.process_response(
+            client=client,
+            response=first,
+            request_params=params,
+            tools=[my_tool],
+            tool_dict=tool_dict,
+            server_tools=[build_code_execution_tool()],
+        )
+
+        (
+            content,
+            tool_outputs,
+            _input,
+            _output,
+            _cached,
+            _cache_create,
+            _details,
+            server_tool_outputs,
+            server_tool_usage,
+            container_id,
+            container_expires_at,
+        ) = result
+
+        assert mock_create.call_count == 2
+
+        # First call (pause_turn resume) should have container
+        first_call = mock_create.call_args_list[0].kwargs
+        assert first_call.get("container") == "container_multi"
+
+        # Second call (after regular tool execution) should also have container
+        second_call = mock_create.call_args_list[1].kwargs
+        assert second_call.get("container") == "container_multi", (
+            "Non-programmatic tool path after pause_turn must pass container_id"
+        )
+
+        assert container_id == "container_multi"
+        assert content == "Result: got 99"
+        assert len(tool_outputs) == 1
+        assert tool_outputs[0]["name"] == "my_tool"
+
+    @pytest.mark.asyncio
     async def test_programmatic_tool_call_user_message_only_tool_results(self):
         """When responding to a code-execution-issued tool_use, the next user
         message in params['messages'] must contain ONLY tool_result blocks."""

--- a/tests/test_anthropic_server_tools.py
+++ b/tests/test_anthropic_server_tools.py
@@ -712,6 +712,255 @@ class TestProcessResponse:
         assert tool_outputs[0]["name"] == "my_tool"
 
     @pytest.mark.asyncio
+    async def test_post_tool_function_called_for_server_tool_results(self):
+        """post_tool_function should be invoked for every server tool result
+        block so callers can observe server-tool activity."""
+        provider = AnthropicProvider(api_key="sk-test")
+        srv_use = make_block(
+            "server_tool_use",
+            id="srvtoolu_ws01",
+            name="web_search",
+            input={"query": "test query"},
+        )
+        ws_result = make_block(
+            "web_search_tool_result",
+            tool_use_id="srvtoolu_ws01",
+            content=[{"title": "Result", "url": "https://example.com"}],
+        )
+        text = make_block("text", text="Found it.")
+        response = make_response([srv_use, ws_result, text])
+
+        client = SimpleNamespace(messages=SimpleNamespace(create=AsyncMock()))
+
+        post_tool_calls = []
+
+        async def mock_post_tool(function_name, input_args, tool_result, tool_id):
+            post_tool_calls.append(
+                {
+                    "function_name": function_name,
+                    "input_args": input_args,
+                    "tool_result": tool_result,
+                    "tool_id": tool_id,
+                }
+            )
+
+        await provider.process_response(
+            client=client,
+            response=response,
+            request_params={"messages": [], "model": "claude-opus-4-6"},
+            tools=None,
+            tool_dict={},
+            server_tools=[build_web_search_tool()],
+            post_tool_function=mock_post_tool,
+        )
+
+        assert len(post_tool_calls) == 1
+        call = post_tool_calls[0]
+        assert call["function_name"] == "web_search"
+        assert call["input_args"] == {"query": "test query"}
+        assert call["tool_id"] == "srvtoolu_ws01"
+        assert isinstance(call["tool_result"], list)
+
+    @pytest.mark.asyncio
+    async def test_post_tool_function_called_for_code_execution_results(self):
+        """post_tool_function should fire for code_execution results when the
+        server_tool_use and result are in the same response."""
+        provider = AnthropicProvider(api_key="sk-test")
+        srv_use = make_block(
+            "server_tool_use",
+            id="srvtoolu_ce01",
+            name="code_execution",
+            input={"code": "print('hi')"},
+        )
+        ce_result = make_block(
+            "code_execution_tool_result",
+            tool_use_id="srvtoolu_ce01",
+            content={"stdout": "hi\n"},
+        )
+        text = make_block("text", text="done")
+        response = make_response([srv_use, ce_result, text])
+
+        client = SimpleNamespace(messages=SimpleNamespace(create=AsyncMock()))
+
+        post_tool_calls = []
+
+        async def mock_post_tool(function_name, input_args, tool_result, tool_id):
+            post_tool_calls.append(
+                {
+                    "function_name": function_name,
+                    "input_args": input_args,
+                    "tool_result": tool_result,
+                    "tool_id": tool_id,
+                }
+            )
+
+        await provider.process_response(
+            client=client,
+            response=response,
+            request_params={
+                "messages": [{"role": "user", "content": "run code"}],
+                "model": "claude-opus-4-6",
+            },
+            tools=None,
+            tool_dict={},
+            server_tools=[build_code_execution_tool()],
+            post_tool_function=mock_post_tool,
+        )
+
+        assert len(post_tool_calls) == 1
+        call = post_tool_calls[0]
+        assert call["function_name"] == "code_execution"
+        assert call["input_args"] == {"code": "print('hi')"}
+        assert call["tool_id"] == "srvtoolu_ce01"
+        assert call["tool_result"] == {"stdout": "hi\n"}
+
+    @pytest.mark.asyncio
+    async def test_post_tool_function_called_across_pause_turn(self):
+        """When pause_turn splits server_tool_use and its result across two
+        responses, post_tool_function should still be called (with the block
+        type as fallback name since the use block is in a prior response)."""
+        provider = AnthropicProvider(api_key="sk-test")
+        # First response: pause_turn with server_tool_use only
+        srv_use = make_block(
+            "server_tool_use",
+            id="srvtoolu_ce01",
+            name="code_execution",
+            input={"code": "print('hi')"},
+        )
+        first = make_response(
+            [srv_use],
+            stop_reason="pause_turn",
+            container=SimpleNamespace(
+                id="container_pt", expires_at="2026-01-01T00:00:00Z"
+            ),
+        )
+        # Second response: result block only (use block was in prior response)
+        ce_result = make_block(
+            "code_execution_tool_result",
+            tool_use_id="srvtoolu_ce01",
+            content={"stdout": "hi\n"},
+        )
+        text = make_block("text", text="done")
+        second = make_response(
+            [ce_result, text],
+            stop_reason="end_turn",
+            container=SimpleNamespace(
+                id="container_pt", expires_at="2026-01-01T00:00:00Z"
+            ),
+        )
+
+        client = SimpleNamespace(
+            messages=SimpleNamespace(create=AsyncMock(return_value=second))
+        )
+
+        post_tool_calls = []
+
+        async def mock_post_tool(function_name, input_args, tool_result, tool_id):
+            post_tool_calls.append(
+                {
+                    "function_name": function_name,
+                    "tool_result": tool_result,
+                    "tool_id": tool_id,
+                }
+            )
+
+        await provider.process_response(
+            client=client,
+            response=first,
+            request_params={
+                "messages": [{"role": "user", "content": "run code"}],
+                "model": "claude-opus-4-6",
+            },
+            tools=None,
+            tool_dict={},
+            server_tools=[build_code_execution_tool()],
+            post_tool_function=mock_post_tool,
+        )
+
+        # post_tool_function should have been called for the result block
+        assert len(post_tool_calls) == 1
+        call = post_tool_calls[0]
+        assert call["tool_id"] == "srvtoolu_ce01"
+        assert call["tool_result"] == {"stdout": "hi\n"}
+
+    @pytest.mark.asyncio
+    async def test_post_tool_function_sync_works_for_server_tools(self):
+        """A synchronous post_tool_function should also be called for server
+        tool results."""
+        provider = AnthropicProvider(api_key="sk-test")
+        srv_use = make_block(
+            "server_tool_use",
+            id="srvtoolu_s01",
+            name="web_search",
+            input={"query": "sync test"},
+        )
+        ws_result = make_block(
+            "web_search_tool_result",
+            tool_use_id="srvtoolu_s01",
+            content=[{"title": "Sync"}],
+        )
+        text = make_block("text", text="ok")
+        response = make_response([srv_use, ws_result, text])
+
+        client = SimpleNamespace(messages=SimpleNamespace(create=AsyncMock()))
+
+        post_tool_calls = []
+
+        def sync_post_tool(function_name, input_args, tool_result, tool_id):
+            post_tool_calls.append(function_name)
+
+        await provider.process_response(
+            client=client,
+            response=response,
+            request_params={"messages": [], "model": "claude-opus-4-6"},
+            tools=None,
+            tool_dict={},
+            server_tools=[build_web_search_tool()],
+            post_tool_function=sync_post_tool,
+        )
+
+        assert post_tool_calls == ["web_search"]
+
+    @pytest.mark.asyncio
+    async def test_post_tool_function_fallback_when_no_server_tool_use_block(self):
+        """When a server tool result block has no matching server_tool_use block
+        (e.g. the use block was in a previous response), the fallback should
+        use the result block type as function_name."""
+        provider = AnthropicProvider(api_key="sk-test")
+        # Only result block, no corresponding server_tool_use in this response
+        ws_result = make_block(
+            "web_search_tool_result",
+            tool_use_id="srvtoolu_orphan",
+            content=[{"title": "Orphan"}],
+        )
+        text = make_block("text", text="here")
+        response = make_response([ws_result, text])
+
+        client = SimpleNamespace(messages=SimpleNamespace(create=AsyncMock()))
+
+        post_tool_calls = []
+
+        async def mock_post_tool(function_name, input_args, tool_result, tool_id):
+            post_tool_calls.append(
+                {"function_name": function_name, "input_args": input_args}
+            )
+
+        await provider.process_response(
+            client=client,
+            response=response,
+            request_params={"messages": [], "model": "claude-opus-4-6"},
+            tools=None,
+            tool_dict={},
+            server_tools=[build_web_search_tool()],
+            post_tool_function=mock_post_tool,
+        )
+
+        assert len(post_tool_calls) == 1
+        # Falls back to the block type name since no server_tool_use was found
+        assert post_tool_calls[0]["function_name"] == "web_search_tool_result"
+        assert post_tool_calls[0]["input_args"] == {}
+
+    @pytest.mark.asyncio
     async def test_programmatic_tool_call_user_message_only_tool_results(self):
         """When responding to a code-execution-issued tool_use, the next user
         message in params['messages'] must contain ONLY tool_result blocks."""

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.5.2"
+version = "1.5.3b1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Fixes the non-programmatic tool path in `AnthropicProvider.process_response` to propagate `container_id` in follow-up API calls, matching the behavior of the `pause_turn` and programmatic tool paths
- When `code_execution` creates a container and the model then calls a regular user tool, the API requires `container_id` — this was missing, causing a `400 BadRequestError`
- Fixes `post_tool_function` not being called for server-side tool results (web_search, code_execution, etc.) — these were collected into `server_tool_outputs` but callers had no way to observe them via `post_tool_function`
- Adds regression tests covering container propagation and post_tool_function invocation for server tools

Closes #270

## Test plan
- [x] `test_non_programmatic_tool_path_passes_container_id` — verifies container_id is passed in the follow-up API call when code_execution created a container
- [x] `test_non_programmatic_tool_path_without_container` — verifies no container key is added when code_execution wasn't used
- [x] `test_container_id_across_pause_then_tool_use` — end-to-end: pause_turn creates container, then regular tool call must also pass it
- [x] `test_post_tool_function_called_for_server_tool_results` — verifies post_tool_fn is called with correct tool name, input args, and result for server tools
- [x] `test_post_tool_function_called_for_code_execution_results` — verifies post_tool_fn fires for code_execution when use+result are in the same response
- [x] `test_post_tool_function_called_across_pause_turn` — verifies post_tool_fn fires even when the result block is in a different response than the use block
- [x] `test_post_tool_function_sync_works_for_server_tools` — verifies sync post_tool_fn works
- [x] `test_post_tool_function_fallback_when_no_server_tool_use_block` — verifies fallback to block type name when no matching server_tool_use exists
- [x] All 35 tests in `test_anthropic_server_tools.py` pass