### PR TITLE
Add OpenRouter provider routing option

### DIFF
--- a/defog/llm/providers/openrouter_provider.py
+++ b/defog/llm/providers/openrouter_provider.py
@@ -135,6 +135,47 @@ class OpenRouterProvider(BaseLLMProvider):
         return None
 
     @staticmethod
+    def _build_provider_routing(
+        providers: Optional[Union[List[str], Dict[str, Any]]],
+    ) -> Optional[Dict[str, Any]]:
+        """Build OpenRouter's ``provider`` routing object.
+
+        A list is public API sugar for ``provider.only``. A dict is treated as
+        the full provider routing object and copied so callers can pass
+        advanced OpenRouter fields without this client mutating their input.
+        """
+        if providers is None:
+            return None
+
+        if isinstance(providers, dict):
+            if not providers:
+                raise ValueError("providers must not be an empty dict")
+            key_aliases = {
+                "allowFallbacks": "allow_fallbacks",
+                "requireParameters": "require_parameters",
+                "dataCollection": "data_collection",
+                "enforceDistillableText": "enforce_distillable_text",
+                "preferredMinThroughput": "preferred_min_throughput",
+                "preferredMaxLatency": "preferred_max_latency",
+                "maxPrice": "max_price",
+            }
+            return {
+                key_aliases.get(key, key): value for key, value in providers.items()
+            }
+
+        if isinstance(providers, (list, tuple)):
+            provider_list = list(providers)
+            if not provider_list or not all(
+                isinstance(provider, str) and provider for provider in provider_list
+            ):
+                raise ValueError("providers must be a non-empty list of strings")
+            return {"only": provider_list}
+
+        raise ValueError(
+            "providers must be a list of strings or a provider routing dict"
+        )
+
+    @staticmethod
     def _deterministic_json_repair(content: str) -> str:
         """Apply deterministic fixes for common JSON issues from open models.
 
@@ -280,6 +321,9 @@ class OpenRouterProvider(BaseLLMProvider):
             "temperature": 0.0,
             "max_tokens": 4096,
         }
+        extra_body = request_params.get("extra_body")
+        if extra_body:
+            repair_params["extra_body"] = extra_body
         # Ask for structured output if we can build a response_format
         rf = self._build_response_format(response_format)
         if rf:
@@ -301,6 +345,7 @@ class OpenRouterProvider(BaseLLMProvider):
         client,
         model: str,
         request_params: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
     ) -> Any:
         """Parse structured response with deterministic repair and LLM fallback.
 
@@ -342,12 +387,15 @@ class OpenRouterProvider(BaseLLMProvider):
 
         # --- Step 3: LLM-based repair ---
         try:
+            request_params_for_repair = dict(request_params or {})
+            if extra_body:
+                request_params_for_repair["extra_body"] = extra_body
             result = await self._llm_json_repair(
                 raw_content,
                 response_format,
                 client,
                 model,
-                request_params or {},
+                request_params_for_repair,
             )
             if _is_parsed(result):
                 logger.info("LLM-based JSON repair succeeded")
@@ -377,6 +425,7 @@ class OpenRouterProvider(BaseLLMProvider):
         reasoning_effort: Optional[str] = None,
         parallel_tool_calls: bool = True,
         previous_response_id: Optional[str] = None,
+        providers: Optional[Union[List[str], Dict[str, Any]]] = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """Build parameters for the OpenAI-compatible Chat Completions API."""
@@ -416,6 +465,10 @@ class OpenRouterProvider(BaseLLMProvider):
 
         # Extra body for OpenRouter-specific features
         extra_body: Dict[str, Any] = {}
+
+        provider_routing = self._build_provider_routing(providers)
+        if provider_routing:
+            extra_body["provider"] = provider_routing
 
         # Prompt caching for Anthropic models
         if self._is_anthropic_model(model):
