### PR TITLE
Fix DeepSeek pricing and bump version to 1.6.5

### DIFF
--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -221,13 +221,13 @@ MODEL_COSTS = {
         "cached_input_cost_per1k": 0.00015,
     },
     "deepseek-v4-pro": {
-        "input_cost_per1k": 0.00174,
-        "cached_input_cost_per1k": 0.000145,
-        "output_cost_per1k": 0.00348,
+        "input_cost_per1k": 0.000435,
+        "cached_input_cost_per1k": 0.000003625,
+        "output_cost_per1k": 0.00087,
     },
     "deepseek-v4-flash": {
         "input_cost_per1k": 0.00014,
-        "cached_input_cost_per1k": 0.000028,
+        "cached_input_cost_per1k": 0.0000028,
         "output_cost_per1k": 0.00028,
     },
     "glm-5.2": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.4"
+version = "1.6.5"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Corrects `deepseek-v4-pro` and `deepseek-v4-flash` token costs in `defog/llm/cost/models.py` to match the [official DeepSeek pricing page](https://api-docs.deepseek.com/quick_start/pricing).
- Bumps version `1.6.4` → `1.6.5`.

## Details
Per-1M prices from the official page, converted to per-1k (÷1000):

| Model | input (cache miss) | cache hit | output |
|---|---|---|---|
| deepseek-v4-flash | $0.14 → 0.00014 | $0.0028 → 0.0000028 | $0.28 → 0.00028 |
| deepseek-v4-pro | $0.435 → 0.000435 | $0.003625 → 0.000003625 | $0.87 → 0.00087 |

- `deepseek-v4-flash`: input/output were already correct; the cache-hit rate was 10× too high (`0.000028` → `0.0000028`).
- `deepseek-v4-pro`: was on stale standard pricing; all three rates updated to current page values.

## Testing
- `tests/test_deepseek.py::...::test_pricing_entries_resolve` passes.

Note: 1.6.5 has already been published to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)