### PR TITLE
Add task_budget support for Claude Opus 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,19 @@ response = await chat_async(
 )
 print(response.content)
 print(response.container_id)   # reuse via `container_id=` on a follow-up call
+
+
+# Task budgets: advisory token cap across the full agentic loop
+# (Claude Opus 4.7 only). Accepts an int (expands to {"type": "tokens",
+# "total": N}) or the full dict with optional "remaining" for loops that
+# compact history between requests. Minimum 20,000 tokens.
+response = await chat_async(
+    provider="anthropic",
+    model="claude-opus-4-7",
+    messages=[{"role": "user", "content": "Audit this repo for security issues."}],
+    tools=[...],
+    task_budget=64000,
+)
 ```
 
 See [docs/llm/anthropic-server-tools.md](docs/llm/anthropic-server-tools.md)

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -143,6 +143,64 @@ class AnthropicProvider(BaseLLMProvider):
 
         return {"role": "user", "content": content}
 
+    @staticmethod
+    def _normalize_task_budget(
+        task_budget: Optional[Union[int, Dict[str, Any]]],
+        model: str,
+    ) -> Optional[Dict[str, Any]]:
+        """Validate + normalize a caller-supplied ``task_budget`` into the shape
+        Anthropic's Messages API expects: ``{"type": "tokens", "total": N,
+        "remaining"?: M}``.
+
+        Returns ``None`` when no budget is set. Raises ``ValueError`` on invalid
+        input or when the model does not support task budgets.
+        """
+        if task_budget is None:
+            return None
+
+        if "opus-4-7" not in model:
+            raise ValueError(
+                "task_budget is only supported on claude-opus-4-7; "
+                f"got model={model!r}."
+            )
+
+        if isinstance(task_budget, bool):
+            # bool is an int subclass in Python; reject it explicitly so callers
+            # don't accidentally pass True/False.
+            raise ValueError("task_budget must be an int or dict, not bool.")
+        if isinstance(task_budget, int):
+            normalized: Dict[str, Any] = {"type": "tokens", "total": task_budget}
+        elif isinstance(task_budget, dict):
+            normalized = dict(task_budget)
+            normalized.setdefault("type", "tokens")
+            if "total" not in normalized:
+                raise ValueError("task_budget dict must include 'total'.")
+        else:
+            raise ValueError(
+                f"task_budget must be an int or dict; got {type(task_budget).__name__}."
+            )
+
+        total = normalized["total"]
+        if not isinstance(total, int) or isinstance(total, bool):
+            raise ValueError("task_budget 'total' must be an int.")
+        if total < 20000:
+            raise ValueError(
+                "task_budget 'total' must be at least 20000 tokens "
+                f"(Anthropic API minimum); got {total}."
+            )
+
+        if "remaining" in normalized and normalized["remaining"] is not None:
+            remaining = normalized["remaining"]
+            if not isinstance(remaining, int) or isinstance(remaining, bool):
+                raise ValueError("task_budget 'remaining' must be an int.")
+            if remaining > total:
+                raise ValueError(
+                    "task_budget 'remaining' cannot exceed 'total' "
+                    f"({remaining} > {total})."
+                )
+
+        return normalized
+
     def build_params(
         self,
         messages: List[Dict[str, Any]],
@@ -161,6 +219,7 @@ class AnthropicProvider(BaseLLMProvider):
         server_tools: Optional[List[Dict[str, Any]]] = None,
         programmatic_tool_calling: bool = False,
         container_id: Optional[str] = None,
+        task_budget: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """Create the parameter dict for Anthropic's .messages.create()."""
@@ -313,6 +372,8 @@ class AnthropicProvider(BaseLLMProvider):
                 "type": "json_schema",
                 "schema": transform_schema(response_format),
             }
+        if task_budget is not None:
+            output_config["task_budget"] = task_budget
         if output_config:
             params["output_config"] = output_config
 
@@ -1216,11 +1277,14 @@ class AnthropicProvider(BaseLLMProvider):
         ] = None,
         programmatic_tool_calling: bool = False,
         container_id: Optional[str] = None,
+        task_budget: Optional[Union[int, Dict[str, Any]]] = None,
         conversation_cache: Optional[ConversationCache] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with Anthropic."""
         from .anthropic_server_tools import normalize_server_tools
+
+        normalized_task_budget = self._normalize_task_budget(task_budget, model)
 
         # Create a ToolHandler instance with tool_budget and image_result_keys if provided
         sample_functions = tool_sample_functions or kwargs.get("tool_sample_functions")
@@ -1253,6 +1317,9 @@ class AnthropicProvider(BaseLLMProvider):
                 model=model,
                 programmatic_tool_calling=programmatic_tool_calling,
             )
+
+        if normalized_task_budget is not None:
+            beta_headers_needed.add("task-budgets-2026-03-13")
 
         # Programmatic tool calling silently flips strict_tools off (with a
         # warning emitted in build_params) and forces parallel tool use to
@@ -1310,6 +1377,7 @@ class AnthropicProvider(BaseLLMProvider):
             server_tools=normalized_server_tools or None,
             programmatic_tool_calling=programmatic_tool_calling,
             container_id=container_id,
+            task_budget=normalized_task_budget,
         )
 
         # Construct a tool dict if needed

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -118,6 +118,7 @@ async def chat_async(
     ] = None,
     programmatic_tool_calling: bool = False,
     container_id: Optional[str] = None,
+    task_budget: Optional[Union[int, Dict[str, Any]]] = None,
     conversation_cache: Optional[ConversationCache] = None,
 ) -> LLMResponse:
     """
@@ -168,6 +169,13 @@ async def chat_async(
             Combinable with user ``tools`` and ``mcp_servers``.
         programmatic_tool_calling: Anthropic only. When True, user-supplied ``tools`` are exposed to the code execution sandbox so Claude can write Python that calls them as ``await my_tool(...)``. Requires ``code_execution`` in ``server_tools``. Forces ``strict_tools=False`` and rejects ``parallel_tool_calls=False`` and forced ``tool_choice``.
         container_id: Anthropic only. Continue a code-execution / programmatic-calling session by passing the ``container_id`` returned on a previous ``LLMResponse``.
+        task_budget: Anthropic only, Claude Opus 4.7 only. Advisory token budget for the
+            full agentic loop (thinking + tool calls + tool results + output). Accepts
+            either an int (sugar for ``{"type": "tokens", "total": N}``) or the full
+            dict with optional ``remaining`` for loops that compact history between
+            requests. Minimum total is 20,000 tokens. Setting ``remaining`` that
+            changes turn-to-turn invalidates the prompt cache; prefer setting ``total``
+            once and letting the server-side countdown self-regulate.
         conversation_cache: Optional supplemental store for conversation history (Anthropic and OpenRouter). Runs alongside the built-in pickle cache — pickle writes always happen; ``conversation_cache.store`` is called in addition. On load, ``conversation_cache.load`` is tried first; a non-None return short-circuits the pickle read. Use this to mirror history to a database or shared store so follow-ups work across machines.
     Returns:
         LLMResponse object containing the result
@@ -210,6 +218,7 @@ async def chat_async(
         server_tools is not None
         or programmatic_tool_calling
         or container_id is not None
+        or task_budget is not None
     )
     if _anthropic_only_set:
         if isinstance(provider, LLMProvider):
@@ -218,8 +227,9 @@ async def chat_async(
             _provider_value = str(provider).lower()
         if _provider_value != "anthropic":
             raise ValueError(
-                "server_tools, programmatic_tool_calling, and container_id are "
-                "currently only supported for the anthropic provider."
+                "server_tools, programmatic_tool_calling, container_id, and "
+                "task_budget are currently only supported for the anthropic "
+                "provider."
             )
 
     # Programmatic tool calling forbids ``disable_parallel_tool_use``. The
@@ -353,6 +363,7 @@ async def chat_async(
                 server_tools=server_tools,
                 programmatic_tool_calling=programmatic_tool_calling,
                 container_id=container_id,
+                task_budget=task_budget,
                 conversation_cache=conversation_cache,
             )
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -248,6 +248,7 @@ async def chat_async(
     tool_sample_functions: Optional[Dict[str, Callable]] = None,
     previous_response_id: Optional[str] = None,
     strict_tools: bool = True,
+    task_budget: Optional[Union[int, Dict[str, Any]]] = None,
 ) -> LLMResponse
 ```
 
