### PR TITLE
Add Claude Opus 4.7 support

### DIFF
--- a/defog/llm/citations.py
+++ b/defog/llm/citations.py
@@ -244,9 +244,12 @@ async def citations_tool(
                 if _is_adaptive:
                     payload["thinking"] = {"type": "adaptive"}
                     payload["temperature"] = 1.0
-                    # Cap "max" effort to "high" for non-Opus models.
                     effort = reasoning_effort
                     _is_opus = "opus-4-6" in model or "opus-4-7" in model
+                    # "xhigh" is only on Opus 4.7; cap down otherwise.
+                    if effort == "xhigh" and "opus-4-7" not in model:
+                        effort = "max" if _is_opus else "high"
+                    # "max" is only on Opus; cap to "high" for Sonnet.
                     if effort == "max" and not _is_opus:
                         effort = "high"
                     payload["output_config"] = {"effort": effort}

--- a/defog/llm/citations.py
+++ b/defog/llm/citations.py
@@ -234,15 +234,20 @@ async def citations_tool(
                 "max_tokens": max_tokens,
             }
             if reasoning_effort:
-                # Claude 4.6 models support adaptive thinking, which
+                # Claude 4.6+ models support adaptive thinking, which
                 # replaces the deprecated budget_tokens approach.
-                _is_adaptive = "opus-4-6" in model or "sonnet-4-6" in model
+                _is_adaptive = (
+                    "opus-4-6" in model
+                    or "opus-4-7" in model
+                    or "sonnet-4-6" in model
+                )
                 if _is_adaptive:
                     payload["thinking"] = {"type": "adaptive"}
                     payload["temperature"] = 1.0
                     # Cap "max" effort to "high" for non-Opus models.
                     effort = reasoning_effort
-                    if effort == "max" and "opus-4-6" not in model:
+                    _is_opus = "opus-4-6" in model or "opus-4-7" in model
+                    if effort == "max" and not _is_opus:
                         effort = "high"
                     payload["output_config"] = {"effort": effort}
                 else:

--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -126,6 +126,12 @@ MODEL_COSTS = {
         "cache_creation_input_cost_per1k": 0.00625,
         "output_cost_per1k": 0.025,
     },
+    "claude-opus-4-7": {
+        "input_cost_per1k": 0.005,
+        "cached_input_cost_per1k": 0.00125,
+        "cache_creation_input_cost_per1k": 0.00625,
+        "output_cost_per1k": 0.025,
+    },
     "claude-haiku-4-5": {
         "input_cost_per1k": 0.001,
         "cached_input_cost_per1k": 0.0001,

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -234,6 +234,9 @@ class AnthropicProvider(BaseLLMProvider):
         # effort: "max" is only available on Opus models. Sending it to
         # Sonnet returns an API error.
         supports_max_effort = "opus-4-6" in model or "opus-4-7" in model
+        # effort: "xhigh" is only available on Opus 4.7. Sending it to any
+        # other model returns an API error.
+        supports_xhigh_effort = "opus-4-7" in model
         # Opus models require adaptive thinking always on. For other
         # adaptive models (e.g. Sonnet 4.6), only enable it when
         # reasoning_effort is explicitly requested.
@@ -262,7 +265,7 @@ class AnthropicProvider(BaseLLMProvider):
                     "type": "enabled",
                     "budget_tokens": 4096,
                 }
-            elif reasoning_effort in ("high", "max"):
+            elif reasoning_effort in ("high", "max", "xhigh"):
                 thinking = {
                     "type": "enabled",
                     "budget_tokens": 8192,
@@ -290,11 +293,14 @@ class AnthropicProvider(BaseLLMProvider):
         # structured output format (json_schema).
         output_config = {}
         if use_adaptive and reasoning_effort is not None:
-            # Cap effort to "high" for models that don't support "max".
-            if reasoning_effort == "max" and not supports_max_effort:
-                output_config["effort"] = "high"
-            else:
-                output_config["effort"] = reasoning_effort
+            effort = reasoning_effort
+            # "xhigh" is only on Opus 4.7; cap down for other models.
+            if effort == "xhigh" and not supports_xhigh_effort:
+                effort = "max" if supports_max_effort else "high"
+            # "max" is only on Opus; cap down to "high" for other models.
+            if effort == "max" and not supports_max_effort:
+                effort = "high"
+            output_config["effort"] = effort
         # Native structured outputs via constrained decoding.
         # The Anthropic API supports output_config.format alongside tools
         # with strict: true in the same request, so we always set it here.

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -225,17 +225,19 @@ class AnthropicProvider(BaseLLMProvider):
         # Claude 3.7 Sonnet. Using "-4" instead of "-4-" so that
         # "claude-sonnet-4" (no date suffix) is also matched.
         supports_thinking = "3-7" in model or "-4" in model
-        # Claude 4.6 models use adaptive thinking (type: "adaptive") with
+        # Claude 4.6+ models use adaptive thinking (type: "adaptive") with
         # effort via output_config, replacing the deprecated budget_tokens
         # param. Update this tuple when new models add adaptive support.
-        supports_adaptive = any(p in model for p in ("opus-4-6", "sonnet-4-6"))
-        # effort: "max" is only available on Opus 4.6+. Sending it to
-        # Sonnet 4.6 returns an API error.
-        supports_max_effort = "opus-4-6" in model
-        # Opus 4.6 requires adaptive thinking always on. For other
+        supports_adaptive = any(
+            p in model for p in ("opus-4-6", "opus-4-7", "sonnet-4-6")
+        )
+        # effort: "max" is only available on Opus models. Sending it to
+        # Sonnet returns an API error.
+        supports_max_effort = "opus-4-6" in model or "opus-4-7" in model
+        # Opus models require adaptive thinking always on. For other
         # adaptive models (e.g. Sonnet 4.6), only enable it when
         # reasoning_effort is explicitly requested.
-        requires_adaptive = "opus-4-6" in model
+        requires_adaptive = "opus-4-6" in model or "opus-4-7" in model
         use_adaptive = requires_adaptive or (
             supports_adaptive and reasoning_effort is not None
         )

--- a/defog/llm/providers/anthropic_server_tools.py
+++ b/defog/llm/providers/anthropic_server_tools.py
@@ -56,6 +56,7 @@ SERVER_TOOL_BETA_HEADERS: Dict[str, str] = {
 # return a vague 400.
 DYNAMIC_FILTERING_SUPPORTED_MODELS: Tuple[str, ...] = (
     "opus-4-6",
+    "opus-4-7",
     "sonnet-4-6",
 )
 
@@ -70,11 +71,12 @@ _DYNAMIC_FILTERING_VERSIONS = {
 
 # Models that support the advisor tool as an executor. Advisor is a beta
 # feature; the executor is one of these models and the advisor model
-# (passed via the ``model`` field) is typically Opus 4.6.
+# (passed via the ``model`` field) is typically the latest Opus.
 _ADVISOR_EXECUTOR_SUPPORTED_MODELS: Tuple[str, ...] = (
     "haiku-4-5",
     "sonnet-4-6",
     "opus-4-6",
+    "opus-4-7",
 )
 
 # Code execution version required for programmatic tool calling.

--- a/defog/llm/web_search.py
+++ b/defog/llm/web_search.py
@@ -36,6 +36,7 @@ async def web_search_tool(
             - OpenAI (o-series, gpt-5): "low", "medium", "high"
             - Gemini (gemini-3): "minimal", "low", "medium", "high" (gemini-3-pro only supports "low", "high")
             - Anthropic (claude-3-7, claude-4): "low", "medium", "high"
+              ("max" for Opus 4.6/4.7, "xhigh" for Opus 4.7 only)
 
     Returns:
         dict with keys:
@@ -184,9 +185,12 @@ async def web_search_tool(
                 )
                 if _is_adaptive:
                     request_params["thinking"] = {"type": "adaptive"}
-                    # Cap "max" effort to "high" for non-Opus models.
                     effort = reasoning_effort
                     _is_opus = "opus-4-6" in model or "opus-4-7" in model
+                    # "xhigh" is only on Opus 4.7; cap down otherwise.
+                    if effort == "xhigh" and "opus-4-7" not in model:
+                        effort = "max" if _is_opus else "high"
+                    # "max" is only on Opus; cap to "high" for Sonnet.
                     if effort == "max" and not _is_opus:
                         effort = "high"
                     request_params["output_config"] = {"effort": effort}

--- a/defog/llm/web_search.py
+++ b/defog/llm/web_search.py
@@ -175,14 +175,19 @@ async def web_search_tool(
                 request_params["tool_choice"] = {"type": "auto"}
                 request_params["temperature"] = 1.0
 
-                # Claude 4.6 models support adaptive thinking, which
+                # Claude 4.6+ models support adaptive thinking, which
                 # replaces the deprecated budget_tokens approach.
-                _is_adaptive = "opus-4-6" in model or "sonnet-4-6" in model
+                _is_adaptive = (
+                    "opus-4-6" in model
+                    or "opus-4-7" in model
+                    or "sonnet-4-6" in model
+                )
                 if _is_adaptive:
                     request_params["thinking"] = {"type": "adaptive"}
                     # Cap "max" effort to "high" for non-Opus models.
                     effort = reasoning_effort
-                    if effort == "max" and "opus-4-6" not in model:
+                    _is_opus = "opus-4-6" in model or "opus-4-7" in model
+                    if effort == "max" and not _is_opus:
                         effort = "high"
                     request_params["output_config"] = {"effort": effort}
                 else:

--- a/docs/llm/web-search.md
+++ b/docs/llm/web-search.md
@@ -78,12 +78,13 @@ result = await web_search_tool(
 )
 
 # Anthropic (claude-3-7, claude-4 models)
-# Claude 4.6 models use adaptive thinking automatically.
+# Claude 4.6+ models use adaptive thinking automatically.
 result = await web_search_tool(
     question="Analyze the impact of AI on healthcare",
     model="claude-sonnet-4-6",
     provider=LLMProvider.ANTHROPIC,
-    reasoning_effort="medium"  # "low", "medium", "high" ("max" for Opus 4.6 only)
+    reasoning_effort="medium"  # "low", "medium", "high"
+    # "max" also available on Opus 4.6/4.7; "xhigh" on Opus 4.7 only.
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.5"
+version = "1.5.6"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Anthropic just released Claude Opus 4.7. This PR teaches the defog LLM layer about the new model so it can be selected as a `model=` argument and routed through the right thinking / tool paths.

## What's in here

- Cost lookup entry for `claude-opus-4-7`. Pricing matches Opus 4.6 ($5 input / $25 output per MTok), so cache and cache-creation rates carry over.
- Provider feature flags in `anthropic_provider.py`, `web_search.py`, and `citations.py` now treat Opus 4.7 the same as Opus 4.6: adaptive thinking is required, "max" effort is allowed.
- Server tools in `anthropic_server_tools.py` (advisor executor, dynamic-filtering web_search / web_fetch) accept Opus 4.7 as an executor.

## Why match Opus 4.6 exactly?

Per Anthropic's [model overview](https://platform.claude.com/docs/en/about-claude/models/overview): Opus 4.7 is priced identically to Opus 4.6, supports adaptive thinking only (no extended thinking with `budget_tokens`), and is the recommended successor for the most capable model slot. The provider already routes Opus 4.6 through adaptive-required, so the same code path handles Opus 4.7.

## Test plan

- [x] `uv run pytest tests/test_cost_calculator.py` passes (46 tests)
- [ ] Smoke-test a real Opus 4.7 call from worlddb after merge