### PR TITLE
[codex] add gpt-5.5 openai pricing support

### DIFF
--- a/defog/llm/cost/calculator.py
+++ b/defog/llm/cost/calculator.py
@@ -9,11 +9,17 @@ _SIZE_SUFFIXES = ("mini", "nano", "flash", "lite", "pro")
 
 
 def _split_size_suffix(name: str) -> tuple[str, str]:
-    """Split 'gpt-5.4-mini' -> ('gpt-5.4', 'mini'); 'gpt-5' -> ('gpt-5', '')."""
-    for s in _SIZE_SUFFIXES:
-        token = f"-{s}"
-        if name.endswith(token):
-            return name[: -len(token)], s
+    """Split size-tier model ids while allowing optional snapshot suffixes.
+
+    Examples:
+      - 'gpt-5.4-mini' -> ('gpt-5.4', 'mini')
+      - 'gpt-5.5-pro-2026-04-23' -> ('gpt-5.5', 'pro')
+      - 'gpt-5' -> ('gpt-5', '')
+    """
+    parts = name.split("-")
+    for index in range(len(parts) - 1, 0, -1):
+        if parts[index] in _SIZE_SUFFIXES:
+            return "-".join(parts[:index]), parts[index]
     return name, ""
 
 

--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -40,6 +40,15 @@ MODEL_COSTS = {
         "cached_input_cost_per1k": 0.000005,
         "output_cost_per1k": 0.0004,
     },
+    "gpt-5.5": {
+        "input_cost_per1k": 0.005,
+        "cached_input_cost_per1k": 0.0005,
+        "output_cost_per1k": 0.03,
+    },
+    "gpt-5.5-pro": {
+        "input_cost_per1k": 0.03,
+        "output_cost_per1k": 0.18,
+    },
     "gpt-5.4": {
         "input_cost_per1k": 0.0025,
         "cached_input_cost_per1k": 0.00025,

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -29,6 +29,17 @@ def test_gpt_5_4_entries_are_explicit():
     assert _find_match("gpt-5.4-mini") == "gpt-5.4-mini"
 
 
+def test_gpt_5_5_entries_are_explicit():
+    # gpt-5.5 has distinct pricing from gpt-5/gpt-5.4 and must not silently
+    # fall back to an older GPT-5 family price.
+    assert "gpt-5.5" in MODEL_COSTS
+    assert "gpt-5.5-pro" in MODEL_COSTS
+    assert _find_match("gpt-5.5") == "gpt-5.5"
+    assert _find_match("gpt-5.5-2026-04-23") == "gpt-5.5"
+    assert _find_match("gpt-5.5-pro") == "gpt-5.5-pro"
+    assert _find_match("gpt-5.5-pro-2026-04-23") == "gpt-5.5-pro"
+
+
 def test_unknown_mini_does_not_fall_back_to_base_pricing():
     # Regression: previously `gpt-5.4-mini` fell back to `gpt-5` (full) pricing
     # via loose substring match, inflating cost ~5x. With size-suffix parity,
@@ -70,9 +81,21 @@ def test_gpt_5_4_pricing_matches_openai_rate_card():
     assert _cost("gpt-5.4") == pytest.approx(1.75)
 
 
+def test_gpt_5_5_pricing_matches_openai_rate_card():
+    # Per https://openai.com/api/pricing/ and
+    # https://openai.com/index/introducing-gpt-5-5/ as of 2026-04-24:
+    # gpt-5.5: $5.00 input / $0.50 cached input / $30.00 output per 1M tokens
+    assert _cost("gpt-5.5") == pytest.approx(3.5)
+    assert _cost("gpt-5.5", cached=1000) == pytest.approx(3.55)
+    # gpt-5.5-pro: $30.00 input / $180.00 output per 1M tokens
+    assert _cost("gpt-5.5-pro") == pytest.approx(21.0)
+
+
 def test_is_model_supported():
     assert CostCalculator.is_model_supported("gpt-5-mini") is True
     assert CostCalculator.is_model_supported("gpt-5.4-mini") is True
+    assert CostCalculator.is_model_supported("gpt-5.5") is True
+    assert CostCalculator.is_model_supported("gpt-5.5-pro") is True
     assert CostCalculator.is_model_supported("gpt-5.9-mini") is True
     assert CostCalculator.is_model_supported("claude-sonnet-4-6") is True
     assert CostCalculator.is_model_supported("totally-made-up-xyz") is False
@@ -99,9 +122,7 @@ def test_calculator_matches_models_json(model: str) -> None:
         + output_t / 1000 * costs["output_cost_per1k"]
     ) * 100
     if cached_t:
