### PR TITLE
Fix Gemini structured output response_format format

### DIFF
--- a/defog/llm/providers/gemini_provider.py
+++ b/defog/llm/providers/gemini_provider.py
@@ -282,13 +282,17 @@ class GeminiProvider(BaseLLMProvider):
             request_params["system_instruction"] = system_instruction
 
         if response_format:
-            request_params["response_mime_type"] = "application/json"
             if isinstance(response_format, type) and issubclass(
                 response_format, BaseModel
             ):
-                request_params["response_format"] = response_format.model_json_schema()
+                schema = response_format.model_json_schema()
             else:
-                request_params["response_format"] = response_format
+                schema = response_format
+            request_params["response_format"] = {
+                "type": "text",
+                "mime_type": "application/json",
+                "schema": schema,
+            }
 
         if previous_response_id:
             request_params["previous_interaction_id"] = previous_response_id
@@ -563,11 +567,6 @@ class GeminiProvider(BaseLLMProvider):
                     # Pass through configuration from request_params
                     if "tools" in request_params:
                         next_interaction_kwargs["tools"] = request_params["tools"]
-
-                    if "response_mime_type" in request_params:
-                        next_interaction_kwargs["response_mime_type"] = request_params[
-                            "response_mime_type"
-                        ]
 
                     if "response_format" in request_params:
                         next_interaction_kwargs["response_format"] = request_params[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.9"
+version = "1.5.10"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.5.9"
+version = "1.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Wrap `response_format` payload as `{type: "text", mime_type: "application/json", schema: <json_schema>}` for Gemini's Interactions API — passing a bare JSON Schema produced the misleading `responseFormat must be set when responseMimeType is set` 400 error.
- Drop the separate `response_mime_type` field (and its pass-through in the tool-call follow-up); the mime type now lives inside the wrapper.
- Bump version to 1.5.10.

## Test plan
- [x] `tests/test_llm.py::TestChatClients::test_sql_chat_structured_async` now passes for all Gemini models
- [x] `tests/test_llm.py::TestChatClients::test_sql_chat_structured_reasoning_effort_async` still passes
- [x] `tests/test_llm.py::TestGeminiSystemInstruction` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)