### PR TITLE
Add support for gemini-3.5-flash

### DIFF
--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -203,6 +203,11 @@ MODEL_COSTS = {
         "output_cost_per1k": 0.012,
         "cached_input_cost_per1k": 0.0002,
     },
+    "gemini-3.5-flash": {
+        "input_cost_per1k": 0.0015,
+        "output_cost_per1k": 0.009,
+        "cached_input_cost_per1k": 0.00015,
+    },
     "deepseek-v4-pro": {
         "input_cost_per1k": 0.00174,
         "cached_input_cost_per1k": 0.000145,

--- a/docs/llm/web-search.md
+++ b/docs/llm/web-search.md
@@ -28,7 +28,7 @@ Web search is supported on the following providers:
 |----------|--------------|-------|
 | OpenAI | `gpt-4.1-mini`, `gpt-4.1` | Uses Responses API with web_search tool |
 | Anthropic | `claude-haiku-4-5`, `claude-sonnet-4` | Uses web_search_20250305 tool |
-| Gemini | `gemini-2.0-flash`, `gemini-3-flash-preview` | Uses google_search via Interactions API |
+| Gemini | `gemini-2.0-flash`, `gemini-3-flash-preview`, `gemini-3.5-flash` | Uses google_search via Interactions API |
 
 ### Structured Output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.8"
+version = "1.5.9"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,6 +82,7 @@ if os.getenv("GEMINI_API_KEY"):
         "gemini-2.5-pro",
         "gemini-3.1-flash-lite-preview",
         "gemini-3.1-pro-preview",
+        "gemini-3.5-flash",
     ]
 else:
     AVAILABLE_PROVIDERS["gemini"] = False

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -112,6 +112,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
                     "gemini-3-pro-preview",
                     "gemini-3.1-flash-lite-preview",
                     "gemini-3.1-pro-preview",
+                    "gemini-3.5-flash",
                 ]
             )
         models = [m for m in test_models if m in sum(AVAILABLE_MODELS.values(), [])]
@@ -156,6 +157,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
                     "gemini-3-pro-preview",
                     "gemini-3.1-flash-lite-preview",
                     "gemini-3.1-pro-preview",
+                    "gemini-3.5-flash",
                 ]
             )
 
@@ -241,6 +243,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
                     "gemini-3-pro-preview",
                     "gemini-3.1-flash-lite-preview",
                     "gemini-3.1-pro-preview",
+                    "gemini-3.5-flash",
                 ]
             )
         if AVAILABLE_MODELS.get("anthropic"):


### PR DESCRIPTION
## Summary
- Add `gemini-3.5-flash` pricing entry to `defog/llm/cost/models.py` ($1.50 / $9.00 / $0.15 per 1M input/output/cached, per [Google's pricing page](https://ai.google.dev/gemini-api/docs/pricing))
- Add it to the conftest model roster and the three `test_llm.py` chat-roster tests so it gets exercised end-to-end
- Mention it in the Gemini row of `docs/llm/web-search.md`

## Why no provider changes
Google launched Gemini 3.5 Flash (GA) at I/O 2026. The Interactions API contract is unchanged vs. Gemini 3.x — the existing `model.startswith("gemini-3")` branches in `GeminiProvider` (reasoning_effort/thinking_level, stateless history for thought-signature safety) already cover the new model, and `gemini-3.5-flash` is not in the `gemini-3-pro` restricted-effort branch, so all four `thinking_level` values are accepted.

## Test plan
Verified live against the Gemini API:

- [x] `map_model_to_provider("gemini-3.5-flash") == LLMProvider.GEMINI`
- [x] `CostCalculator.is_model_supported("gemini-3.5-flash")` is True and pricing table values match the published rates
- [x] Simple `chat_async` call returns content and a non-zero cost
- [x] `reasoning_effort` accepts all four values: `minimal`, `low`, `medium`, `high`
- [x] Tool calling returns the expected function-call output
- [x] `tests/test_llm.py::test_simple_chat_async` and `::test_sql_chat_async` both pass with the model in the roster

## Out of scope
`tests/test_llm.py::test_sql_chat_structured_async` fails for Gemini with `responseFormat must be set when responseMimeType is set` — this is pre-existing on `main` (reproduces without this branch) and affects all Gemini models, not just 3.5 Flash. Worth a follow-up PR to fix the Interactions API request shape for structured output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)