### PR TITLE
Human-in-the-loop tool calls: pause/resume for chat_async (#282)

### DIFF
--- a/defog/llm/__init__.py
+++ b/defog/llm/__init__.py
@@ -1,6 +1,7 @@
 """LLM module for multi-provider chat completions."""
 
 from .utils import chat_async, LLMResponse
+from .exceptions import PauseToolExecution
 from .pdf_processor import (
     PDFAnalysisInput,
     ClaudePDFProcessor,
@@ -24,6 +25,7 @@ __all__ = [
     # Core functions
     "chat_async",
     "LLMResponse",
+    "PauseToolExecution",
     # PDF processing
     "PDFAnalysisInput",
     "ClaudePDFProcessor",

--- a/defog/llm/exceptions/__init__.py
+++ b/defog/llm/exceptions/__init__.py
@@ -6,6 +6,7 @@ from .llm_exceptions import (
     ConfigurationError,
     AuthenticationError,
     APIError,
+    PauseToolExecution,
 )
 
 __all__ = [
@@ -16,4 +17,5 @@ __all__ = [
     "ConfigurationError",
     "AuthenticationError",
     "APIError",
+    "PauseToolExecution",
 ]

--- a/defog/llm/exceptions/llm_exceptions.py
+++ b/defog/llm/exceptions/llm_exceptions.py
@@ -44,3 +44,58 @@ class APIError(LLMError):
     """Exception raised when there's a general API error."""
 
     pass
+
+
+class PauseToolExecution(BaseException):
+    """Raised by a tool to suspend the agent loop for human-in-the-loop input.
+
+    A tool raises this to pause ``chat_async`` mid-run (e.g. to ask the end
+    user a clarifying question). ``chat_async`` stops the loop and returns an
+    :class:`~defog.llm.providers.base.LLMResponse` with ``status="paused"``,
+    the in-flight ``messages`` (with thinking blocks intact), the
+    ``pending_tool_use`` that paused, and the ``pause_payload`` the tool
+    passed. The caller persists those, collects the answer (possibly minutes
+    later, on a different worker, or after a restart), and resumes via
+    ``chat_async(..., messages=paused_messages, resume_tool_results={tool_use_id: answer})``.
+
+    This subclasses ``BaseException`` (like ``asyncio.CancelledError``) on
+    purpose: the tool-execution path is littered with ``except Exception``
+    handlers that turn tool failures into retries or error strings, and a
+    pause must not be swallowed by any of them. defog's tool-execution layer
+    fills in ``tool_use_id`` / ``tool_name`` / ``tool_input`` (the tool itself
+    does not know its own call id), and the provider fills in ``messages`` /
+    ``pending_tool_use`` / ``response_id`` when it captures the conversation.
+
+    Args:
+        payload: Arbitrary, JSON-serializable data the tool wants to hand back
+            to the application (e.g. the questions to ask the user). Surfaced
+            as ``LLMResponse.pause_payload``.
+    """
+
+    def __init__(self, payload=None):
+        self.payload = payload
+        # Filled in by the tool-execution layer, which knows the call id/name.
+        self.tool_use_id = None
+        self.tool_name = None
+        self.tool_input = None
+        # Filled in by the provider when it captures the in-flight conversation.
+        self.messages = None
+        self.pending_tool_use = None
+        self.response_id = None
+        # Results of sibling tools that finished in the same batch, keyed by
+        # call id. Used to preserve already-done work across the pause.
+        self.completed_results = {}
+        # Best-effort partial token usage at the pause point.
+        self.input_tokens = 0
+        self.output_tokens = 0
+        self.cached_input_tokens = 0
+        self.cache_creation_input_tokens = 0
+        super().__init__("Tool execution paused for human-in-the-loop input")
+
+    def attach_identity(self, tool_use_id, tool_name, tool_input):
+        """Record which tool paused, if not already known."""
+        if self.tool_use_id is None:
+            self.tool_use_id = tool_use_id
+            self.tool_name = tool_name
+            self.tool_input = tool_input
+        return self

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Any, Optional, Callable, Tuple, Union
 from anthropic import AsyncAnthropic, transform_schema
 
 from .base import BaseLLMProvider, LLMResponse
-from ..exceptions import ProviderError, MaxTokensError, ToolError
+from ..exceptions import ProviderError, MaxTokensError, ToolError, PauseToolExecution
 from ..config import LLMConfig
 from ..memory.conversation_cache import ConversationCache
 from ..cost import CostCalculator
@@ -46,6 +46,220 @@ class AnthropicProvider(BaseLLMProvider):
 
     def get_provider_name(self) -> str:
         return "anthropic"
+
+    # ------------------------------------------------------------------
+    # Human-in-the-loop pause/resume helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _serialize_block(block: Any) -> Any:
+        """Convert an Anthropic SDK content block to a JSON-serializable dict.
+
+        Plain dicts pass through unchanged; SDK objects (ThinkingBlock,
+        ToolUseBlock, etc.) are dumped via ``model_dump()`` so the captured
+        conversation survives pickling/JSON and round-trips back into the API
+        on resume (thinking signatures included).
+        """
+        if isinstance(block, dict):
+            return block
+        if hasattr(block, "model_dump"):
+            try:
+                return block.model_dump()
+            except Exception:
+                pass
+        return block
+
+    @classmethod
+    def _serialize_messages(
+        cls, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Serialize a list of Anthropic-format messages to plain dicts."""
+        serialized: List[Dict[str, Any]] = []
+        for msg in messages:
+            content = msg.get("content")
+            if isinstance(content, list):
+                content = [cls._serialize_block(b) for b in content]
+            serialized.append({"role": msg.get("role"), "content": content})
+        return serialized
+
+    def _inject_resume_tool_results(
+        self,
+        messages: List[Dict[str, Any]],
+        resume_tool_results: Dict[str, Any],
+        tool_handler: ToolHandler,
+        preview_max_tokens: Optional[int],
+        model: str,
+    ) -> List[Dict[str, Any]]:
+        """Complete the trailing tool_result turn for a resumed conversation.
+
+        Finds the last assistant turn that issued ``tool_use`` blocks, then
+        appends ``tool_result`` blocks for every pending tool_use id, pulling
+        each result from ``resume_tool_results``. Sibling tools that already
+        ran (captured at pause time as a partial tool_result turn) are left
+        untouched.
+        """
+        asst_idx = None
+        for i in range(len(messages) - 1, -1, -1):
+            if messages[i].get("role") != "assistant":
+                continue
+            content = messages[i].get("content")
+            if isinstance(content, list) and any(
+                isinstance(b, dict) and b.get("type") in ("tool_use", "mcp_tool_use")
+                for b in content
+            ):
+                asst_idx = i
+                break
+
+        if asst_idx is None:
+            raise ValueError(
+                "resume_tool_results was provided but no assistant tool_use turn "
+                "was found in messages. Pass back the messages from the paused "
+                "LLMResponse."
+            )
+
+        tool_use_ids = [
+            b["id"]
+            for b in messages[asst_idx]["content"]
+            if isinstance(b, dict)
+            and b.get("type") in ("tool_use", "mcp_tool_use")
+            and b.get("id")
+        ]
+
+        # Look for an existing (partial) tool_result user turn right after the
+        # assistant turn — that's where sibling results from the pause live.
+        existing_result_ids = set()
+        trailing_user_turn = None
+        if (
+            asst_idx + 1 < len(messages)
+            and messages[asst_idx + 1].get("role") == "user"
+            and isinstance(messages[asst_idx + 1].get("content"), list)
+        ):
+            trailing_user_turn = messages[asst_idx + 1]
+            for b in trailing_user_turn["content"]:
+                if isinstance(b, dict) and b.get("type") == "tool_result":
+                    existing_result_ids.add(b.get("tool_use_id"))
+
+        missing_ids = [tid for tid in tool_use_ids if tid not in existing_result_ids]
+        provided = set(resume_tool_results or {})
+        unfilled = [tid for tid in missing_ids if tid not in provided]
+        if unfilled:
+            raise ValueError(
+                "resume_tool_results is missing results for pending tool_use "
+                f"id(s): {unfilled}. Provide a result for every pending tool "
+                "call (the one that paused plus any sibling tool calls in the "
+                "same assistant turn)."
+            )
+
+        new_blocks = []
+        for tid in missing_ids:
+            text_for_llm, _, _ = tool_handler.prepare_result_for_llm(
+                resume_tool_results[tid],
+                preview_max_tokens=preview_max_tokens,
+                model=model,
+            )
+            new_blocks.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tid,
+                    "content": text_for_llm,
+                }
+            )
+
+        if trailing_user_turn is not None:
+            trailing_user_turn["content"].extend(new_blocks)
+        else:
+            messages.insert(asst_idx + 1, {"role": "user", "content": new_blocks})
+
+        return messages
+
+    def _capture_pause(
+        self,
+        pause: PauseToolExecution,
+        request_params: Dict[str, Any],
+        thinking_blocks: List[Any],
+        tool_call_blocks: List[Any],
+        tool_handler: ToolHandler,
+        preview_max_tokens: Optional[int],
+        model: str,
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        cached_input_tokens: int,
+        cache_creation_input_tokens: int,
+    ) -> PauseToolExecution:
+        """Capture the in-flight conversation on a PauseToolExecution.
+
+        Appends the assistant turn that issued the tool_use(s) — with thinking
+        blocks intact — and, when other tools in the same batch already
+        finished, a partial tool_result turn preserving their output. The
+        result is a fully serialized history the caller persists and replays
+        on resume.
+        """
+        captured: List[Dict[str, Any]] = []
+        system = request_params.get("system")
+        if system:
+            captured.append({"role": "system", "content": system})
+        captured.extend(self._serialize_messages(request_params.get("messages", [])))
+
+        assistant_content = [self._serialize_block(b) for b in thinking_blocks]
+        assistant_content.extend(self._serialize_block(b) for b in tool_call_blocks)
+        captured.append({"role": "assistant", "content": assistant_content})
+
+        sibling_blocks = []
+        for block in tool_call_blocks:
+            bid = getattr(block, "id", None)
+            if bid in pause.completed_results:
+                text_for_llm, _, _ = tool_handler.prepare_result_for_llm(
+                    pause.completed_results[bid],
+                    preview_max_tokens=preview_max_tokens,
+                    model=model,
+                )
+                sibling_blocks.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": bid,
+                        "content": text_for_llm,
+                    }
+                )
+        if sibling_blocks:
+            captured.append({"role": "user", "content": sibling_blocks})
+
+        pause.messages = captured
+        pause.pending_tool_use = {
+            "id": pause.tool_use_id,
+            "name": pause.tool_name,
+            "input": pause.tool_input,
+        }
+        pause.input_tokens = input_tokens
+        pause.output_tokens = output_tokens
+        pause.cached_input_tokens = cached_input_tokens
+        pause.cache_creation_input_tokens = cache_creation_input_tokens
+        return pause
+
+    def _build_paused_response(
+        self, pause: PauseToolExecution, model: str, start_time: float
+    ) -> LLMResponse:
+        """Build the LLMResponse returned to the caller when a tool pauses."""
+        cost = CostCalculator.calculate_cost(
+            model,
+            pause.input_tokens,
+            pause.output_tokens,
+            pause.cached_input_tokens,
+            pause.cache_creation_input_tokens,
+        )
+        return LLMResponse(
+            model=model,
+            content=None,
+            time=round(time.time() - start_time, 3),
+            input_tokens=pause.input_tokens,
+            output_tokens=pause.output_tokens,
+            cached_input_tokens=pause.cached_input_tokens,
+            cache_creation_input_tokens=pause.cache_creation_input_tokens,
+            cost_in_cents=cost,
+            status="paused",
+            pending_tool_use=pause.pending_tool_use,
+            pause_payload=pause.payload,
+            messages=pause.messages,
+        )
 
     def convert_content_to_anthropic(self, content: Any) -> Any:
         """Convert message content to Anthropic format."""
@@ -854,20 +1068,40 @@ class AnthropicProvider(BaseLLMProvider):
                         # Execute regular tool calls (not MCP tools, which are already executed by the API)
                         results = []
                         if regular_tool_calls:
-                            (
-                                results,
-                                consecutive_exceptions,
-                            ) = await self.execute_tool_calls_with_retry(
-                                regular_tool_calls,
-                                tool_dict,
-                                request_params["messages"],
-                                post_tool_function,
-                                consecutive_exceptions,
-                                tool_handler=tool_handler,
-                                parallel_tool_calls=kwargs.get(
-                                    "parallel_tool_calls", True
-                                ),
-                            )
+                            try:
+                                (
+                                    results,
+                                    consecutive_exceptions,
+                                ) = await self.execute_tool_calls_with_retry(
+                                    regular_tool_calls,
+                                    tool_dict,
+                                    request_params["messages"],
+                                    post_tool_function,
+                                    consecutive_exceptions,
+                                    tool_handler=tool_handler,
+                                    parallel_tool_calls=kwargs.get(
+                                        "parallel_tool_calls", True
+                                    ),
+                                )
+                            except PauseToolExecution as pause:
+                                # A tool asked to suspend the loop. Capture the
+                                # assistant tool_use turn (thinking intact) plus
+                                # any sibling results, then propagate so
+                                # execute_chat can return a paused LLMResponse.
+                                self._capture_pause(
+                                    pause,
+                                    request_params,
+                                    thinking_blocks,
+                                    tool_call_blocks,
+                                    tool_handler,
+                                    tool_result_preview_max_tokens,
+                                    model_for_tokens,
+                                    input_tokens=total_input_tokens,
+                                    output_tokens=total_output_tokens,
+                                    cached_input_tokens=cached_input_tokens,
+                                    cache_creation_input_tokens=cache_creation_input_tokens,
+                                )
+                                raise
 
                         # For MCP tools, extract results from mcp_tool_result blocks
                         mcp_results = []
@@ -1279,6 +1513,7 @@ class AnthropicProvider(BaseLLMProvider):
         container_id: Optional[str] = None,
         task_budget: Optional[Union[int, Dict[str, Any]]] = None,
         conversation_cache: Optional[ConversationCache] = None,
+        resume_tool_results: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with Anthropic."""
@@ -1362,6 +1597,17 @@ class AnthropicProvider(BaseLLMProvider):
             messages, previous_response_id, conversation_cache
         )
 
+        # Resuming a paused human-in-the-loop run: complete the trailing
+        # tool_result turn from the supplied answers before building params.
+        if resume_tool_results:
+            conversation_messages = self._inject_resume_tool_results(
+                conversation_messages,
+                resume_tool_results,
+                tool_handler,
+                preview_max_tokens,
+                model,
+            )
+
         params, _ = self.build_params(
             messages=conversation_messages,
             model=model,
@@ -1427,6 +1673,11 @@ class AnthropicProvider(BaseLLMProvider):
                 programmatic_tool_calling=programmatic_tool_calling,
                 **kwargs,
             )
+        except PauseToolExecution as pause:
+            # A tool suspended the loop; return a paused LLMResponse instead of
+            # raising. The caller persists response.messages + pending_tool_use
+            # and resumes later via resume_tool_results.
+            return self._build_paused_response(pause, model, t)
         except Exception as e:
             traceback.print_exc()
             raise ProviderError(self.get_provider_name(), f"API call failed: {e}", e)

--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -37,6 +37,13 @@ class LLMResponse:
     server_tool_usage: Optional[Dict[str, int]] = None
     container_id: Optional[str] = None
     container_expires_at: Optional[str] = None
+    # Human-in-the-loop pause/resume fields. Populated only when a tool raised
+    # PauseToolExecution; ``status`` is "paused" in that case and the caller
+    # resumes via chat_async(messages=..., resume_tool_results=...).
+    status: Optional[str] = None
+    pending_tool_use: Optional[Dict[str, Any]] = None
+    pause_payload: Optional[Any] = None
+    messages: Optional[List[Dict[str, Any]]] = None
 
 
 class BaseLLMProvider(ABC):

--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from typing import Dict, List, Any, Optional, Callable, Tuple, Union
 
 from .base import BaseLLMProvider, LLMResponse
-from ..exceptions import ProviderError, ToolError
+from ..exceptions import ProviderError, ToolError, PauseToolExecution
 from ..config import LLMConfig
 from ..cost import CostCalculator
 from ..utils_function_calling import get_function_specs, convert_tool_choice
@@ -40,6 +40,161 @@ class OpenAIProvider(BaseLLMProvider):
 
     def get_provider_name(self) -> str:
         return "openai"
+
+    # ------------------------------------------------------------------
+    # Human-in-the-loop pause/resume helpers
+    # ------------------------------------------------------------------
+    def _capture_pause(
+        self,
+        pause: PauseToolExecution,
+        response,
+        request_params: Dict[str, Any],
+        tool_handler: ToolHandler,
+        preview_max_tokens: Optional[int],
+        model: str,
+        *,
+        input_tokens: int,
+        cached_input_tokens: int,
+        output_tokens: int,
+    ) -> PauseToolExecution:
+        """Capture state on a PauseToolExecution for the Responses API.
+
+        OpenAI keeps the assistant turn (reasoning + function_call) server-side,
+        referenced by ``response.id``. So instead of serializing message blocks
+        we stash the originating response id (resumed via ``previous_response_id``)
+        plus any sibling ``function_call_output`` items that already completed,
+        and the system instructions so they can be re-sent on resume.
+        """
+        stashed: List[Dict[str, Any]] = []
+        instructions = request_params.get("instructions")
+        if instructions:
+            stashed.append({"role": "system", "content": instructions})
+        for call_id, result in pause.completed_results.items():
+            text_for_llm, _, _ = tool_handler.prepare_result_for_llm(
+                result, preview_max_tokens=preview_max_tokens, model=model
+            )
+            stashed.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": text_for_llm,
+                }
+            )
+
+        pause.messages = stashed
+        pause.response_id = getattr(response, "id", None)
+        pause.pending_tool_use = {
+            "id": pause.tool_use_id,
+            "name": pause.tool_name,
+            "input": pause.tool_input,
+        }
+        pause.input_tokens = input_tokens
+        pause.cached_input_tokens = cached_input_tokens
+        pause.output_tokens = output_tokens
+        return pause
+
+    def _build_paused_response(
+        self, pause: PauseToolExecution, model: str, start_time: float
+    ) -> LLMResponse:
+        """Build the LLMResponse returned to the caller when a tool pauses."""
+        cost = CostCalculator.calculate_cost(
+            model, pause.input_tokens, pause.output_tokens, pause.cached_input_tokens
+        )
+        return LLMResponse(
+            model=model,
+            content=None,
+            time=round(time.time() - start_time, 3),
+            input_tokens=pause.input_tokens,
+            cached_input_tokens=pause.cached_input_tokens,
+            output_tokens=pause.output_tokens,
+            cost_in_cents=cost,
+            status="paused",
+            pending_tool_use=pause.pending_tool_use,
+            pause_payload=pause.payload,
+            messages=pause.messages,
+            response_id=pause.response_id,
+        )
+
+    def _build_resume_params(
+        self,
+        messages: List[Dict[str, Any]],
+        resume_tool_results: Dict[str, Any],
+        model: str,
+        tools: Optional[List[Callable]],
+        tool_choice: Optional[str],
+        reasoning_effort: Optional[str],
+        store: bool,
+        metadata: Optional[Dict[str, str]],
+        timeout: int,
+        parallel_tool_calls: bool,
+        previous_response_id: Optional[str],
+        max_completion_tokens: Optional[int],
+        response_format,
+        tool_handler: ToolHandler,
+        preview_max_tokens: Optional[int],
+    ) -> Dict[str, Any]:
+        """Build Responses API params to resume a paused run.
+
+        The paused assistant turn (reasoning + function_call) is referenced via
+        ``previous_response_id``; we only submit ``function_call_output`` items
+        for every pending tool call plus any siblings stashed at pause time.
+        """
+        if not previous_response_id:
+            raise ValueError(
+                "Resuming an OpenAI run requires previous_response_id "
+                "(pass the paused response's response_id)."
+            )
+
+        instructions_parts: List[str] = []
+        input_items: List[Dict[str, Any]] = []
+        for msg in messages or []:
+            if not isinstance(msg, dict):
+                continue
+            if msg.get("type") == "function_call_output":
+                input_items.append(msg)
+            elif msg.get("role") in ("system", "developer"):
+                content = msg.get("content")
+                if isinstance(content, str):
+                    instructions_parts.append(content)
+                elif isinstance(content, list):
+                    instructions_parts.extend(
+                        b.get("text", "")
+                        for b in content
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    )
+
+        for call_id, result in resume_tool_results.items():
+            text_for_llm, _, _ = tool_handler.prepare_result_for_llm(
+                result, preview_max_tokens=preview_max_tokens, model=model
+            )
+            input_items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": call_id,
+                    "output": text_for_llm,
+                }
+            )
+
+        request_params, _ = self.build_params(
+            messages=[],
+            model=model,
+            max_completion_tokens=max_completion_tokens,
+            temperature=0.0,
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            reasoning_effort=reasoning_effort,
+            store=store,
+            metadata=metadata,
+            timeout=timeout,
+            parallel_tool_calls=parallel_tool_calls,
+            previous_response_id=previous_response_id,
+        )
+        request_params["input"] = input_items
+        instructions = "\n\n".join(p for p in instructions_parts if p.strip())
+        if instructions:
+            request_params["instructions"] = instructions
+        return request_params
 
     async def _apply_pre_model_call_hook(
         self,
@@ -539,18 +694,36 @@ class OpenAIProvider(BaseLLMProvider):
                             )
 
                         # Use base class method for tool execution with retry