@@ -688,7 +741,12 @@ class OpenRouterProvider(BaseLLMProvider):
                     total_openrouter_cost = (total_openrouter_cost or 0) + _cost
                 raw_content = response.choices[0].message.content or ""
                 content = await self._parse_with_repair(
-                    raw_content, response_format, client, model, request_params
+                    raw_content,
+                    response_format,
+                    client,
+                    model,
+                    request_params,
+                    extra_body=extra_body,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -704,7 +762,12 @@ class OpenRouterProvider(BaseLLMProvider):
                 # Already called with response_format in build_params
                 raw_content = response.choices[0].message.content or ""
                 content = await self._parse_with_repair(
-                    raw_content, response_format, client, model, request_params
+                    raw_content,
+                    response_format,
+                    client,
+                    model,
+                    request_params,
+                    extra_body=extra_body,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -754,6 +817,7 @@ class OpenRouterProvider(BaseLLMProvider):
         tool_sample_functions: Optional[Dict[str, Callable]] = None,
         tool_result_preview_max_tokens: Optional[int] = None,
         previous_response_id: Optional[str] = None,
+        providers: Optional[Union[List[str], Dict[str, Any]]] = None,
         tool_phase_complete_message: str = "exploration done, generating answer",
         conversation_cache: Optional[ConversationCache] = None,
         **kwargs,
@@ -813,6 +877,7 @@ class OpenRouterProvider(BaseLLMProvider):
             timeout=timeout,
             parallel_tool_calls=parallel_tool_calls,
             previous_response_id=previous_response_id,
+            providers=providers,
         )
 
         # Build tool dict

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -99,6 +99,7 @@ async def chat_async(
     pre_model_call_hook: Optional[Callable] = None,
     config: Optional[LLMConfig] = None,
     base_url: Optional[str] = None,
+    providers: Optional[Union[List[str], Dict[str, Any]]] = None,
     mcp_servers: Optional[List[str]] = None,
     image_result_keys: Optional[List[str]] = None,
     tool_budget: Optional[Dict[str, int]] = None,
@@ -150,6 +151,10 @@ async def chat_async(
             for the primary provider (e.g., for proxies or self-hosted endpoints).
             Both the Anthropic and OpenAI SDKs accept this parameter natively.
             If not provided, falls back to the URL in config, then to the SDK's default.
+        providers: OpenRouter-only upstream provider routing. Pass a list of provider
+            slugs to restrict the request to those providers (maps to OpenRouter
+            ``provider.only``), or pass a full provider routing dict such as
+            ``{"order": ["deepinfra/turbo"], "allow_fallbacks": False}``.
         mcp_servers: List of MCP server urls for streamable http servers (e.g., ["http://localhost:8000/mcp", "http://localhost:8001/mcp"])
         image_result_keys: List of keys to check in tool results for image data (e.g., ['image_base64', 'screenshot_data'])
         tool_budget: Dictionary mapping tool names to maximum allowed calls. Tools not in the dictionary have unlimited calls.
@@ -208,6 +213,16 @@ async def chat_async(
 
     base_delay = 1  # Initial delay in seconds
     error_trace = None
+
+    def _provider_value(provider_obj: Union[LLMProvider, str]) -> str:
+        return (
+            provider_obj.value
+            if isinstance(provider_obj, LLMProvider)
+            else str(provider_obj).lower()
+        )
+
+    if providers is not None and _provider_value(provider) != "openrouter":
+        raise ValueError("providers is only supported when provider is 'openrouter'.")
 
     # validate that mcp servers are simple strings and nothing else
     if mcp_servers:
@@ -336,38 +351,45 @@ async def chat_async(
                 provider_instance.validate_pre_model_call_hook(pre_model_call_hook)
 
             # Execute the chat completion
-            response = await provider_instance.execute_chat(
-                messages=messages,
-                model=current_model,
-                max_completion_tokens=max_completion_tokens,
-                temperature=temperature,
-                response_format=response_format,
-                verbosity=verbosity,
-                tools=tools,
-                tool_choice=tool_choice,
-                store=store,
-                metadata=metadata,
-                timeout=timeout,
-                reasoning_effort=reasoning_effort,
-                post_tool_function=post_tool_function,
-                post_response_hook=post_response_hook,
-                pre_model_call_hook=pre_model_call_hook,
-                image_result_keys=image_result_keys,
-                tool_budget=tool_budget,
-                parallel_tool_calls=parallel_tool_calls,
-                tool_output_max_tokens=tool_output_max_tokens,
-                tool_result_preview_max_tokens=tool_result_preview_max_tokens,
-                tool_sample_functions=tool_sample_functions,
-                previous_response_id=previous_response_id,
-                return_tool_outputs_only=insert_tool_citations,
-                strict_tools=strict_tools,
-                tool_phase_complete_message=tool_phase_complete_message,
-                server_tools=server_tools,
-                programmatic_tool_calling=programmatic_tool_calling,
-                container_id=container_id,
-                task_budget=task_budget,
-                conversation_cache=conversation_cache,
-            )
+            execute_kwargs = {
+                "messages": messages,
+                "model": current_model,
+                "max_completion_tokens": max_completion_tokens,
+                "temperature": temperature,
+                "response_format": response_format,
+                "verbosity": verbosity,
+                "tools": tools,
+                "tool_choice": tool_choice,
+                "store": store,
+                "metadata": metadata,
+                "timeout": timeout,
+                "reasoning_effort": reasoning_effort,
+                "post_tool_function": post_tool_function,
+                "post_response_hook": post_response_hook,
+                "pre_model_call_hook": pre_model_call_hook,
+                "image_result_keys": image_result_keys,
+                "tool_budget": tool_budget,
+                "parallel_tool_calls": parallel_tool_calls,
+                "tool_output_max_tokens": tool_output_max_tokens,
+                "tool_result_preview_max_tokens": tool_result_preview_max_tokens,
+                "tool_sample_functions": tool_sample_functions,
+                "previous_response_id": previous_response_id,
+                "return_tool_outputs_only": insert_tool_citations,
+                "strict_tools": strict_tools,
+                "tool_phase_complete_message": tool_phase_complete_message,
+                "server_tools": server_tools,
+                "programmatic_tool_calling": programmatic_tool_calling,
+                "container_id": container_id,
+                "task_budget": task_budget,
+                "conversation_cache": conversation_cache,
+            }
+            if (
+                providers is not None
+                and _provider_value(current_provider) == "openrouter"
+            ):
+                execute_kwargs["providers"] = providers
+
+            response = await provider_instance.execute_chat(**execute_kwargs)
 
             # Process citations if requested and we have tool outputs
             if insert_tool_citations and response.tool_outputs:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -238,6 +238,7 @@ async def chat_async(
     post_tool_function: Optional[Callable] = None,
     config: Optional[LLMConfig] = None,
     base_url: Optional[str] = None,
+    providers: Optional[Union[List[str], Dict[str, Any]]] = None,
     mcp_servers: Optional[List[str]] = None,
     image_result_keys: Optional[List[str]] = None,
     tool_budget: Optional[Dict[str, int]] = None,
@@ -253,6 +254,7 @@ async def chat_async(
 ```
 
 - `base_url`: Custom base URL for the provider's API endpoint (e.g. for proxies or self-hosted models). Overrides the default URL for the primary provider. Can also be set via environment variables (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, etc.) or through `LLMConfig`.
+- `providers`: OpenRouter-only upstream provider routing. Pass a list such as `["azure"]` to restrict routing to those providers (`provider.only`), or a full routing dict such as `{"order": ["deepinfra/turbo"], "allow_fallbacks": False}`.
 - `tool_result_preview_max_tokens`: Optional token budget for the tool output preview that is sent back to the LLM. Full tool outputs are still stored on the response object.
 - `tool_sample_functions`: Optional mapping of tool name to a callable (or a single callable) that returns a sampled version of the tool output before it is passed back to the LLM.
 - `strict_tools`: When `True` (default), Anthropic uses constrained decoding to enforce tool parameter schemas (`strict: true`). Set to `False` to skip constrained decoding for lower latency with tool-heavy agents. Only affects the Anthropic provider.

--- a/docs/llm/core-chat-functions.md
+++ b/docs/llm/core-chat-functions.md
@@ -148,4 +148,20 @@ response = await chat_async(
     response_format=MyPydanticModel
 )
 
+# Restrict OpenRouter to specific upstream providers
+response = await chat_async(
+    provider="openrouter",
+    model="openai/gpt-5-mini",
+    messages=messages,
+    providers=["azure"],  # sends OpenRouter provider.only
+)
+
+# Advanced OpenRouter routing object
+response = await chat_async(
+    provider="openrouter",
+    model="deepseek/deepseek-r1",
+    messages=messages,
+    providers={"order": ["deepinfra/turbo"], "allow_fallbacks": False},
+)
+
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.11"
+version = "1.5.12"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_openrouter_provider_routing.py
+++ b/tests/test_openrouter_provider_routing.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from defog.llm.config import LLMConfig
+from defog.llm.providers.base import LLMResponse
+from defog.llm.providers.openrouter_provider import OpenRouterProvider
+from defog.llm.utils import chat_async
+
+
+def test_build_params_providers_list_maps_to_only():
+    provider = OpenRouterProvider(api_key="sk-test")
+
+    request_params, _ = provider.build_params(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="openai/gpt-5-mini",
+        providers=["azure", "openai"],
+    )
+
+    assert request_params["extra_body"]["provider"] == {"only": ["azure", "openai"]}
+
+
+def test_build_params_provider_routing_dict_is_passed_through_and_normalized():
+    provider = OpenRouterProvider(api_key="sk-test")
+
+    request_params, _ = provider.build_params(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="anthropic/claude-sonnet-4.6",
+        providers={"order": ["anthropic"], "allowFallbacks": False},
+    )
+
+    assert request_params["extra_body"]["provider"] == {
+        "order": ["anthropic"],
+        "allow_fallbacks": False,
+    }
+    assert request_params["extra_body"]["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.parametrize("providers", [[], ["anthropic", ""], "anthropic"])
+def test_build_params_rejects_invalid_providers(providers):
+    provider = OpenRouterProvider(api_key="sk-test")
+
+    with pytest.raises(ValueError, match="providers"):
+        provider.build_params(
+            messages=[{"role": "user", "content": "Hello"}],
+            model="openai/gpt-5-mini",
+            providers=providers,
+        )
+
+
+@pytest.mark.asyncio
+async def test_chat_async_forwards_openrouter_providers(monkeypatch):
+    captured = {}
+
+    async def fake_execute_chat(self, **kwargs):
+        captured.update(kwargs)
+        return LLMResponse(
+            content="ok",
+            model=kwargs["model"],
+            time=0.0,
+            input_tokens=1,
+            output_tokens=1,
+        )
+
+    monkeypatch.setattr(OpenRouterProvider, "execute_chat", fake_execute_chat)
+
+    response = await chat_async(
+        provider="openrouter",
+        model="openai/gpt-5-mini",
+        messages=[{"role": "user", "content": "Hello"}],
+        providers=["azure"],
+        config=LLMConfig(api_keys={"openrouter": "sk-test"}),
+        max_retries=1,
+    )
+
+    assert response.content == "ok"
+    assert captured["providers"] == ["azure"]
+
+
+@pytest.mark.asyncio
+async def test_chat_async_rejects_providers_for_non_openrouter():
+    with pytest.raises(ValueError, match="openrouter"):
+        await chat_async(
+            provider="openai",
+            model="gpt-5-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+            providers=["azure"],
+            config=LLMConfig(api_keys={"openai": "sk-test"}),
+            max_retries=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_llm_json_repair_forwards_provider_extra_body():
+    provider = OpenRouterProvider(api_key="sk-test")
+    extra_body = {"provider": {"only": ["azure"]}}
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="fixed"))]
+    )
+    client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=AsyncMock(return_value=response))
+        )
+    )
+
+    result = await provider._llm_json_repair(
+        broken_content="broken",
+        response_format=None,
+        client=client,
+        model="openai/gpt-5-mini",
+        request_params={"messages": [], "extra_body": extra_body},
+    )
+
+    assert result == "fixed"
+    assert client.chat.completions.create.call_args.kwargs["extra_body"] == extra_body

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.5.11"
+version = "1.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- Add a `providers` argument to `chat_async` for OpenRouter upstream provider routing.
- Map `providers=[...]` to OpenRouter's `provider.only` request body field.
- Support advanced OpenRouter routing dictionaries for fields like `order`, `allow_fallbacks`, and `require_parameters`.
- Document the new option and add focused unit coverage.

## How to use
Restrict an OpenRouter call to specific upstream providers:

```python
response = await chat_async(
    provider="openrouter",
    model="openai/gpt-5-mini",
    messages=[{"role": "user", "content": "Hello"}],
    providers=["azure"],
)
```

This sends the OpenRouter routing object:

```json
{
  "provider": {
    "only": ["azure"]
  }
}
```

For advanced OpenRouter routing, pass the full routing dict:

```python
response = await chat_async(
    provider="openrouter",
    model="deepseek/deepseek-r1",
    messages=[{"role": "user", "content": "Hello"}],
    providers={
        "order": ["deepinfra/turbo"],
        "allow_fallbacks": False,
    },
)
```

CamelCase aliases accepted by OpenRouter examples, such as `allowFallbacks` and `requireParameters`, are normalized to the snake_case fields sent by the OpenAI client.

## Validation
- `uv run ruff check defog/llm/utils.py defog/llm/providers/openrouter_provider.py tests/test_openrouter_provider_routing.py`
- `uv run pytest tests/test_openrouter_provider_routing.py tests/test_openrouter_choices_validation.py -q`
- `uv run pytest tests/test_deepseek.py::TestDeepSeekProviderRegistration -q`
