### PR TITLE
Add conversation_cache hook for mirroring history to custom stores

### DIFF
--- a/defog/llm/memory/__init__.py
+++ b/defog/llm/memory/__init__.py
@@ -2,11 +2,13 @@
 
 from .history_manager import MemoryManager, ConversationHistory
 from .compactifier import compactify_messages
+from .conversation_cache import ConversationCache
 from .token_counter import TokenCounter
 
 __all__ = [
     "MemoryManager",
     "ConversationHistory",
+    "ConversationCache",
     "compactify_messages",
     "TokenCounter",
 ]

--- a/defog/llm/memory/conversation_cache.py
+++ b/defog/llm/memory/conversation_cache.py
@@ -6,11 +6,41 @@ import re
 import time
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Hashable, List, Optional, Set, Tuple
+from typing import Any, Dict, Hashable, List, Optional, Protocol, Set, Tuple, runtime_checkable
 
 import aiofiles
 
 from defog import config as defog_config
+
+
+@runtime_checkable
+class ConversationCache(Protocol):
+    """Supplemental storage backend for cached LLM conversations.
+
+    An implementation is called alongside the built-in pickle cache so callers
+    can mirror conversation history to a database, shared filesystem, or any
+    other store. The pickle cache is always written; this protocol runs in
+    addition to it.
+
+    Load semantics: when a ConversationCache is passed to chat_async, its load
+    is tried first. A non-None return short-circuits the pickle read, so the
+    supplemental store takes precedence when it has the entry.
+    """
+
+    async def load(
+        self, response_id: str
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return messages for response_id, or None on miss."""
+        ...
+
+    async def store(
+        self,
+        response_id: str,
+        messages: List[Dict[str, Any]],
+        expire: Optional[int] = None,
+    ) -> None:
+        """Persist messages keyed by response_id. expire is seconds from now, or None for no expiry."""
+        ...
 
 
 def _get_cache_directory() -> Path:

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -10,6 +10,7 @@ from anthropic import AsyncAnthropic, transform_schema
 from .base import BaseLLMProvider, LLMResponse
 from ..exceptions import ProviderError, MaxTokensError, ToolError
 from ..config import LLMConfig
+from ..memory.conversation_cache import ConversationCache
 from ..cost import CostCalculator
 from ..utils_function_calling import get_function_specs, convert_tool_choice
 from ..image_utils import convert_to_anthropic_format
@@ -1207,6 +1208,7 @@ class AnthropicProvider(BaseLLMProvider):
         ] = None,
         programmatic_tool_calling: bool = False,
         container_id: Optional[str] = None,
+        conversation_cache: Optional[ConversationCache] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with Anthropic."""
@@ -1282,7 +1284,7 @@ class AnthropicProvider(BaseLLMProvider):
         tools = self.filter_tools_by_budget(tools, tool_handler)
 
         conversation_messages = await self.prepare_conversation_messages(
-            messages, previous_response_id
+            messages, previous_response_id, conversation_cache
         )
 
         params, _ = self.build_params(
@@ -1361,7 +1363,7 @@ class AnthropicProvider(BaseLLMProvider):
                 conversation_messages, content
             )
             await self.persist_conversation_history(
-                cache_response_id, history_for_cache
+                cache_response_id, history_for_cache, conversation_cache
             )
             response_id = cache_response_id
 

--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -9,6 +9,7 @@ import uuid
 from ..config.settings import LLMConfig
 from ..exceptions import ToolError
 from ..memory.conversation_cache import (
+    ConversationCache,
     load_messages as load_cached_messages,
     store_messages as store_cached_messages,
 )
@@ -385,11 +386,29 @@ class BaseLLMProvider(ABC):
         return tools, tool_handler.build_tool_dict(tools)
 
     async def _load_cached_conversation(
-        self, previous_response_id: Optional[str]
+        self,
+        previous_response_id: Optional[str],
+        conversation_cache: Optional[ConversationCache] = None,
     ) -> Optional[List[Dict[str, Any]]]:
-        """Fetch cached conversation for a response id."""
+        """Fetch cached conversation for a response id.
+
+        If conversation_cache is provided, its load is tried first; a non-None
+        result short-circuits the pickle read.
+        """
         if not previous_response_id:
             return None
+        if conversation_cache is not None:
+            try:
+                supplemental = await conversation_cache.load(previous_response_id)
+            except Exception as exc:
+                self.logger.warning(
+                    "Supplemental conversation cache load failed for %s: %s",
+                    previous_response_id,
+                    exc,
+                )
+                supplemental = None
+            if supplemental is not None:
+                return supplemental
         try:
             return await load_cached_messages(previous_response_id)
         except Exception as exc:
@@ -427,10 +446,13 @@ class BaseLLMProvider(ABC):
         self,
         messages: List[Dict[str, Any]],
         previous_response_id: Optional[str] = None,
+        conversation_cache: Optional[ConversationCache] = None,
     ) -> List[Dict[str, Any]]:
         """Return full conversation including any cached history."""
         base_messages = deepcopy(messages)