-                        (
-                            results,
-                            consecutive_exceptions,
-                        ) = await self.execute_tool_calls_with_retry(
-                            tool_calls_batch,
-                            tool_dict,
-                            request_params["input"],
-                            post_tool_function,
-                            consecutive_exceptions,
-                            tool_handler,
-                            parallel_tool_calls=parallel_tool_calls,
-                        )
+                        try:
+                            (
+                                results,
+                                consecutive_exceptions,
+                            ) = await self.execute_tool_calls_with_retry(
+                                tool_calls_batch,
+                                tool_dict,
+                                request_params["input"],
+                                post_tool_function,
+                                consecutive_exceptions,
+                                tool_handler,
+                                parallel_tool_calls=parallel_tool_calls,
+                            )
+                        except PauseToolExecution as pause:
+                            # A tool asked to suspend the loop. Capture the
+                            # originating response id + sibling outputs and
+                            # propagate so execute_chat returns a paused
+                            # LLMResponse.
+                            self._capture_pause(
+                                pause,
+                                response,
+                                request_params,
+                                tool_handler,
+                                tool_result_preview_max_tokens,
+                                model,
+                                input_tokens=total_input_tokens,
+                                cached_input_tokens=total_cached_input_tokens,
+                                output_tokens=total_output_tokens,
+                            )
+                            raise
 
                         # Do not append an assistant tool_calls placeholder in Responses input
 
