### PR TITLE
Auto-apply Anthropic mid-conversation system messages on Opus 4.8

### DIFF
--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -141,6 +141,12 @@ MODEL_COSTS = {
         "cache_creation_input_cost_per1k": 0.00625,
         "output_cost_per1k": 0.025,
     },
+    "claude-opus-4-8": {
+        "input_cost_per1k": 0.005,
+        "cached_input_cost_per1k": 0.00125,
+        "cache_creation_input_cost_per1k": 0.00625,
+        "output_cost_per1k": 0.025,
+    },
     "claude-haiku-4-5": {
         "input_cost_per1k": 0.001,
         "cached_input_cost_per1k": 0.0001,

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -68,6 +68,49 @@ class AnthropicProvider(BaseLLMProvider):
                 pass
         return block
 
+    @staticmethod
+    def _merge_system_content(a: Any, b: Any) -> Any:
+        """Merge two system-message contents into one.
+
+        Anthropic rejects consecutive ``{"role": "system"}`` turns, so when two
+        mid-conversation system messages end up adjacent we fold them together.
+        Two plain strings join with a blank line; otherwise both are normalized
+        to text-block lists and concatenated.
+        """
+
+        def _as_blocks(content: Any) -> List[Any]:
+            if isinstance(content, str):
+                return [{"type": "text", "text": content}]
+            return list(content)
+
+        if isinstance(a, str) and isinstance(b, str):
+            return f"{a}\n\n{b}"
+        return _as_blocks(a) + _as_blocks(b)
+
+    @classmethod
+    def _coalesce_system_messages(
+        cls, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Merge runs of consecutive ``{"role": "system"}`` messages into one.
+
+        Anthropic rejects consecutive system turns, so adjacent system messages
+        are folded together (via :meth:`_merge_system_content`) before any
+        placement decisions are made. Non-system messages pass through
+        unchanged. The input list is not mutated.
+        """
+        out: List[Dict[str, Any]] = []
+        for msg in messages:
+            if msg.get("role") == "system" and out and out[-1].get("role") == "system":
+                out[-1] = {
+                    "role": "system",
+                    "content": cls._merge_system_content(
+                        out[-1]["content"], msg["content"]
+                    ),
+                }
+            else:
+                out.append(msg)
+        return out
+
     @classmethod
     def _serialize_messages(
         cls, messages: List[Dict[str, Any]]
@@ -461,34 +504,71 @@ class AnthropicProvider(BaseLLMProvider):
                 return True
             return False
 
-        for msg in messages:
+        # Mid-conversation system messages (Claude Opus 4.8 only, enabled
+        # automatically): a ``{"role": "system"}`` message that appears *after*
+        # the conversation has started is kept in place as a system turn
+        # instead of being hoisted into the top-level ``system`` field. Keeping
+        # it in place preserves the cached prefix — editing the top-level
+        # ``system`` field invalidates the cache for everything after it —
+        # while still giving the instruction system-level priority from that
+        # point onward. Leading system messages (those before any user/
+        # assistant turn) are always hoisted, matching conventional usage.
+        #
+        # This is a safe, transparent optimization: a system message is only
+        # kept in place when its position is unambiguously legal per Anthropic's
+        # placement rules (it directly follows a user turn and is either the
+        # last message or directly precedes an assistant turn). In any other
+        # position — or on any other model — it falls back to the historical
+        # hoist-into-``system`` behavior, so no previously valid request starts
+        # erroring.
+        keep_mid_in_place = "opus-4-8" in model
+        # Collapse runs of consecutive system messages first; Anthropic rejects
+        # consecutive ``system`` turns, and merging them up front lets the
+        # placement check below treat each as a single unit.
+        coalesced = self._coalesce_system_messages(messages)
+
+        def _hoist(content: Any) -> None:
+            if isinstance(content, str):
+                system_messages.append(content)
+            elif isinstance(content, list):
+                system_messages.append(
+                    "\n\n".join([item["text"] for item in content if "text" in item])
+                )
+
+        seen_non_system = False
+        for idx, msg in enumerate(coalesced):
             if msg.get("role") == "system":
-                if isinstance(msg["content"], str):
-                    system_messages.append(msg["content"])
-                elif isinstance(msg["content"], list):
-                    system_messages.append(
-                        "\n\n".join(
-                            [item["text"] for item in msg["content"] if "text" in item]
-                        )
+                in_place = False
+                if keep_mid_in_place and seen_non_system:
+                    prev = converted_messages[-1] if converted_messages else None
+                    nxt = coalesced[idx + 1] if idx + 1 < len(coalesced) else None
+                    prev_ok = prev is not None and prev.get("role") == "user"
+                    next_ok = nxt is None or nxt.get("role") == "assistant"
+                    in_place = prev_ok and next_ok
+                if in_place:
+                    converted_messages.append(
+                        {"role": "system", "content": msg["content"]}
                     )
-            else:
-                # Convert message content to Anthropic format
-                converted_msg = msg.copy()
-                converted_content = self.convert_content_to_anthropic(msg["content"])
+                else:
+                    _hoist(msg["content"])
+                continue
 
-                # Ensure user messages are never empty
-                if msg.get("role") == "assistant" and _content_is_empty(
-                    converted_content
-                ):
-                    converted_content = (
-                        "No content was generated for this turn. "
-                        "Refer to the preceding tool outputs for context."
-                    )
+            seen_non_system = True
+            # Convert message content to Anthropic format
+            converted_msg = msg.copy()
+            converted_content = self.convert_content_to_anthropic(msg["content"])
 
-                converted_msg["content"] = converted_content
-                converted_messages.append(converted_msg)
+            # Ensure user messages are never empty
+            if msg.get("role") == "assistant" and _content_is_empty(converted_content):
+                converted_content = (
+                    "No content was generated for this turn. "
+                    "Refer to the preceding tool outputs for context."
+                )
 
-        # Concatenate all system messages into a single string
+            converted_msg["content"] = converted_content
+            converted_messages.append(converted_msg)
+
+        # Concatenate all hoisted system messages into a single string
         sys_msg = "\n\n".join(system_messages) if system_messages else ""
 
         messages = converted_messages
@@ -502,18 +582,22 @@ class AnthropicProvider(BaseLLMProvider):
         # effort via output_config, replacing the deprecated budget_tokens
         # param. Update this tuple when new models add adaptive support.
         supports_adaptive = any(
-            p in model for p in ("opus-4-6", "opus-4-7", "sonnet-4-6")
+            p in model for p in ("opus-4-6", "opus-4-7", "opus-4-8", "sonnet-4-6")
         )
         # effort: "max" is only available on Opus models. Sending it to
         # Sonnet returns an API error.
-        supports_max_effort = "opus-4-6" in model or "opus-4-7" in model
-        # effort: "xhigh" is only available on Opus 4.7. Sending it to any
-        # other model returns an API error.
-        supports_xhigh_effort = "opus-4-7" in model
+        supports_max_effort = any(
+            p in model for p in ("opus-4-6", "opus-4-7", "opus-4-8")
+        )
+        # effort: "xhigh" is only available on Opus 4.7 and Opus 4.8. Sending
+        # it to any other model returns an API error.
+        supports_xhigh_effort = "opus-4-7" in model or "opus-4-8" in model
         # Opus models require adaptive thinking always on. For other
         # adaptive models (e.g. Sonnet 4.6), only enable it when
         # reasoning_effort is explicitly requested.
-        requires_adaptive = "opus-4-6" in model or "opus-4-7" in model
+        requires_adaptive = any(
+            p in model for p in ("opus-4-6", "opus-4-7", "opus-4-8")
+        )
         use_adaptive = requires_adaptive or (
             supports_adaptive and reasoning_effort is not None
         )

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -186,6 +186,9 @@ async def chat_async(
             once and letting the server-side countdown self-regulate.
         conversation_cache: Optional supplemental store for conversation history (Anthropic and OpenRouter). Runs alongside the built-in pickle cache — pickle writes always happen; ``conversation_cache.store`` is called in addition. On load, ``conversation_cache.load`` is tried first; a non-None return short-circuits the pickle read. Use this to mirror history to a database or shared store so follow-ups work across machines.
         resume_tool_results: Anthropic and OpenAI only. Resume a run that was paused by a tool raising ``PauseToolExecution``. Maps each pending tool-call id (from the paused ``LLMResponse.pending_tool_use``) to the result to deliver as that tool's output, e.g. ``{tool_use_id: {"answers": [...]}}``. defog appends the matching tool_result turn and continues the agent loop. Pass the paused response's ``messages`` back via ``messages`` (Anthropic), and additionally its ``response_id`` via ``previous_response_id`` (OpenAI).
+
+    Mid-conversation system messages (Anthropic, Claude Opus 4.8 only) are handled automatically: a ``{"role": "system"}`` message that appears *after* the conversation has started — directly following a user turn and either ending the list or directly preceding an assistant turn — is kept in place as a system turn instead of being hoisted into the top-level ``system`` field. This preserves the cached prefix (editing the top-level ``system`` field invalidates the cache for everything after it) while still giving the instruction system-level priority from that point onward. Leading system messages, system messages in any other position, and all system messages on other models or providers continue to be hoisted into the top-level system prompt, so existing behaviour is unchanged.
+
     Returns:
         LLMResponse object containing the result
 

--- a/docs/llm/core-chat-functions.md
+++ b/docs/llm/core-chat-functions.md
@@ -42,7 +42,7 @@ response = await chat_async(
     temperature=0.7,
     
     # Advanced parameters
-    reasoning_effort="high",          # low, medium, high (max for Opus 4.6 only)
+    reasoning_effort="high",          # low, medium, high; max on Opus 4.6/4.7/4.8; xhigh on Opus 4.7/4.8
     response_format=MyPydanticModel,  # Structured output
     tools=[...],                      # Function calling
     tool_choice="auto",               # auto, none, required, or specific tool
@@ -165,3 +165,45 @@ response = await chat_async(
 )
 
 ```
+
+## Mid-Conversation System Messages (Anthropic, Claude Opus 4.8)
+
+System instructions normally live at the start of the conversation and are
+hoisted into Anthropic's top-level `system` field. Editing that field — for
+example, appending a new instruction partway through a long session —
+invalidates the prompt cache for the entire conversation that follows it.
+
+On **Claude Opus 4.8**, `chat_async` handles this automatically. A
+`{"role": "system"}` message that appears *after* the conversation has started
+is kept in place as a system turn (rather than being hoisted), which preserves
+the cached prefix while still giving the instruction system-level priority from
+that point onward. No flag is required.
+
+```python
+response = await chat_async(
+    provider="anthropic",
+    model="claude-opus-4-8",
+    messages=[
+        {"role": "system", "content": "You are a code review assistant."},
+        {"role": "user", "content": "Review process() in utils.py."},
+        {"role": "assistant", "content": "Looks fine for small inputs."},
+        {"role": "user", "content": "Now review the calling code."},
+        # Appended mid-session — kept in place, so the cached prefix above
+        # (system prompt + earlier turns) still hits the cache.
+        {"role": "system", "content": "From now on, require type annotations."},
+    ],
+)
+```
+
+This is a safe, transparent optimization with no behavioral surprises:
+
+- The **leading** system prompt (before any user/assistant turn) is always
+  hoisted into the top-level `system` field, as before.
+- A mid-conversation system message is kept in place **only when its position is
+  unambiguously legal** for Anthropic's API — it directly follows a user turn
+  and is either the last message or directly precedes an assistant turn.
+- In any other position — or on any other model or provider — every system
+  message is hoisted into the top-level system prompt, exactly as it was before.
+  No previously valid request changes behavior.
+- Consecutive in-place system messages are merged into one (Anthropic rejects
+  adjacent system turns).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.0"
+version = "1.6.1"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_anthropic_mid_conversation_system.py
+++ b/tests/test_anthropic_mid_conversation_system.py
@@ -1,0 +1,343 @@
+"""Tests for Anthropic mid-conversation system messages in chat_async /
+AnthropicProvider.
+
+A ``{"role": "system"}`` message that appears *after* the conversation has
+started is normally hoisted into the top-level ``system`` field (which
+invalidates the cached prefix). On Claude Opus 4.8 the provider instead keeps
+such a message in place as a system turn — automatically, with no flag —
+whenever its position is unambiguously legal per Anthropic's placement rules
+(directly follows a user turn; is the last message or directly precedes an
+assistant turn). In any other position, or on any other model, it falls back
+to the historical hoist-into-``system`` behaviour, so no previously valid
+request changes.
+
+The unit + mocked-wiring tests below do not hit the live API. The final class
+is an end-to-end test against the real Anthropic API and is skipped unless
+``ANTHROPIC_API_KEY`` is set. Run it with:
+
+    PYTHONPATH=. python -m pytest tests/test_anthropic_mid_conversation_system.py \
+        -v --envfile .env
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from defog.llm import chat_async
+from defog.llm.providers.anthropic_provider import AnthropicProvider
+
+
+OPUS_48 = "claude-opus-4-8"
+SONNET = "claude-sonnet-4-6"
+
+
+def _leading_then_mid():
+    """A conversation with a leading system prompt plus a mid-conversation
+    system instruction appended after the latest user turn (a legal in-place
+    position)."""
+    return [
+        {"role": "system", "content": "You are a code review assistant."},
+        {"role": "user", "content": "Review process() in utils.py."},
+        {"role": "assistant", "content": "Looks fine for small inputs."},
+        {"role": "user", "content": "Now review the calling code."},
+        {"role": "system", "content": "From now on, require type annotations."},
+    ]
+
+
+class TestMergeSystemContent:
+    def test_two_strings_join_with_blank_line(self):
+        assert AnthropicProvider._merge_system_content("a", "b") == "a\n\nb"
+
+    def test_mixed_str_and_blocks_normalize_to_blocks(self):
+        merged = AnthropicProvider._merge_system_content(
+            "a", [{"type": "text", "text": "b"}]
+        )
+        assert merged == [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b"},
+        ]
+
+    def test_two_block_lists_concatenate(self):
+        merged = AnthropicProvider._merge_system_content(
+            [{"type": "text", "text": "a"}],
+            [{"type": "text", "text": "b"}],
+        )
+        assert merged == [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b"},
+        ]
+
+
+class TestCoalesceSystemMessages:
+    def test_consecutive_systems_merged(self):
+        out = AnthropicProvider._coalesce_system_messages(
+            [
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "a"},
+                {"role": "system", "content": "b"},
+            ]
+        )
+        assert out == [
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "a\n\nb"},
+        ]
+
+    def test_non_adjacent_systems_not_merged(self):
+        msgs = [
+            {"role": "system", "content": "a"},
+            {"role": "user", "content": "hi"},
+            {"role": "system", "content": "b"},
+        ]
+        assert AnthropicProvider._coalesce_system_messages(msgs) == msgs
+
+    def test_input_not_mutated(self):
+        msgs = [
+            {"role": "system", "content": "a"},
+            {"role": "system", "content": "b"},
+        ]
+        AnthropicProvider._coalesce_system_messages(msgs)
+        assert len(msgs) == 2
+
+
+class TestNonOpus48HoistsEverything:
+    """On any non-Opus-4.8 model every system message is hoisted — the
+    historical behaviour is unchanged."""
+
+    def test_sonnet_hoists_mid_system(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=_leading_then_mid(),
+            model=SONNET,
+        )
+        assert "You are a code review assistant." in params["system"]
+        assert "require type annotations" in params["system"]
+        assert all(m["role"] != "system" for m in params["messages"])
+
+
+class TestOpus48KeepsLegalMidSystemInPlace:
+    def test_leading_hoisted_mid_kept_in_place(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=_leading_then_mid(),
+            model=OPUS_48,
+        )
+        # Leading system prompt hoisted...
+        assert params["system"] == "You are a code review assistant."
+        # ...mid-conversation instruction NOT hoisted...
+        assert "type annotations" not in params["system"]
+        # ...it stays in place as the final system turn.
+        assert params["messages"][-1] == {
+            "role": "system",
+            "content": "From now on, require type annotations.",
+        }
+
+    def test_no_leading_system_means_empty_top_level(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "bye"},
+                {"role": "system", "content": "Be terse now."},
+            ],
+            model=OPUS_48,
+        )
+        assert params["system"] == ""
+        assert params["messages"][-1]["role"] == "system"
+
+    def test_list_content_kept_in_place_unchanged(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        block_content = [{"type": "text", "text": "Be terse."}]
+        params, _ = provider.build_params(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": block_content},
+            ],
+            model=OPUS_48,
+        )
+        assert params["messages"][-1] == {
+            "role": "system",
+            "content": block_content,
+        }
+
+    def test_consecutive_mid_system_messages_merged_and_kept(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "First instruction."},
+                {"role": "system", "content": "Second instruction."},
+            ],
+            model=OPUS_48,
+        )
+        system_turns = [m for m in params["messages"] if m["role"] == "system"]
+        assert len(system_turns) == 1
+        assert system_turns[0]["content"] == "First instruction.\n\nSecond instruction."
+        assert params["system"] == ""
+
+    def test_mid_system_followed_by_assistant_kept(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "Be terse."},
+                {"role": "assistant", "content": "ok"},
+            ],
+            model=OPUS_48,
+        )
+        roles = [m["role"] for m in params["messages"]]
+        assert roles == ["user", "system", "assistant"]
+        assert params["system"] == ""
+
+
+class TestOpus48FallsBackToHoistInIllegalPositions:
+    """When the position is not unambiguously legal, the message is hoisted —
+    never an error. This guarantees previously valid requests keep working."""
+
+    def test_followed_by_user_is_hoisted(self):
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "system", "content": "Be terse."},
+                {"role": "user", "content": "more"},
+            ],
+            model=OPUS_48,
+        )
+        # Not kept in place; hoisted instead. No exception raised.
+        assert "Be terse." in params["system"]
+        assert all(m["role"] != "system" for m in params["messages"])
+
+    def test_preceded_by_assistant_is_hoisted(self):
+        # A system message directly after a normal assistant turn is not a legal
+        # in-place position (Anthropic requires the preceding turn to be a user
+        # turn or an assistant turn ending in server tool use), so it hoists.
+        provider = AnthropicProvider(api_key="sk-test")
+        params, _ = provider.build_params(
+            messages=[
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "system", "content": "Be terse."},
+            ],
+            model=OPUS_48,
+        )
+        assert "Be terse." in params["system"]
+        assert all(m["role"] != "system" for m in params["messages"])
+
+
+class TestExecuteChatWiring:
+    """End-to-end wiring: patch AsyncAnthropic and confirm the in-place system
+    message reaches the request payload's messages array while the top-level
+    ``system`` field holds only the leading prompt."""
+
+    @staticmethod
+    def _fake_client_factory(captured: Dict[str, Any]):
+        def fake_client_ctor(**client_kwargs: Any) -> SimpleNamespace:
+            captured["client_kwargs"] = client_kwargs
+
+            async def _create(**params: Any) -> SimpleNamespace:
+                captured["request_params"] = params
+                return SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="ok")],
+                    stop_reason="end_turn",
+                    usage=SimpleNamespace(
+                        input_tokens=1,
+                        output_tokens=1,
+                        cache_read_input_tokens=0,
+                        cache_creation_input_tokens=0,
+                    ),
+                    container=None,
+                    model=OPUS_48,
+                    id="msg_01test",
+                )
+
+            messages_ns = SimpleNamespace(create=AsyncMock(side_effect=_create))
+            return SimpleNamespace(messages=messages_ns)
+
+        return fake_client_ctor
+
+    @pytest.mark.asyncio
+    async def test_opus48_keeps_mid_system_in_payload(self):
+        captured: Dict[str, Any] = {}
+        with patch(
+            "defog.llm.providers.anthropic_provider.AsyncAnthropic",
+            side_effect=self._fake_client_factory(captured),
+        ):
+            await chat_async(
+                provider="anthropic",
+                model=OPUS_48,
+                messages=_leading_then_mid(),
+                max_retries=1,
+            )
+
+        request_params = captured["request_params"]
+        # Leading prompt hoisted; mid-conversation instruction is NOT.
+        assert request_params["system"] == "You are a code review assistant."
+        assert "type annotations" not in request_params["system"]
+        # Mid-conversation instruction is carried as an in-place system turn.
+        assert request_params["messages"][-1] == {
+            "role": "system",
+            "content": "From now on, require type annotations.",
+        }
+
+    @pytest.mark.asyncio
+    async def test_sonnet_hoists_everything_in_payload(self):
+        captured: Dict[str, Any] = {}
+        with patch(
+            "defog.llm.providers.anthropic_provider.AsyncAnthropic",
+            side_effect=self._fake_client_factory(captured),
+        ):
+            await chat_async(
+                provider="anthropic",
+                model=SONNET,
+                messages=_leading_then_mid(),
+                max_retries=1,
+            )
+
+        request_params = captured["request_params"]
+        assert "type annotations" in request_params["system"]
+        assert all(m["role"] != "system" for m in request_params["messages"])
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set; skipping live Anthropic API test",
+)
+class TestLiveMidConversationSystem:
+    """Live end-to-end test against the real Anthropic API (Opus 4.8).
+
+    Appends a mid-conversation system instruction that strongly determines the
+    model's output, then asserts the instruction was applied — proving the
+    in-place system turn carries system-level priority through the real API.
+    """
+
+    @pytest.mark.asyncio
+    async def test_mid_system_instruction_is_applied(self):
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+            {"role": "assistant", "content": "The capital of France is Paris."},
+            {"role": "user", "content": "And the capital of Japan?"},
+            {
+                "role": "system",
+                "content": (
+                    "From now on, end every reply with the exact token "
+                    "<<ACK>> on its own line."
+                ),
+            },
+        ]
+        response = await chat_async(
+            provider="anthropic",
+            model=OPUS_48,
+            messages=messages,
+            max_completion_tokens=256,
+            max_retries=2,
+        )
+        assert response.content is not None
+        # The mid-conversation system instruction must have been honoured.
+        assert "<<ACK>>" in response.content

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Anthropic recently shipped [mid-conversation system messages](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-8#mid-conversation-system-messages): a `{"role": "system"}` message can be appended partway through a conversation without invalidating the prompt-cache prefix that precedes it, while still carrying system-level priority from that point onward.

`chat_async`/`AnthropicProvider` previously **hoisted every system message** — regardless of position — into the top-level `system` field. That defeats the feature entirely:
- Editing the top-level `system` field invalidates the cache for the whole conversation that follows it (the exact cost the feature avoids).
- The positional semantics ("later system messages take precedence") collapse into a flat `\n\n` concatenation.

This PR makes the provider keep a mid-conversation system message **in place** as a system turn on **Claude Opus 4.8** — automatically, with **no new parameter or API surface**.

## Design: safe, transparent optimization

A system message is kept in place **only when its position is unambiguously legal** per Anthropic's placement rules; otherwise it falls back to the historical hoist behavior. This means **no previously valid request changes behavior or starts erroring** — it's a pure caching/semantics improvement when applicable.

- **Leading** system messages (before any user/assistant turn) → always hoisted into top-level `system`, as before.
- **Mid-conversation** system messages → kept in place only when they directly follow a `user` turn **and** are either the last message or directly precede an `assistant` turn. Any other position → hoisted (safe fallback).
- **Other models / providers** → unchanged; everything is hoisted exactly as before.
- **Consecutive** system messages are coalesced into one (Anthropic rejects adjacent `system` turns).
- **Pause/resume** round-trips correctly: the captured leading `system` is re-hoisted on resume, and in-place system turns are preserved.

## Baseline Opus 4.8 support (dependency)

The feature is Opus-4.8-only, but the repo didn't support Opus 4.8 at runtime (it knew about models only up to Opus 4.7) — a live call 400s with "`temperature` is deprecated for this model." Per Anthropic's [migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide), Opus 4.7/4.8 reject non-default sampling params, so they must use the adaptive-thinking path (`temperature=1.0`, the API default). This PR therefore also:
- Adds a `claude-opus-4-8` pricing entry (identical to Opus 4.7: \$5/\$25 per MTok, same cache rates — per Anthropic's pricing page).
- Wires Opus 4.8 into the adaptive-thinking / effort detection (adaptive always-on; supports `max` and `xhigh` effort).

`task_budget` remains gated to Opus 4.7 only; extending it to 4.8 is a separate follow-up.

## Testing

`tests/test_anthropic_mid_conversation_system.py`:
- Unit tests for `_merge_system_content` and `_coalesce_system_messages`.
- The hoist-vs-in-place decision: leading hoisted + mid kept; list content preserved; consecutive merged; followed-by-assistant kept; **illegal positions (followed-by-user, preceded-by-assistant) fall back to hoist with no error**; non-Opus-4.8 hoists everything.
- A mocked **end-to-end wiring** test (patches `AsyncAnthropic`) asserting the in-place system turn reaches the request payload while top-level `system` holds only the leading prompt.
- A **live end-to-end** test (skipped without `ANTHROPIC_API_KEY`) that appends a mid-conversation instruction and confirms the real Opus 4.8 API honors it.

```
17 passed  # incl. the live Opus 4.8 call
```

Existing Anthropic suites (task_budget, caching/pricing, server tools, pause/resume, hooks) all pass (82 tests).

## Docs

`docs/llm/core-chat-functions.md`: new "Mid-Conversation System Messages" section, plus a corrected `reasoning_effort` note (`max` on Opus 4.6/4.7/4.8; `xhigh` on Opus 4.7/4.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)