-        cached_messages = await self._load_cached_conversation(previous_response_id)
+        cached_messages = await self._load_cached_conversation(
+            previous_response_id, conversation_cache
+        )
         if cached_messages:
             base_messages = self._merge_cached_and_new_messages(
                 cached_messages, base_messages
@@ -438,9 +460,12 @@ class BaseLLMProvider(ABC):
         return base_messages
 
     async def persist_conversation_history(
-        self, response_id: Optional[str], messages: List[Dict[str, Any]]
+        self,
+        response_id: Optional[str],
+        messages: List[Dict[str, Any]],
+        conversation_cache: Optional[ConversationCache] = None,
     ) -> None:
-        """Persist conversation history for later continuation."""
+        """Persist conversation history to the pickle cache, and to the supplemental cache if supplied."""
         if not response_id or not messages:
             return
         try:
@@ -451,6 +476,15 @@ class BaseLLMProvider(ABC):
                 response_id,
                 exc,
             )
+        if conversation_cache is not None:
+            try:
+                await conversation_cache.store(response_id, messages)
+            except Exception as exc:
+                self.logger.warning(
+                    "Supplemental conversation cache store failed for %s: %s",
+                    response_id,
+                    exc,
+                )
 
     def generate_response_id(self) -> str:
         """Generate a unique response id for conversation chaining."""

--- a/defog/llm/providers/openrouter_provider.py
+++ b/defog/llm/providers/openrouter_provider.py
@@ -9,6 +9,7 @@ from typing import Dict, List, Any, Optional, Callable, Tuple, Union
 from .base import BaseLLMProvider, LLMResponse
 from ..exceptions import ProviderError, ToolError
 from ..config import LLMConfig
+from ..memory.conversation_cache import ConversationCache
 from ..cost import CostCalculator
 from ..utils_function_calling import get_function_specs, convert_tool_choice
 from ..image_utils import convert_to_openai_format
@@ -754,6 +755,7 @@ class OpenRouterProvider(BaseLLMProvider):
         tool_result_preview_max_tokens: Optional[int] = None,
         previous_response_id: Optional[str] = None,
         tool_phase_complete_message: str = "exploration done, generating answer",
+        conversation_cache: Optional[ConversationCache] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion via OpenRouter."""
@@ -782,7 +784,7 @@ class OpenRouterProvider(BaseLLMProvider):
 
         # Handle conversation continuation via base class cache
         messages = await self.prepare_conversation_messages(
-            messages, previous_response_id
+            messages, previous_response_id, conversation_cache
         )
 
         # Create OpenAI client pointed at OpenRouter
@@ -865,7 +867,9 @@ class OpenRouterProvider(BaseLLMProvider):
 
         # Persist conversation history for follow-up calls
         history = self.append_assistant_message_to_history(messages, content)
-        await self.persist_conversation_history(gen_response_id, history)
+        await self.persist_conversation_history(
+            gen_response_id, history, conversation_cache
+        )
 
         # Use OpenRouter-reported cost if available, fall back to local price table
         if openrouter_cost is not None:

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -15,6 +15,7 @@ from .exceptions import LLMError, ConfigurationError, ToolError
 from .config import LLMConfig
 from .llm_providers import LLMProvider
 from .citations import citations_tool
+from .memory.conversation_cache import ConversationCache
 from copy import deepcopy
 from .utils_mcp import get_mcp_tools
 
@@ -117,6 +118,7 @@ async def chat_async(
     ] = None,
     programmatic_tool_calling: bool = False,
     container_id: Optional[str] = None,
+    conversation_cache: Optional[ConversationCache] = None,
 ) -> LLMResponse:
     """
     Execute a chat completion with explicit provider parameter.