@@ -255,6 +256,7 @@ async def chat_async(
 - `tool_result_preview_max_tokens`: Optional token budget for the tool output preview that is sent back to the LLM. Full tool outputs are still stored on the response object.
 - `tool_sample_functions`: Optional mapping of tool name to a callable (or a single callable) that returns a sampled version of the tool output before it is passed back to the LLM.
 - `strict_tools`: When `True` (default), Anthropic uses constrained decoding to enforce tool parameter schemas (`strict: true`). Set to `False` to skip constrained decoding for lower latency with tool-heavy agents. Only affects the Anthropic provider.
+- `task_budget`: Anthropic-only, Claude Opus 4.7 only. Advisory token budget for the full agentic loop (thinking + tool calls + tool results + output). Pass an `int` (expands to `{"type": "tokens", "total": N}`) or a dict with optional `remaining` for loops that compact history between requests. Minimum total is 20,000 tokens. Mutating `remaining` between turns invalidates the prompt cache — prefer setting `total` once and letting the server-side countdown self-regulate.
 
 ### LLMResponse
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.6"
+version = "1.5.7"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_anthropic_task_budget.py
+++ b/tests/test_anthropic_task_budget.py
@@ -1,0 +1,246 @@
+"""Mocked unit tests for Anthropic task_budget support in chat_async /
+AnthropicProvider.
+
+These tests do not hit the live Anthropic API. They exercise the
+``_normalize_task_budget`` helper, the ``build_params`` output_config
+wiring, the top-level ``chat_async`` validation path, and the beta-header
+wiring via a patched ``AsyncAnthropic`` client.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from defog.llm import chat_async
+from defog.llm.providers.anthropic_provider import AnthropicProvider
+
+
+OPUS_47 = "claude-opus-4-7"
+
+
+class TestNormalizeTaskBudget:
+    def test_none_returns_none(self):
+        assert AnthropicProvider._normalize_task_budget(None, OPUS_47) is None
+
+    def test_int_sugar(self):
+        result = AnthropicProvider._normalize_task_budget(64000, OPUS_47)
+        assert result == {"type": "tokens", "total": 64000}
+
+    def test_dict_passthrough(self):
+        result = AnthropicProvider._normalize_task_budget(
+            {"type": "tokens", "total": 64000, "remaining": 30000},
+            OPUS_47,
+        )
+        assert result == {"type": "tokens", "total": 64000, "remaining": 30000}
+
+    def test_dict_defaults_type(self):
+        result = AnthropicProvider._normalize_task_budget({"total": 50000}, OPUS_47)
+        assert result == {"type": "tokens", "total": 50000}
+
+    def test_dict_does_not_mutate_caller(self):
+        original = {"total": 50000}
+        AnthropicProvider._normalize_task_budget(original, OPUS_47)
+        assert "type" not in original
+
+    def test_below_minimum_raises(self):
+        with pytest.raises(ValueError, match="at least 20000"):
+            AnthropicProvider._normalize_task_budget(10000, OPUS_47)
+
+    def test_dict_without_total_raises(self):
+        with pytest.raises(ValueError, match="must include 'total'"):
+            AnthropicProvider._normalize_task_budget({"type": "tokens"}, OPUS_47)
+
+    def test_wrong_model_raises(self):
+        with pytest.raises(ValueError, match="only supported on claude-opus-4-7"):
+            AnthropicProvider._normalize_task_budget(64000, "claude-opus-4-6")
+
+    def test_bool_rejected(self):
+        with pytest.raises(ValueError, match="not bool"):
+            AnthropicProvider._normalize_task_budget(True, OPUS_47)
+
+    def test_non_int_total_rejected(self):
+        with pytest.raises(ValueError, match="'total' must be an int"):
+            AnthropicProvider._normalize_task_budget({"total": "64000"}, OPUS_47)
+
+    def test_remaining_exceeds_total_rejected(self):
+        with pytest.raises(ValueError, match="cannot exceed 'total'"):
+            AnthropicProvider._normalize_task_budget(
+                {"total": 50000, "remaining": 60000}, OPUS_47
+            )
+
+
+class TestBuildParamsTaskBudget:
+    def test_task_budget_lands_in_output_config(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[{"role": "user", "content": "hi"}],
+            model=OPUS_47,
+            task_budget={"type": "tokens", "total": 64000},
+        )
+        assert params["output_config"]["task_budget"] == {
+            "type": "tokens",
+            "total": 64000,
+        }
+
+    def test_task_budget_merges_with_effort(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[{"role": "user", "content": "hi"}],
+            model=OPUS_47,
+            reasoning_effort="high",
+            task_budget={"type": "tokens", "total": 64000},
+        )
+        oc = params["output_config"]
+        assert oc["effort"] == "high"
+        assert oc["task_budget"] == {"type": "tokens", "total": 64000}
+
+    def test_no_task_budget_no_key(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[{"role": "user", "content": "hi"}],
+            model=OPUS_47,
+        )
+        assert "task_budget" not in params.get("output_config", {})
+
+
+class TestChatAsyncValidation:
+    @pytest.mark.asyncio
+    async def test_non_anthropic_provider_rejected(self):
+        with pytest.raises(ValueError, match="task_budget"):
+            await chat_async(
+                provider="openai",
+                model="gpt-4.1",
+                messages=[{"role": "user", "content": "hi"}],
+                task_budget=30000,
+            )
+
+    @pytest.mark.asyncio
+    async def test_wrong_anthropic_model_rejected(self):
+        # Model check happens inside execute_chat via _normalize_task_budget.
+        # chat_async wraps errors in max_retries loop, so we set max_retries=1
+        # to surface the first raise.
+        with pytest.raises(Exception, match="only supported on claude-opus-4-7"):
+            await chat_async(
+                provider="anthropic",
+                model="claude-opus-4-6",
+                messages=[{"role": "user", "content": "hi"}],
+                task_budget=30000,
+                max_retries=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_below_minimum_rejected(self):
+        with pytest.raises(Exception, match="at least 20000"):
+            await chat_async(
+                provider="anthropic",
+                model=OPUS_47,
+                messages=[{"role": "user", "content": "hi"}],
+                task_budget=10000,
+                max_retries=1,
+            )
+
+
+class TestExecuteChatWiring:
+    """End-to-end wiring test: patch AsyncAnthropic and confirm that when a
+    caller supplies ``task_budget``, the beta header is present and
+    ``output_config.task_budget`` appears in the request payload."""
+
+    @pytest.mark.asyncio
+    async def test_task_budget_wires_header_and_output_config(self):
+        captured: Dict[str, Any] = {}
+
+        def fake_client_ctor(**client_kwargs: Any) -> SimpleNamespace:
+            captured["client_kwargs"] = client_kwargs
+
+            async def _create(**params: Any) -> SimpleNamespace:
+                captured["request_params"] = params
+                return SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="ok")],
+                    stop_reason="end_turn",
+                    usage=SimpleNamespace(
+                        input_tokens=1,
+                        output_tokens=1,
+                        cache_read_input_tokens=0,
+                        cache_creation_input_tokens=0,
+                    ),
+                    container=None,
+                    model=OPUS_47,
+                    id="msg_01test",
+                )
+
+            messages_ns = SimpleNamespace(create=AsyncMock(side_effect=_create))
+            return SimpleNamespace(messages=messages_ns)
+
+        with patch(
+            "defog.llm.providers.anthropic_provider.AsyncAnthropic",
+            side_effect=fake_client_ctor,
+        ):
+            await chat_async(
+                provider="anthropic",
+                model=OPUS_47,
+                messages=[{"role": "user", "content": "hi"}],
+                task_budget=64000,
+                max_retries=1,
+            )
+
+        headers = captured["client_kwargs"]["default_headers"]
+        assert "task-budgets-2026-03-13" in headers["anthropic-beta"]
+
+        request_params = captured["request_params"]
+        assert request_params["output_config"]["task_budget"] == {
+            "type": "tokens",
+            "total": 64000,
+        }
+
+    @pytest.mark.asyncio
+    async def test_task_budget_dict_form_wires_through(self):
+        captured: Dict[str, Any] = {}
+
+        def fake_client_ctor(**client_kwargs: Any) -> SimpleNamespace:
+            captured["client_kwargs"] = client_kwargs
+
+            async def _create(**params: Any) -> SimpleNamespace:
+                captured["request_params"] = params
+                return SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="ok")],
+                    stop_reason="end_turn",
+                    usage=SimpleNamespace(
+                        input_tokens=1,
+                        output_tokens=1,
+                        cache_read_input_tokens=0,
+                        cache_creation_input_tokens=0,
+                    ),
+                    container=None,
+                    model=OPUS_47,
+                    id="msg_01test",
+                )
+
+            messages_ns = SimpleNamespace(create=AsyncMock(side_effect=_create))
+            return SimpleNamespace(messages=messages_ns)
+
+        with patch(
+            "defog.llm.providers.anthropic_provider.AsyncAnthropic",
+            side_effect=fake_client_ctor,
+        ):
+            await chat_async(
+                provider="anthropic",
+                model=OPUS_47,
+                messages=[{"role": "user", "content": "hi"}],
+                task_budget={
+                    "type": "tokens",
+                    "total": 64000,
+                    "remaining": 30000,
+                },
+                max_retries=1,
+            )
+
+        request_params = captured["request_params"]
+        assert request_params["output_config"]["task_budget"] == {
+            "type": "tokens",
+            "total": 64000,
+            "remaining": 30000,
+        }

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.5.3b1"
+version = "1.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Adds Anthropic's new **task_budget** feature to `chat_async` (beta header `task-budgets-2026-03-13`). Claude Opus 4.7 only.
- Accepts either an `int` (sugar for `{"type": "tokens", "total": N}`) or the full dict with optional `remaining` for loops that compact history between requests. Minimum 20,000 tokens, enforced client-side.
- Wires the budget through the existing `output_config` path alongside `reasoning_effort` / `format`; reuses `beta_headers_needed` for the beta header.
- Model-compatibility check raises `ValueError` for non-Opus-4.7 models; `_anthropic_only_set` guard raises for non-Anthropic providers.

## Prompt caching note (from Anthropic docs)

> The budget-countdown marker is injected server-side per turn, so it does not match across requests. If your client decrements `task_budget.remaining` on each follow-up request, the changed value invalidates any cache prefix that contains it. To preserve caching, set the budget once on the initial request and let the model self-regulate against the server-side countdown rather than mutating the budget client-side.

This is called out in both the `chat_async` docstring and `docs/api-reference.md`. The agentic loop inside `process_response` reuses the same `output_config` across turns, which matches the recommended "set once, don't mutate" behavior — no client-side bookkeeping of `remaining`.

## Test plan

- [x] Unit tests for `_normalize_task_budget` (int/dict/min/model/bool/remaining>total).
- [x] `build_params` tests that `task_budget` lands in `output_config` and merges with `reasoning_effort`.
- [x] `chat_async` validation rejects non-Anthropic provider, wrong model, and below-minimum budget.
- [x] Mocked end-to-end test confirms beta header + `output_config.task_budget` reach `client.messages.create`.
- [x] `PYTHONPATH=. python -m pytest tests/test_anthropic_task_budget.py tests/test_anthropic_server_tools.py tests/test_anthropic_caching_pricing.py` → 58 passed, no regressions.
- [x] Live end-to-end smoke against Anthropic API with Opus 4.7, `task_budget=20000` — request accepted, beta header `interleaved-thinking-2025-05-14,task-budgets-2026-03-13` on the wire, body contains `output_config.task_budget={"type":"tokens","total":20000}`.
- [x] `ruff check` and `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)