@@ -739,6 +912,7 @@ class OpenAIProvider(BaseLLMProvider):
         tool_result_preview_max_tokens: Optional[int] = None,
         previous_response_id: Optional[str] = None,
         tool_phase_complete_message: str = "exploration done, generating answer",
+        resume_tool_results: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with OpenAI."""
@@ -771,21 +945,42 @@ class OpenAIProvider(BaseLLMProvider):
         # Filter tools based on budget before building params
         tools = self.filter_tools_by_budget(tools, tool_handler)
 
-        request_params, messages = self.build_params(
-            messages=messages,
-            model=model,
-            max_completion_tokens=max_completion_tokens,
-            temperature=temperature,
-            response_format=response_format,
-            tools=tools,
-            tool_choice=tool_choice,
-            reasoning_effort=reasoning_effort,
-            store=store,
-            metadata=metadata,
-            timeout=timeout,
-            parallel_tool_calls=parallel_tool_calls,
-            previous_response_id=previous_response_id,
-        )
+        if resume_tool_results:
+            # Resuming a paused human-in-the-loop run: submit the tool outputs
+            # against the response that issued the function calls.
+            request_params = self._build_resume_params(
+                messages,
+                resume_tool_results,
+                model,
+                tools,
+                tool_choice,
+                reasoning_effort,
+                store,
+                metadata,
+                timeout,
+                parallel_tool_calls,
+                previous_response_id,
+                max_completion_tokens,
+                response_format,
+                tool_handler,
+                preview_max_tokens,
+            )
+        else:
+            request_params, messages = self.build_params(
+                messages=messages,
+                model=model,
+                max_completion_tokens=max_completion_tokens,
+                temperature=temperature,
+                response_format=response_format,
+                tools=tools,
+                tool_choice=tool_choice,
+                reasoning_effort=reasoning_effort,
+                store=store,
+                metadata=metadata,
+                timeout=timeout,
+                parallel_tool_calls=parallel_tool_calls,
+                previous_response_id=previous_response_id,
+            )
 
         # Build a tool dict if needed
         tool_dict = {}
@@ -837,6 +1032,11 @@ class OpenAIProvider(BaseLLMProvider):
                 tool_result_preview_max_tokens=preview_max_tokens,
                 tool_phase_complete_message=tool_phase_complete_message,
             )
+        except PauseToolExecution as pause:
+            # A tool suspended the loop; return a paused LLMResponse. The caller
+            # persists response.messages + response.response_id and resumes via
+            # resume_tool_results (with previous_response_id=response.response_id).
+            return self._build_paused_response(pause, model, t)
         except Exception as e:
             raise ProviderError(self.get_provider_name(), f"API call failed: {e}", e)
 

--- a/defog/llm/tools/handler.py
+++ b/defog/llm/tools/handler.py
@@ -2,12 +2,13 @@ import inspect
 import json
 import logging
 from typing import Dict, List, Callable, Any, Optional
-from ..exceptions import ToolError
+from ..exceptions import ToolError, PauseToolExecution
 from ..utils_function_calling import (
     execute_tool,
     execute_tool_async,
     execute_tools_parallel,
     verify_post_tool_function,
+    _tool_call_identity,
 )
 
 logger = logging.getLogger(__name__)
@@ -249,6 +250,11 @@ class ToolHandler:
 
             # Update usage count after successful execution
             self._update_tool_usage(tool_name)
+        except PauseToolExecution as pause:
+            # Human-in-the-loop suspend signal: record which tool paused and
+            # let it propagate untouched (do not wrap as a ToolError).
+            pause.attach_identity(tool_id, tool_name, args)
+            raise
         except Exception as e:
             raise ToolError(tool_name, f"Error executing tool: {e}", e)
 
@@ -313,14 +319,25 @@ class ToolHandler:
                         or tool_call.get("tool_use_id")
                     )
 
-                    # Use execute_tool_call which handles budget tracking
-                    result = await self.execute_tool_call(
-                        func_name,
-                        func_args,
-                        tool_dict,
-                        post_tool_function,
-                        tool_id=tool_id,
-                    )
+                    try:
+                        # Use execute_tool_call which handles budget tracking
+                        result = await self.execute_tool_call(
+                            func_name,
+                            func_args,
+                            tool_dict,
+                            post_tool_function,
+                            tool_id=tool_id,
+                        )
+                    except PauseToolExecution as pause:
+                        # Preserve the results of tools that already ran in
+                        # this batch so the pause doesn't discard their work.
+                        for prior_call, prior_result in zip(tool_calls, results):
+                            prior_id, _, _ = _tool_call_identity(prior_call)
+                            if prior_id is not None:
+                                pause.completed_results.setdefault(
+                                    prior_id, prior_result
+                                )
+                        raise
                     results.append(result)
                 return results
             else:

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -12,7 +12,7 @@ from .providers import (
     DeepSeekProvider,
 )
 from .providers.base import LLMResponse
-from .exceptions import LLMError, ConfigurationError, ToolError
+from .exceptions import LLMError, ConfigurationError, ToolError, PauseToolExecution
 from .config import LLMConfig
 from .llm_providers import LLMProvider
 from .citations import citations_tool
@@ -123,6 +123,7 @@ async def chat_async(
     container_id: Optional[str] = None,
     task_budget: Optional[Union[int, Dict[str, Any]]] = None,
     conversation_cache: Optional[ConversationCache] = None,
+    resume_tool_results: Optional[Dict[str, Any]] = None,
 ) -> LLMResponse:
     """
     Execute a chat completion with explicit provider parameter.