-        expected_cents += (
-            cached_t / 1000 * costs["cached_input_cost_per1k"]
-        ) * 100
+        expected_cents += (cached_t / 1000 * costs["cached_input_cost_per1k"]) * 100
     if cache_creation_t:
         expected_cents += (
             cache_creation_t / 1000 * costs["cache_creation_input_cost_per1k"]

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -89,6 +89,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(map_model_to_provider("gpt-4o-mini"), LLMProvider.OPENAI)
+        self.assertEqual(map_model_to_provider("gpt-5.5"), LLMProvider.OPENAI)
 
         with self.assertRaises(Exception):
             map_model_to_provider("unknown-model")

--- a/tests/test_openai_gpt55_e2e.py
+++ b/tests/test_openai_gpt55_e2e.py
@@ -1,0 +1,59 @@
+"""Live OpenAI GPT-5.5 smoke test.
+
+Requires OPENAI_API_KEY in .env. This skips while gpt-5.5 API access is still
+rolling out, but treats other provider failures as real test failures.
+"""
+
+import os
+
+import pytest
+
+from defog.llm import chat_async
+from defog.llm.llm_providers import LLMProvider
+
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set",
+)
+
+
+_UNAVAILABLE_MARKERS = (
+    "model_not_found",
+    "does not exist",
+    "not found",
+    "not currently available",
+    "not available",
+    "do not have access",
+    "don't have access",
+    "coming soon",
+)
+
+
+@pytest.mark.asyncio
+async def test_gpt_5_5_chat_async_e2e():
+    try:
+        response = await chat_async(
+            provider=LLMProvider.OPENAI,
+            model="gpt-5.5",
+            messages=[
+                {
+                    "role": "user",
+                    "content": "Reply with exactly: gpt-5.5-ok",
+                }
+            ],
+            max_completion_tokens=1024,
+            reasoning_effort="low",
+            max_retries=1,
+        )
+    except Exception as exc:
+        message = str(exc).lower()
+        if any(marker in message for marker in _UNAVAILABLE_MARKERS):
+            pytest.skip(f"gpt-5.5 API access is not available yet: {exc}")
+        raise
+
+    assert response.model == "gpt-5.5"
+    assert "gpt-5.5-ok" in str(response.content).strip()
+    assert response.input_tokens > 0
+    assert response.output_tokens > 0
+    assert response.cost_in_cents is not None


### PR DESCRIPTION
## Summary

- Adds explicit OpenAI cost entries for `gpt-5.5` and `gpt-5.5-pro` using the current official OpenAI rates.
- Updates cost model matching so size-tier ids like `*-pro-*` with snapshot suffixes resolve to the same tier instead of falling back to base GPT-5 pricing.
- Adds provider-routing coverage for `gpt-5.5` and a live OpenAI GPT-5.5 e2e smoke test that skips only when API rollout/access is not available yet.

## Docs checked

- https://openai.com/api/pricing/
- https://openai.com/index/introducing-gpt-5-5/

## Validation

- `uv run pytest tests/test_cost_calculator.py tests/test_llm.py::TestChatClients::test_map_model_to_provider tests/test_openai_gpt55_e2e.py -q -rs --envfile .env`
- Result: `51 passed, 1 skipped`; the e2e skip was OpenAI returning `model_not_found` for `gpt-5.5` on this account.