@@ -166,6 +168,7 @@ async def chat_async(
             Combinable with user ``tools`` and ``mcp_servers``.
         programmatic_tool_calling: Anthropic only. When True, user-supplied ``tools`` are exposed to the code execution sandbox so Claude can write Python that calls them as ``await my_tool(...)``. Requires ``code_execution`` in ``server_tools``. Forces ``strict_tools=False`` and rejects ``parallel_tool_calls=False`` and forced ``tool_choice``.
         container_id: Anthropic only. Continue a code-execution / programmatic-calling session by passing the ``container_id`` returned on a previous ``LLMResponse``.
+        conversation_cache: Optional supplemental store for conversation history (Anthropic and OpenRouter). Runs alongside the built-in pickle cache — pickle writes always happen; ``conversation_cache.store`` is called in addition. On load, ``conversation_cache.load`` is tried first; a non-None return short-circuits the pickle read. Use this to mirror history to a database or shared store so follow-ups work across machines.
     Returns:
         LLMResponse object containing the result
 
@@ -350,6 +353,7 @@ async def chat_async(
                 server_tools=server_tools,
                 programmatic_tool_calling=programmatic_tool_calling,
                 container_id=container_id,
+                conversation_cache=conversation_cache,
             )
 
             # Process citations if requested and we have tool outputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.3"
+version = "1.5.4"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_conversation_cache_hook.py
+++ b/tests/test_conversation_cache_hook.py
@@ -1,0 +1,158 @@
+"""Unit tests for the supplemental ConversationCache hook on BaseLLMProvider.
+
+These exercise the cache semantics without hitting a real provider:
+    - Store writes to both the pickle cache and the supplemental cache.
+    - Load tries the supplemental cache first; falls back to pickle on miss.
+    - With no cache passed, behavior is identical to the pre-hook pickle-only path.
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from defog.llm.memory.conversation_cache import ConversationCache
+from defog.llm.providers.base import BaseLLMProvider
+
+
+class _DummyProvider(BaseLLMProvider):
+    """Minimal concrete provider; only needed so we can instantiate BaseLLMProvider."""
+
+    def get_provider_name(self) -> str:
+        return "dummy"
+
+    def build_params(self, *args, **kwargs):
+        return {}, {}
+
+    async def execute_chat(self, *args, **kwargs):
+        raise NotImplementedError
+
+    async def process_response(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def create_image_message(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class RecordingCache:
+    """In-memory ConversationCache implementation that records every call."""
+
+    def __init__(self) -> None:
+        self.storage: Dict[str, List[Dict[str, Any]]] = {}
+        self.load_calls: List[str] = []
+        self.store_calls: List[tuple] = []
+
+    async def load(self, response_id: str) -> Optional[List[Dict[str, Any]]]:
+        self.load_calls.append(response_id)
+        return self.storage.get(response_id)
+
+    async def store(
+        self,
+        response_id: str,
+        messages: List[Dict[str, Any]],
+        expire: Optional[int] = None,
+    ) -> None:
+        self.store_calls.append((response_id, messages, expire))
+        self.storage[response_id] = messages
+
+
+@pytest.mark.asyncio
+async def test_recording_cache_satisfies_protocol() -> None:
+    """A duck-typed class with the right coroutines is accepted as ConversationCache."""
+    assert isinstance(RecordingCache(), ConversationCache)
+
+
+@pytest.mark.asyncio
+async def test_store_mirrors_to_supplemental_cache(tmp_path, monkeypatch) -> None:
+    """persist_conversation_history writes pickle and also calls supplemental.store."""
+    monkeypatch.setenv("LLM_CONVERSATION_CACHE_DIR", str(tmp_path))
+
+    provider = _DummyProvider()
+    cache = RecordingCache()
+    messages = [{"role": "user", "content": "hi"}]
+
+    await provider.persist_conversation_history("rid-1", messages, cache)
+
+    # Pickle file was written (default behavior).
+    pickle_files = list(tmp_path.glob("*.pkl"))
+    assert len(pickle_files) == 1
+
+    # Supplemental cache also received the write.
+    assert cache.store_calls == [("rid-1", messages, None)]
+
+
+@pytest.mark.asyncio
+async def test_load_prefers_supplemental_cache(tmp_path, monkeypatch) -> None:
+    """If supplemental.load returns a hit, pickle is not consulted."""
+    monkeypatch.setenv("LLM_CONVERSATION_CACHE_DIR", str(tmp_path))
+
+    provider = _DummyProvider()
+    pickle_messages = [{"role": "user", "content": "from pickle"}]
+    supplemental_messages = [{"role": "user", "content": "from supplemental"}]
+
+    # Seed both stores with different content keyed by the same response id.
+    await provider.persist_conversation_history("rid-2", pickle_messages, None)
+    cache = RecordingCache()
+    cache.storage["rid-2"] = supplemental_messages
+
+    loaded = await provider._load_cached_conversation("rid-2", cache)
+
+    assert loaded == supplemental_messages
+    assert cache.load_calls == ["rid-2"]
+
+
+@pytest.mark.asyncio
+async def test_load_falls_back_to_pickle_on_supplemental_miss(
+    tmp_path, monkeypatch
+) -> None:
+    """If supplemental.load returns None, pickle is used."""
+    monkeypatch.setenv("LLM_CONVERSATION_CACHE_DIR", str(tmp_path))
+
+    provider = _DummyProvider()
+    pickle_messages = [{"role": "user", "content": "from pickle"}]
+    await provider.persist_conversation_history("rid-3", pickle_messages, None)
+
+    cache = RecordingCache()  # empty
+    loaded = await provider._load_cached_conversation("rid-3", cache)
+
+    assert loaded == pickle_messages
+    assert cache.load_calls == ["rid-3"]
+
+
+@pytest.mark.asyncio
+async def test_no_cache_preserves_pickle_only_behavior(tmp_path, monkeypatch) -> None:
+    """With no supplemental cache, everything works exactly as before."""
+    monkeypatch.setenv("LLM_CONVERSATION_CACHE_DIR", str(tmp_path))
+
+    provider = _DummyProvider()
+    messages = [{"role": "user", "content": "plain"}]
+
+    await provider.persist_conversation_history("rid-4", messages)
+    loaded = await provider._load_cached_conversation("rid-4")
+
+    assert loaded == messages
+
+
+@pytest.mark.asyncio
+async def test_supplemental_store_failure_does_not_prevent_pickle_write(
+    tmp_path, monkeypatch
+) -> None:
+    """Errors in the supplemental store are logged and swallowed."""
+    monkeypatch.setenv("LLM_CONVERSATION_CACHE_DIR", str(tmp_path))
+
+    class BrokenCache:
+        async def load(self, response_id):
+            return None
+
+        async def store(self, response_id, messages, expire=None):
+            raise RuntimeError("backend is down")
+
+    provider = _DummyProvider()
+    messages = [{"role": "user", "content": "hi"}]
+
+    # Must not raise.
+    await provider.persist_conversation_history("rid-5", messages, BrokenCache())
+
+    # Pickle write still succeeded.
+    loaded = await provider._load_cached_conversation("rid-5")
+    assert loaded == messages


### PR DESCRIPTION
## What this does

Lets callers plug in their own storage backend for LLM conversation history without giving up the built-in pickle cache.

A new ``ConversationCache`` protocol exposes ``load(response_id)`` and ``store(response_id, messages, expire=None)``. ``chat_async`` now takes an optional ``conversation_cache`` argument on the Anthropic and OpenRouter providers (the only two that go through the pickle cache today — OpenAI and Gemini use native ``previous_response_id`` threading).

## How it behaves

- **Store**: the pickle write always happens (unchanged default). If ``conversation_cache`` is passed, its ``store`` is then called.
- **Load**: if ``conversation_cache`` is passed, its ``load`` is tried first. A non-None return short-circuits the pickle read; ``None`` falls back to pickle. If no cache is passed, pickle is used as today.
- **Failures** in the supplemental store are logged and swallowed so a broken backend can't take down a chat call.

## Example

```python
from defog.llm.memory import ConversationCache
from defog.llm.utils import chat_async
from defog.llm.llm_providers import LLMProvider


class InMemoryCache(ConversationCache):
    """Minimal implementation — replace with Postgres, Redis, etc."""

    def __init__(self):
        self._store = {}

    async def load(self, response_id):
        return self._store.get(response_id)

    async def store(self, response_id, messages, expire=None):
        self._store[response_id] = messages


cache = InMemoryCache()

# First call: messages for this response_id land in both pickle and our cache.
r1 = await chat_async(
    provider=LLMProvider.ANTHROPIC,
    model="claude-haiku-4-5-20251001",
    messages=[{"role": "user", "content": "What is the capital of France?"}],
    max_completion_tokens=64,
    conversation_cache=cache,
)

# Follow-up: cache.load(r1.response_id) runs first. If it hits, pickle is skipped.
r2 = await chat_async(
    provider=LLMProvider.ANTHROPIC,
    model="claude-haiku-4-5-20251001",
    messages=[{"role": "user", "content": "What country is that in?"}],
    max_completion_tokens=64,
    previous_response_id=r1.response_id,
    conversation_cache=cache,
)
```

## Why

Today, anyone who wants conversation history to survive across machines or process restarts either has to maintain a separate pickle directory on shared storage or reach into defog's internals to replace ``store_messages`` / ``load_messages`` at runtime. This makes the extension point explicit and supported.

## Test plan
- [x] ``pytest tests/test_conversation_cache_hook.py`` — 6 new unit tests covering protocol compliance, mirrored writes, load precedence, fallback on miss, pickle-only backward compat, and graceful failure
- [x] Smoke-test against real Anthropic: two-turn conversation with a follow-up confirms the hook fires for both store and load end-to-end