@@ -184,6 +185,7 @@ async def chat_async(
             changes turn-to-turn invalidates the prompt cache; prefer setting ``total``
             once and letting the server-side countdown self-regulate.
         conversation_cache: Optional supplemental store for conversation history (Anthropic and OpenRouter). Runs alongside the built-in pickle cache — pickle writes always happen; ``conversation_cache.store`` is called in addition. On load, ``conversation_cache.load`` is tried first; a non-None return short-circuits the pickle read. Use this to mirror history to a database or shared store so follow-ups work across machines.
+        resume_tool_results: Anthropic and OpenAI only. Resume a run that was paused by a tool raising ``PauseToolExecution``. Maps each pending tool-call id (from the paused ``LLMResponse.pending_tool_use``) to the result to deliver as that tool's output, e.g. ``{tool_use_id: {"answers": [...]}}``. defog appends the matching tool_result turn and continues the agent loop. Pass the paused response's ``messages`` back via ``messages`` (Anthropic), and additionally its ``response_id`` via ``previous_response_id`` (OpenAI).
     Returns:
         LLMResponse object containing the result
 
@@ -223,6 +225,21 @@ async def chat_async(
 
     if providers is not None and _provider_value(provider) != "openrouter":
         raise ValueError("providers is only supported when provider is 'openrouter'.")
+
+    # Human-in-the-loop resume is only wired for anthropic and openai.
+    if resume_tool_results is not None:
+        if _provider_value(provider) not in ("anthropic", "openai"):
+            raise ValueError(
+                "resume_tool_results is only supported for the 'anthropic' and "
+                "'openai' providers."
+            )
+        if not isinstance(resume_tool_results, dict):
+            raise ValueError("resume_tool_results must be a dict of {tool_id: result}.")
+        if not tools:
+            raise ValueError(
+                "resume_tool_results requires the same `tools` used in the paused "
+                "run so the agent loop can continue."
+            )
 
     # validate that mcp servers are simple strings and nothing else
     if mcp_servers:
@@ -382,6 +399,7 @@ async def chat_async(
                 "container_id": container_id,
                 "task_budget": task_budget,
                 "conversation_cache": conversation_cache,
+                "resume_tool_results": resume_tool_results,
             }
             if (
                 providers is not None
@@ -390,6 +408,11 @@ async def chat_async(
                 execute_kwargs["providers"] = providers
 
             response = await provider_instance.execute_chat(**execute_kwargs)
+
+            # A tool suspended the loop for human-in-the-loop input. Return the
+            # paused response as-is; citation/post-processing does not apply.
+            if getattr(response, "status", None) == "paused":
+                return response
 
             # Process citations if requested and we have tool outputs
             if insert_tool_citations and response.tool_outputs:
@@ -488,6 +511,16 @@ async def chat_async(
 
             return response
 
+        except PauseToolExecution:
+            # A tool raised PauseToolExecution but the provider does not
+            # support the pause/resume primitive (only anthropic and openai
+            # capture/return a paused response). Surface a clear error rather
+            # than leaking the raw control-flow signal.
+            raise ConfigurationError(
+                "A tool raised PauseToolExecution, but the human-in-the-loop "
+                "pause/resume primitive is only supported for the 'anthropic' "
+                "and 'openai' providers."
+            )
         except ToolError:
             # Tool execution errors should not trigger a retry of the entire
             # agentic loop — only the erroneous step should be retried (which

--- a/defog/llm/utils_function_calling.py
+++ b/defog/llm/utils_function_calling.py
@@ -14,6 +14,22 @@ from typing import (
 from pydantic import BaseModel, Field, create_model
 from defog.llm.models import OpenAIFunctionSpecs, AnthropicFunctionSpecs
 from defog.llm.llm_providers import LLMProvider
+from defog.llm.exceptions import PauseToolExecution
+
+
+def _tool_call_identity(tool_call: Dict[str, Any]):
+    """Extract (id, name, args) from a tool_call dict in any provider shape."""
+    tool_id = (
+        tool_call.get("id")
+        or tool_call.get("tool_call_id")
+        or tool_call.get("call_id")
+        or tool_call.get("tool_use_id")
+    )
+    func_name = tool_call.get("function", {}).get("name") or tool_call.get("name")
+    func_args = tool_call.get("function", {}).get("arguments") or tool_call.get(
+        "arguments", {}
+    )
+    return tool_id, func_name, func_args
 
 
 def python_type_to_json_schema_type(python_type):
@@ -420,30 +436,36 @@ async def execute_tools_parallel(
         # Sequential execution (current behavior)
         results = []
         for tool_call in tool_calls:
-            func_name = tool_call.get("function", {}).get("name") or tool_call.get(
-                "name"
-            )
-            func_args = tool_call.get("function", {}).get("arguments") or tool_call.get(
-                "arguments", {}
-            )
+            tool_id, func_name, func_args = _tool_call_identity(tool_call)
 
-            if func_name in tool_dict:
-                tool = tool_dict[func_name]
-                if inspect.iscoroutinefunction(tool):
-                    result = await execute_tool_async(tool, func_args)
+            try:
+                if func_name in tool_dict:
+                    tool = tool_dict[func_name]
+                    if inspect.iscoroutinefunction(tool):
+                        result = await execute_tool_async(tool, func_args)
+                    else:
+                        result = execute_tool(tool, func_args)
+                    results.append(result)
                 else:
-                    result = execute_tool(tool, func_args)
-                results.append(result)
-            else:
-                results.append(f"Error: Function {func_name} not found")
+                    results.append(f"Error: Function {func_name} not found")
+            except PauseToolExecution as pause:
+                # A tool asked to suspend the loop. Annotate it with the
+                # results of the tools that already finished in this batch so
+                # the provider can preserve that work across the pause.
+                pause.attach_identity(tool_id, func_name, func_args)
+                for prior_call, prior_result in zip(tool_calls, results):
+                    prior_id, _, _ = _tool_call_identity(prior_call)
+                    if prior_id is not None:
+                        pause.completed_results[prior_id] = prior_result
+                raise
         return results
     else:
         # Parallel execution
         async def execute_single_tool(tool_call):
+            func_name = tool_call.get("function", {}).get("name") or tool_call.get(
+                "name"
+            )
             try:
-                func_name = tool_call.get("function", {}).get("name") or tool_call.get(
-                    "name"
-                )
                 func_args = tool_call.get("function", {}).get(
                     "arguments"
                 ) or tool_call.get("arguments", {})
@@ -460,12 +482,32 @@ async def execute_tools_parallel(
                         )
                 else:
                     return f"Error: Function {func_name} not found"
+            except PauseToolExecution:
+                # Let pause signals propagate; gather(return_exceptions=True)
+                # captures them as results and we re-raise below. (They are
+                # BaseException, so this except clause is only here for clarity.)
+                raise
             except Exception as e:
                 return f"Error executing {func_name}: {str(e)}"
 
         # Execute all tool calls concurrently
         tasks = [execute_single_tool(tool_call) for tool_call in tool_calls]
         results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        # If any tool asked to pause, surface the first pause and attach the
+        # results of every sibling that completed normally so the provider can
+        # preserve that work when it captures the conversation.
+        for tool_call, result in zip(tool_calls, results):
+            if isinstance(result, PauseToolExecution):
+                tool_id, func_name, func_args = _tool_call_identity(tool_call)
+                result.attach_identity(tool_id, func_name, func_args)
+                for sibling_call, sibling_result in zip(tool_calls, results):
+                    sibling_id, _, _ = _tool_call_identity(sibling_call)
+                    if sibling_id is not None and not isinstance(
+                        sibling_result, BaseException
+                    ):
+                        result.completed_results[sibling_id] = sibling_result
+                raise result
 
         # Convert any exceptions to error strings
         processed_results = []

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -13,6 +13,7 @@ This directory contains detailed documentation for all LLM-related functionality
 
 - [Tool Budget Management](tool-budget-management.md) - Limit tool usage to control costs
 - [Tool Citations](tool-citations.md) - Automatic citation addition for tool outputs
+- [Human-in-the-Loop Tool Calls](human-in-the-loop.md) - Pause an agent loop from inside a tool to ask the user, then resume with their answer
 - [Cost Tracking](cost-tracking.md) - Track and monitor LLM operation costs
 
 ## Specialized Tools

--- a/docs/llm/function-calling.md
+++ b/docs/llm/function-calling.md
@@ -129,3 +129,32 @@ response = await chat_async(
 ```
 
 The assistant receives the sampled/truncated preview, while `response.tool_outputs` always contains the full tool output for logging or follow-up use.
+
+### Pause a Tool to Ask the User (Human-in-the-Loop)
+
+A tool can suspend the whole agent loop to ask the end user something, return
+control to your application, and resume later with the user's answer delivered
+as that tool's result:
+
+```python
+from defog.llm import chat_async, PauseToolExecution
+
+async def ask_user_question(question: str) -> dict:
+    """Ask the end user a clarifying question when the request is ambiguous."""
+    raise PauseToolExecution(payload={"questions": [question]})
+
+resp = await chat_async(provider="anthropic", model="claude-sonnet-4-6",
+                        messages=messages, tools=[ask_user_question])
+
+if resp.status == "paused":
+    answer = collect_answer(resp.pause_payload)         # may be much later
+    resp = await chat_async(
+        provider="anthropic", model="claude-sonnet-4-6",
+        messages=resp.messages, tools=[ask_user_question],
+        resume_tool_results={resp.pending_tool_use["id"]: answer},
+    )
+```
+
+See [Human-in-the-Loop Tool Calls](human-in-the-loop.md) for the full flow,
+including OpenAI (`previous_response_id`), persisting across a restart, and
+parallel tool calls.

--- a/docs/llm/human-in-the-loop.md
+++ b/docs/llm/human-in-the-loop.md
@@ -1,0 +1,156 @@
+# Human-in-the-Loop Tool Calls (Pause / Resume)
+
+`chat_async` can **pause an agent loop from inside a tool**, hand control back
+to your application, and **resume later** — even minutes later, on a different
+worker, or after a process restart — delivering the answer as that tool's
+`tool_result`.
+
+This is the standard "ask the user a clarifying question" / approval /
+confirmation pattern. The fast (sub-second) case already works by simply
+`await`-ing inside the tool. This primitive is for the case where the answer
+arrives out-of-band and you need to release the run and pick it up again.
+
+Supported providers: **Anthropic** and **OpenAI**.
+
+## The primitive
+
+A tool raises `PauseToolExecution` to suspend the loop:
+
+```python
+from defog.llm import chat_async, PauseToolExecution
+
+async def ask_user_question(question: str) -> dict:
+    """Ask the end user a clarifying question when the request is ambiguous."""
+    raise PauseToolExecution(payload={"questions": [question]})
+```
+
+`chat_async` catches it (even under `parallel_tool_calls=True`), stops the
+loop, and returns an `LLMResponse` describing the pause:
+
+```python
+resp = await chat_async(
+    provider="anthropic",
+    model="claude-sonnet-4-6",
+    messages=messages,
+    tools=[ask_user_question],
+)
+
+resp.status            # "paused"
+resp.pending_tool_use  # {"id": ..., "name": "ask_user_question", "input": {...}}
+resp.pause_payload     # {"questions": [...]}  — whatever the tool passed
+resp.messages          # full in-flight history incl. the assistant tool_use
+                       # turn, with thinking blocks intact (Anthropic)
+resp.response_id       # resume handle for OpenAI (see below)
+```
+
+`PauseToolExecution` subclasses `BaseException` (like `asyncio.CancelledError`)
+so the `except Exception` handlers throughout the tool-execution path — and
+`asyncio.gather(return_exceptions=True)` under parallel execution — cannot
+accidentally swallow it.
+
+## Resuming
+
+Persist what the paused response gives you, collect the answer, then call
+`chat_async` again with `resume_tool_results` — a dict mapping each pending
+tool-call id to the result to deliver as that tool's output. defog appends the
+matching `tool_result` turn and continues the loop. You never build provider
+message blocks by hand.
+
+### Anthropic
+
+The captured assistant turn (thinking + `tool_use`) lives in `resp.messages`,
+so resuming only needs the messages plus the answer:
+
+```python
+tool_use_id = resp.pending_tool_use["id"]
+
+final = await chat_async(
+    provider="anthropic",
+    model="claude-sonnet-4-6",
+    messages=resp.messages,                       # persisted from the pause
+    tools=[ask_user_question],                    # same tools as the paused run
+    resume_tool_results={tool_use_id: {"answer": "Use the prod database."}},
+)
+
+final.content  # the model's final answer, computed with the user's input
+```
+
+### OpenAI
+
+OpenAI keeps the assistant turn (reasoning + function call) server-side,
+referenced by a response id, so resuming additionally needs
+`previous_response_id`:
+
+```python
+tool_use_id = resp.pending_tool_use["id"]
+
+final = await chat_async(
+    provider="openai",
+    model="gpt-4.1",
+    messages=resp.messages,                       # persisted from the pause
+    tools=[ask_user_question],
+    previous_response_id=resp.response_id,         # <- required for OpenAI
+    resume_tool_results={tool_use_id: {"answer": "Use the prod database."}},
+)
+```
+
+OpenAI retains the originating response for 30 days when `store=True` (the
+default), which is what makes "resume on a different worker / after a restart"
+work.
+
+## Persisting across a restart
+
+`resp.messages`, `resp.pending_tool_use`, `resp.pause_payload`, and (OpenAI)
+`resp.response_id` are all plain JSON-serializable data. Persist them to your
+database / queue, return control, and resume from a completely fresh process:
+
+```python
+import json
+
+# At pause time:
+record = {
+    "messages": resp.messages,
+    "pending_tool_use": resp.pending_tool_use,
+    "pause_payload": resp.pause_payload,
+    "response_id": resp.response_id,   # OpenAI
+}
+db.save(run_id, json.dumps(record))
+
+# Later, anywhere:
+record = json.loads(db.load(run_id))
+answer = collect_answer_from_user(record["pause_payload"])
+final = await chat_async(
+    provider="openai",
+    model="gpt-4.1",
+    messages=record["messages"],
+    tools=[ask_user_question],
+    previous_response_id=record["response_id"],
+    resume_tool_results={record["pending_tool_use"]["id"]: answer},
+)
+```
+
+## Parallel tool calls
+
+If the model issues several tool calls in one turn and one of them pauses, the
+work of the sibling tools that already finished is **not** discarded — their
+results are captured alongside the assistant turn (Anthropic: a partial
+`tool_result` turn; OpenAI: stashed `function_call_output` items). On resume you
+only need to supply results for the tool calls that were actually paused;
+defog fills in the rest.
+
+If more than one tool pauses in the same turn, only the first is surfaced as
+`pending_tool_use`; provide results for every pending id via
+`resume_tool_results` (defog raises a clear `ValueError` listing any it is still
+missing).
+
+## Notes & limitations
+
+- Pass the **same `tools`** to the resume call that the paused run used, so the
+  agent loop can continue.
+- `resume_tool_results` is only supported for the `anthropic` and `openai`
+  providers. Raising `PauseToolExecution` under any other provider raises a
+  clear `ConfigurationError`.
+- A paused `LLMResponse` has `content=None` and reports only best-effort
+  partial token usage up to the pause point.
+- This is for the suspend-and-resume-later flow. If the answer is available
+  within the request, just `await` for it inside the tool — no pause needed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.5.12"
+version = "1.6.0"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_llm_pause_resume.py
+++ b/tests/test_llm_pause_resume.py
@@ -1,0 +1,398 @@
+"""Tests for the human-in-the-loop pause/resume primitive.
+
+Covers:
+  * PauseToolExecution propagating out of parallel + sequential tool execution
+    (Limitation 1 from issue #282) with tool identity and sibling results
+    preserved.
+  * Anthropic message capture / resume-injection helpers (offline).
+  * chat_async validation around resume_tool_results.
+  * Live end-to-end pause -> resume for Anthropic and OpenAI (gated on keys).
+"""
+
+import asyncio
+import pytest
+
+from defog.llm import chat_async, PauseToolExecution
+from defog.llm.utils_function_calling import execute_tools_parallel
+from defog.llm.tools.handler import ToolHandler
+from defog.llm.providers.anthropic_provider import AnthropicProvider
+from tests.conftest import skip_if_no_api_key
+
+
+# ---------------------------------------------------------------------------
+# Tools used across tests
+# ---------------------------------------------------------------------------
+async def ask_user_question(question: str) -> dict:
+    """Ask the end user a clarifying question and wait for their answer.
+
+    Use this whenever a request is ambiguous and you need more information
+    before you can proceed.
+    """
+    raise PauseToolExecution(payload={"questions": [question]})
+
+
+def add_numbers(a: int, b: int) -> int:
+    """Return the sum of two numbers."""
+    return a + b
+
+
+# ---------------------------------------------------------------------------
+# Offline: propagation through the tool-execution layer (Limitation 1)
+# ---------------------------------------------------------------------------
+class TestPausePropagation:
+    def setup_method(self):
+        self.tool_dict = {
+            "ask_user_question": ask_user_question,
+            "add_numbers": add_numbers,
+        }
+        self.calls = [
+            {"id": "call_add", "name": "add_numbers", "arguments": {"a": 2, "b": 3}},
+            {
+                "id": "call_ask",
+                "name": "ask_user_question",
+                "arguments": {"question": "which db?"},
+            },
+        ]
+
+    def test_pause_is_base_exception(self):
+        # Must not be caught by generic `except Exception` handlers.
+        assert issubclass(PauseToolExecution, BaseException)
+        assert not issubclass(PauseToolExecution, Exception)
+
+    def test_parallel_propagates_with_identity_and_siblings(self):
+        async def run():
+            return await execute_tools_parallel(
+                self.calls, self.tool_dict, enable_parallel=True
+            )
+
+        with pytest.raises(PauseToolExecution) as exc_info:
+            asyncio.run(run())
+
+        pause = exc_info.value
+        assert pause.tool_use_id == "call_ask"
+        assert pause.tool_name == "ask_user_question"
+        assert pause.tool_input == {"question": "which db?"}
+        assert pause.payload == {"questions": ["which db?"]}
+        # Sibling that finished normally is preserved.
+        assert pause.completed_results == {"call_add": 5}
+
+    def test_sequential_propagates_with_identity_and_siblings(self):
+        async def run():
+            return await execute_tools_parallel(
+                self.calls, self.tool_dict, enable_parallel=False
+            )
+
+        with pytest.raises(PauseToolExecution) as exc_info:
+            asyncio.run(run())
+
+        pause = exc_info.value
+        assert pause.tool_use_id == "call_ask"
+        assert pause.completed_results == {"call_add": 5}
+
+    def test_tool_handler_batch_parallel_propagates(self):
+        async def run():
+            return await ToolHandler().execute_tool_calls_batch(
+                self.calls, self.tool_dict, parallel_tool_calls=True
+            )
+
+        with pytest.raises(PauseToolExecution) as exc_info:
+            asyncio.run(run())
+        assert exc_info.value.tool_use_id == "call_ask"
+        assert exc_info.value.completed_results == {"call_add": 5}
+
+    def test_tool_handler_batch_sequential_propagates(self):
+        async def run():
+            return await ToolHandler().execute_tool_calls_batch(
+                self.calls, self.tool_dict, parallel_tool_calls=False
+            )
+
+        with pytest.raises(PauseToolExecution) as exc_info:
+            asyncio.run(run())
+        assert exc_info.value.tool_use_id == "call_ask"
+        assert exc_info.value.completed_results == {"call_add": 5}
+
+
+# ---------------------------------------------------------------------------
+# Offline: Anthropic capture / resume-injection helpers
+# ---------------------------------------------------------------------------
+class TestAnthropicResumeHelpers:
+    def setup_method(self):
+        self.provider = AnthropicProvider(api_key="test-key")
+        self.handler = ToolHandler()
+
+    def test_serialize_messages_passes_dicts_through(self):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "hmm", "signature": "sig"},
+                    {"type": "tool_use", "id": "tu_1", "name": "ask", "input": {}},
+                ],
+            },
+        ]
+        out = self.provider._serialize_messages(messages)
+        assert out == messages  # plain dicts unchanged, thinking preserved
+
+    def test_inject_resume_tool_results_appends_user_turn(self):
+        messages = [
+            {"role": "user", "content": "help me"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "let me ask"},
+                    {
+                        "type": "tool_use",
+                        "id": "tu_1",
+                        "name": "ask_user_question",
+                        "input": {"question": "x"},
+                    },
+                ],
+            },
+        ]
+        out = self.provider._inject_resume_tool_results(
+            messages,
+            {"tu_1": "use the prod db"},
+            self.handler,
+            None,
+            "claude-haiku-4-5",
+        )
+        assert out[-1]["role"] == "user"
+        assert out[-1]["content"] == [
+            {
+                "type": "tool_result",
+                "tool_use_id": "tu_1",
+                "content": "use the prod db",
+            }
+        ]
+
+    def test_inject_completes_partial_sibling_turn(self):
+        # Parallel pause: a sibling tool_result is already present; the resume
+        # must fill in only the still-pending tool call.
+        messages = [
+            {"role": "user", "content": "help me"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu_add",
+                        "name": "add_numbers",
+                        "input": {},
+                    },
+                    {
+                        "type": "tool_use",
+                        "id": "tu_ask",
+                        "name": "ask_user_question",
+                        "input": {},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_add", "content": "5"}
+                ],
+            },
+        ]
+        out = self.provider._inject_resume_tool_results(
+            messages, {"tu_ask": "answer"}, self.handler, None, "claude-haiku-4-5"
+        )
+        # The trailing user turn now has results for both tool calls.
+        result_ids = {
+            b["tool_use_id"] for b in out[-1]["content"] if b["type"] == "tool_result"
+        }
+        assert result_ids == {"tu_add", "tu_ask"}
+
+    def test_inject_missing_result_raises(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "tool_use", "id": "tu_1", "name": "ask", "input": {}}
+                ],
+            }
+        ]
+        with pytest.raises(ValueError, match="missing results"):
+            self.provider._inject_resume_tool_results(
+                messages, {"other_id": "x"}, self.handler, None, "claude-haiku-4-5"
+            )
+
+    def test_inject_without_tool_use_turn_raises(self):
+        messages = [{"role": "user", "content": "hi"}]
+        with pytest.raises(ValueError, match="no assistant tool_use turn"):
+            self.provider._inject_resume_tool_results(
+                messages, {"tu_1": "x"}, self.handler, None, "claude-haiku-4-5"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Offline: chat_async validation
+# ---------------------------------------------------------------------------
+class TestResumeValidation:
+    def test_unsupported_provider_rejected(self):
+        with pytest.raises(ValueError, match="only supported for"):
+            asyncio.run(
+                chat_async(
+                    provider="gemini",
+                    model="gemini-2.5-flash",
+                    messages=[{"role": "user", "content": "hi"}],
+                    tools=[ask_user_question],
+                    resume_tool_results={"tu_1": "x"},
+                )
+            )
+
+    def test_resume_requires_tools(self):
+        with pytest.raises(ValueError, match="requires the same `tools`"):
+            asyncio.run(
+                chat_async(
+                    provider="anthropic",
+                    model="claude-haiku-4-5",
+                    messages=[{"role": "user", "content": "hi"}],
+                    resume_tool_results={"tu_1": "x"},
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Live: end-to-end pause -> resume
+# ---------------------------------------------------------------------------
+SYSTEM_PROMPT = (
+    "You are a careful assistant. Before giving any recommendation you MUST "
+    "call the ask_user_question tool exactly once to clarify the user's intent. "
+    "After you receive their answer, give your final recommendation as text and "
+    "do not ask any further questions."
+)
+
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("anthropic")
+async def test_anthropic_pause_and_resume():
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": "Recommend a programming language for me to learn.",
+        },
+    ]
+    tools = [ask_user_question]
+
+    paused = await chat_async(
+        provider="anthropic",
+        model="claude-haiku-4-5",
+        messages=messages,
+        tools=tools,
+        max_completion_tokens=1024,
+    )
+
+    assert paused.status == "paused"
+    assert paused.pending_tool_use is not None
+    assert paused.pending_tool_use["name"] == "ask_user_question"
+    assert paused.pending_tool_use["id"]
+    assert paused.pause_payload and "questions" in paused.pause_payload
+    assert isinstance(paused.messages, list) and len(paused.messages) >= 2
+
+    tool_use_id = paused.pending_tool_use["id"]
+    resumed = await chat_async(
+        provider="anthropic",
+        model="claude-haiku-4-5",
+        messages=paused.messages,
+        tools=tools,
+        max_completion_tokens=1024,
+        resume_tool_results={
+            tool_use_id: "I want to build web backends and value job prospects."
+        },
+    )
+
+    assert resumed.status != "paused"
+    assert isinstance(resumed.content, str) and len(resumed.content) > 0
+
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("anthropic")
+async def test_anthropic_pause_resume_preserves_thinking():
+    """The captured assistant turn must keep thinking blocks intact so the
+    signed thinking round-trips back into the API on resume."""
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {"role": "user", "content": "Recommend a database for my project."},
+    ]
+    tools = [ask_user_question]
+
+    paused = await chat_async(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        messages=messages,
+        tools=tools,
+        reasoning_effort="low",
+        max_completion_tokens=2048,
+    )
+
+    assert paused.status == "paused"
+    assistant_turn = [m for m in paused.messages if m["role"] == "assistant"][-1]
+    block_types = [
+        b.get("type") for b in assistant_turn["content"] if isinstance(b, dict)
+    ]
+    assert "thinking" in block_types or "redacted_thinking" in block_types
+    assert "tool_use" in block_types
+
+    tool_use_id = paused.pending_tool_use["id"]
+    resumed = await chat_async(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        messages=paused.messages,
+        tools=tools,
+        reasoning_effort="low",
+        max_completion_tokens=2048,
+        resume_tool_results={
+            tool_use_id: "A high-write, time-series analytics workload."
+        },
+    )
+
+    assert resumed.status != "paused"
+    assert isinstance(resumed.content, str) and len(resumed.content) > 0
+
+
+@pytest.mark.asyncio
+@skip_if_no_api_key("openai")
+async def test_openai_pause_and_resume():
+    messages = [
+        {"role": "system", "content": SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": "Recommend a programming language for me to learn.",
+        },
+    ]
+    tools = [ask_user_question]
+
+    paused = await chat_async(
+        provider="openai",
+        model="gpt-4.1",
+        messages=messages,
+        tools=tools,
+        max_completion_tokens=1024,
+    )
+
+    assert paused.status == "paused"
+    assert paused.pending_tool_use is not None
+    assert paused.pending_tool_use["name"] == "ask_user_question"
+    assert paused.pending_tool_use["id"]
+    assert paused.pause_payload and "questions" in paused.pause_payload
+    # OpenAI resumes via previous_response_id (assistant turn is server-side).
+    assert paused.response_id
+
+    tool_use_id = paused.pending_tool_use["id"]
+    resumed = await chat_async(
+        provider="openai",
+        model="gpt-4.1",
+        messages=paused.messages,
+        tools=tools,
+        max_completion_tokens=1024,
+        previous_response_id=paused.response_id,
+        resume_tool_results={
+            tool_use_id: "I want to build web backends and value job prospects."
+        },
+    )
+
+    assert resumed.status != "paused"
+    assert isinstance(resumed.content, str) and len(resumed.content) > 0

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.5.12"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Closes #282.

Adds a first-class **pause / resume primitive for human-in-the-loop tool calls** to `chat_async`. A tool can suspend the agent loop to ask the end user something, return control to the application, and resume later — **minutes later, on a different worker, or after a restart** — with the user's answer delivered as that tool's `tool_result`. defog owns all the message bookkeeping (thinking-block preservation, `tool_use`/`tool_result` pairing, provider differences); the application never builds provider message blocks.

**Providers:** Anthropic and OpenAI.

---

## How to use it

### 1. Write a tool that pauses

A tool raises `PauseToolExecution` with whatever payload your app needs (e.g. the questions to ask):

```python
from defog.llm import chat_async, PauseToolExecution

async def ask_user_question(question: str) -> dict:
    """Ask the end user a clarifying question when the request is ambiguous."""
    raise PauseToolExecution(payload={"questions": [question]})
```

### 2. Run — and detect the pause

`chat_async` catches the signal (even under `parallel_tool_calls=True`), stops the loop, and returns a paused `LLMResponse`:

```python
resp = await chat_async(
    provider="anthropic",
    model="claude-sonnet-4-6",
    messages=messages,
    tools=[ask_user_question],
)

resp.status            # "paused"
resp.pending_tool_use  # {"id": ..., "name": "ask_user_question", "input": {...}}
resp.pause_payload     # {"questions": [...]}  — exactly what the tool passed
resp.messages          # full in-flight history incl. the assistant tool_use turn,
                       # thinking blocks intact (Anthropic)
resp.response_id       # resume handle for OpenAI (see below)
```

### 3. Collect the answer and resume

Pass `resume_tool_results` — a dict mapping each pending tool-call id to the result to deliver as that tool's output. defog appends the matching `tool_result` turn and continues the loop.

**Anthropic** (the captured assistant turn lives in `resp.messages`):

```python
tool_use_id = resp.pending_tool_use["id"]

final = await chat_async(
    provider="anthropic",
    model="claude-sonnet-4-6",
    messages=resp.messages,                       # persisted from the pause
    tools=[ask_user_question],                    # same tools as the paused run
    resume_tool_results={tool_use_id: {"answer": "Use the prod database."}},
)
final.content   # the model's final answer, computed with the user's input
```

**OpenAI** keeps the assistant turn (reasoning + function call) server-side, so resume additionally needs `previous_response_id`:

```python
tool_use_id = resp.pending_tool_use["id"]

final = await chat_async(
    provider="openai",
    model="gpt-4.1",
    messages=resp.messages,
    tools=[ask_user_question],
    previous_response_id=resp.response_id,         # <- required for OpenAI
    resume_tool_results={tool_use_id: {"answer": "Use the prod database."}},
)
```

### Persisting across a restart / different worker

`resp.messages`, `resp.pending_tool_use`, `resp.pause_payload`, and (OpenAI) `resp.response_id` are all plain JSON-serializable data:

```python
# At pause time:
db.save(run_id, json.dumps({
    "messages": resp.messages,
    "pending_tool_use": resp.pending_tool_use,
    "pause_payload": resp.pause_payload,
    "response_id": resp.response_id,   # OpenAI
}))

# Later, from a completely fresh process:
rec = json.loads(db.load(run_id))
answer = collect_answer_from_user(rec["pause_payload"])
final = await chat_async(
    provider="openai", model="gpt-4.1",
    messages=rec["messages"], tools=[ask_user_question],
    previous_response_id=rec["response_id"],
    resume_tool_results={rec["pending_tool_use"]["id"]: answer},
)
```

OpenAI retains the originating response for 30 days when `store=True` (the default), which is what makes cross-process resume work.

---

## How it solves the two limitations from the issue

### Limitation 1 — a tool couldn't signal "suspend" by raising

`PauseToolExecution` subclasses **`BaseException`** (like `asyncio.CancelledError`), so the `except Exception` handlers throughout the tool-execution path can't swallow it.

- `execute_tools_parallel` detects the signal among `asyncio.gather(return_exceptions=True)` results and re-raises it; the sequential paths propagate it directly.
- As it travels up (`execute_tool_call` → `execute_tool_calls_batch` → `execute_tool_calls_with_retry`), defog annotates it with the tool's `id`/`name`/`input` (the tool itself doesn't know its own call id) and **preserves the results of sibling tools that already finished**, so parallel work isn't discarded.

### Limitation 2 — no supported way to capture/resume the in-flight conversation

Each provider captures the conversation on pause and `chat_async` returns a paused `LLMResponse` instead of raising:

- **Anthropic:** `resp.messages` is the full provider-format history including the assistant `tool_use` turn, with **thinking blocks dumped verbatim (signatures intact)** so they round-trip back into the API on resume. On resume defog completes the trailing `tool_result` turn from `resume_tool_results`.
- **OpenAI:** the assistant turn (reasoning + function call) is referenced via `previous_response_id`; defog stashes any sibling `function_call_output` items and the system instructions, and on resume submits `function_call_output` for every pending call.

---

## Parallel tool calls

If the model issues several tool calls in one turn and one pauses, the finished siblings' results are captured alongside the assistant turn (Anthropic: a partial `tool_result` turn; OpenAI: stashed `function_call_output` items). On resume you only supply results for the tools that actually paused; defog fills in the rest. If more than one tool pauses in the same turn, only the first is surfaced as `pending_tool_use`, and defog raises a clear `ValueError` on resume listing any pending id still missing a result.

## API surface

- New export: `from defog.llm import PauseToolExecution`.
- New `LLMResponse` fields: `status`, `pending_tool_use`, `pause_payload`, `messages` (populated only on pause).
- New `chat_async` param: `resume_tool_results: dict[str, Any]` (Anthropic/OpenAI only; requires the same `tools`).
- Raising `PauseToolExecution` under an unsupported provider raises a clear `ConfigurationError`.

A paused response has `content=None` and reports best-effort partial token usage up to the pause point. Backwards compatible: all new fields/params default to `None`, and normal (non-pausing) tool runs are unaffected.

## Tests

`tests/test_llm_pause_resume.py` — **15 tests, all passing**:
- Offline: pause propagation through all four execution paths (parallel/sequential × direct/`ToolHandler`) with identity + sibling preservation; Anthropic serialize / resume-injection helpers; `chat_async` validation.
- Live (gated on API keys): Anthropic pause→resume, **Anthropic pause→resume with extended thinking** (asserts the captured assistant turn contains a `thinking` block and the signed thinking round-trips), OpenAI pause→resume.

No new `ruff` errors; existing tool-call tests unaffected.

## Docs

- New: `docs/llm/human-in-the-loop.md` (full flow, OpenAI specifics, persistence, parallel calls, limitations).
- Linked from `docs/llm/README.md` and a quick example added to `docs/llm/function-calling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)