### PR TITLE
Add GPT-5.6 model family support

### DIFF
--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -40,6 +40,27 @@ MODEL_COSTS = {
         "cached_input_cost_per1k": 0.000005,
         "output_cost_per1k": 0.0004,
     },
+    # gpt-5.6 is an alias for gpt-5.6-sol.
+    "gpt-5.6": {
+        "input_cost_per1k": 0.005,
+        "cached_input_cost_per1k": 0.0005,
+        "output_cost_per1k": 0.03,
+    },
+    "gpt-5.6-sol": {
+        "input_cost_per1k": 0.005,
+        "cached_input_cost_per1k": 0.0005,
+        "output_cost_per1k": 0.03,
+    },
+    "gpt-5.6-terra": {
+        "input_cost_per1k": 0.0025,
+        "cached_input_cost_per1k": 0.00025,
+        "output_cost_per1k": 0.015,
+    },
+    "gpt-5.6-luna": {
+        "input_cost_per1k": 0.001,
+        "cached_input_cost_per1k": 0.0001,
+        "output_cost_per1k": 0.006,
+    },
     "gpt-5.5": {
         "input_cost_per1k": 0.005,
         "cached_input_cost_per1k": 0.0005,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.6"
+version = "1.6.7"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -40,6 +40,19 @@ def test_gpt_5_5_entries_are_explicit():
     assert _find_match("gpt-5.5-pro-2026-04-23") == "gpt-5.5-pro"
 
 
+def test_gpt_5_6_entries_are_explicit():
+    # GPT-5.6 uses named tiers rather than the mini/nano/pro tier names.
+    assert "gpt-5.6" in MODEL_COSTS
+    assert "gpt-5.6-sol" in MODEL_COSTS
+    assert "gpt-5.6-terra" in MODEL_COSTS
+    assert "gpt-5.6-luna" in MODEL_COSTS
+    assert _find_match("gpt-5.6") == "gpt-5.6"
+    assert _find_match("gpt-5.6-sol") == "gpt-5.6-sol"
+    assert _find_match("gpt-5.6-terra") == "gpt-5.6-terra"
+    assert _find_match("gpt-5.6-luna") == "gpt-5.6-luna"
+    assert _find_match("gpt-5.6-terra-2026-07-09") == "gpt-5.6-terra"
+
+
 def test_unknown_mini_does_not_fall_back_to_base_pricing():
     # Regression: previously `gpt-5.4-mini` fell back to `gpt-5` (full) pricing
     # via loose substring match, inflating cost ~5x. With size-suffix parity,
@@ -91,11 +104,26 @@ def test_gpt_5_5_pricing_matches_openai_rate_card():
     assert _cost("gpt-5.5-pro") == pytest.approx(21.0)
 
 
+def test_gpt_5_6_pricing_matches_openai_rate_card():
+    # Per https://developers.openai.com/api/docs/pricing as of 2026-07-12.
+    # Sol (and its gpt-5.6 alias): $5 / $0.50 cached / $30 per 1M tokens.
+    assert _cost("gpt-5.6") == pytest.approx(3.5)
+    assert _cost("gpt-5.6-sol", cached=1000) == pytest.approx(3.55)
+    # Terra: $2.50 / $0.25 cached / $15 per 1M tokens.
+    assert _cost("gpt-5.6-terra", cached=1000) == pytest.approx(1.775)
+    # Luna: $1 / $0.10 cached / $6 per 1M tokens.
+    assert _cost("gpt-5.6-luna", cached=1000) == pytest.approx(0.71)
+
+
 def test_is_model_supported():
     assert CostCalculator.is_model_supported("gpt-5-mini") is True
     assert CostCalculator.is_model_supported("gpt-5.4-mini") is True
     assert CostCalculator.is_model_supported("gpt-5.5") is True
     assert CostCalculator.is_model_supported("gpt-5.5-pro") is True
+    assert CostCalculator.is_model_supported("gpt-5.6") is True
+    assert CostCalculator.is_model_supported("gpt-5.6-sol") is True
+    assert CostCalculator.is_model_supported("gpt-5.6-terra") is True
+    assert CostCalculator.is_model_supported("gpt-5.6-luna") is True
     assert CostCalculator.is_model_supported("gpt-5.9-mini") is True
     assert CostCalculator.is_model_supported("claude-sonnet-4-6") is True
     assert CostCalculator.is_model_supported("totally-made-up-xyz") is False

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -90,6 +90,7 @@ class TestChatClients(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(map_model_to_provider("gpt-4o-mini"), LLMProvider.OPENAI)
         self.assertEqual(map_model_to_provider("gpt-5.5"), LLMProvider.OPENAI)
+        self.assertEqual(map_model_to_provider("gpt-5.6-terra"), LLMProvider.OPENAI)
 
         with self.assertRaises(Exception):
             map_model_to_provider("unknown-model")

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.6.6"
+version = "1.6.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- add explicit support and pricing for `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`
- cover aliases, snapshots, cost calculations, and OpenAI provider routing
- bump the package version to 1.6.7

## Testing

- `PYTHONPATH=. uv run python -m pytest tests/test_cost_calculator.py tests/test_llm.py::TestChatClients::test_map_model_to_provider -q` (64 passed)
- `ruff format --check defog/llm/cost/models.py tests/test_cost_calculator.py tests/test_llm.py`
- `ruff check defog/llm/cost/models.py tests/test_cost_calculator.py`
- `git diff --check`
- `uv build`