### PR TITLE
Fix effort-none crash on Anthropic provider; refresh Claude pricing

### DIFF
--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -114,6 +114,21 @@ MODEL_COSTS = {
         "cached_input_cost_per1k": 0.000275,
         "output_cost_per1k": 0.0044,
     },
+    # Speech-to-text models (Transcription API). Input is billed as audio
+    # tokens; OpenAI's rule-of-thumb estimates are ~$0.006/min for
+    # gpt-4o-transcribe(-diarize) and ~$0.003/min for the mini tier.
+    "gpt-4o-transcribe": {
+        "input_cost_per1k": 0.0025,
+        "output_cost_per1k": 0.01,
+    },
+    "gpt-4o-mini-transcribe": {
+        "input_cost_per1k": 0.00125,
+        "output_cost_per1k": 0.005,
+    },
+    "gpt-4o-transcribe-diarize": {
+        "input_cost_per1k": 0.0025,
+        "output_cost_per1k": 0.01,
+    },
     "claude-fable-5": {
         "input_cost_per1k": 0.010,
         "cached_input_cost_per1k": 0.001,

--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -128,49 +128,64 @@ MODEL_COSTS = {
     },
     "claude-sonnet-4": {
         "input_cost_per1k": 0.003,
-        "cached_input_cost_per1k": 0.00075,
+        "cached_input_cost_per1k": 0.0003,
         "cache_creation_input_cost_per1k": 0.00375,
         "output_cost_per1k": 0.015,
     },
     "claude-sonnet-4-5": {
         "input_cost_per1k": 0.003,
-        "cached_input_cost_per1k": 0.00075,
+        "cached_input_cost_per1k": 0.0003,
         "cache_creation_input_cost_per1k": 0.00375,
         "output_cost_per1k": 0.015,
     },
     "claude-sonnet-4-6": {
         "input_cost_per1k": 0.003,
-        "cached_input_cost_per1k": 0.00075,
+        "cached_input_cost_per1k": 0.0003,
         "cache_creation_input_cost_per1k": 0.00375,
         "output_cost_per1k": 0.015,
     },
+    # Introductory pricing through 2026-08-31; becomes $3/$15 per MTok
+    # (cached $0.30/MTok, 5m cache write $3.75/MTok) on 2026-09-01.
+    "claude-sonnet-5": {
+        "input_cost_per1k": 0.002,
+        "cached_input_cost_per1k": 0.0002,
+        "cache_creation_input_cost_per1k": 0.0025,
+        "output_cost_per1k": 0.01,
+    },
     "claude-opus-4-1": {
         "input_cost_per1k": 0.015,
-        "cached_input_cost_per1k": 0.00375,
+        "cached_input_cost_per1k": 0.0015,
         "cache_creation_input_cost_per1k": 0.01875,
         "output_cost_per1k": 0.075,
     },
     "claude-opus-4-5": {
         "input_cost_per1k": 0.005,
-        "cached_input_cost_per1k": 0.00125,
+        "cached_input_cost_per1k": 0.0005,
         "cache_creation_input_cost_per1k": 0.00625,
         "output_cost_per1k": 0.025,
     },
     "claude-opus-4-6": {
         "input_cost_per1k": 0.005,
-        "cached_input_cost_per1k": 0.00125,
+        "cached_input_cost_per1k": 0.0005,
         "cache_creation_input_cost_per1k": 0.00625,
         "output_cost_per1k": 0.025,
     },
     "claude-opus-4-7": {
         "input_cost_per1k": 0.005,
-        "cached_input_cost_per1k": 0.00125,
+        "cached_input_cost_per1k": 0.0005,
         "cache_creation_input_cost_per1k": 0.00625,
         "output_cost_per1k": 0.025,
     },
     "claude-opus-4-8": {
         "input_cost_per1k": 0.005,
-        "cached_input_cost_per1k": 0.00125,
+        "cached_input_cost_per1k": 0.0005,
+        "cache_creation_input_cost_per1k": 0.00625,
+        "output_cost_per1k": 0.025,
+    },
+    # Launched 2026-07-24 at unchanged Opus-generation pricing.
+    "claude-opus-5": {
+        "input_cost_per1k": 0.005,
+        "cached_input_cost_per1k": 0.0005,
         "cache_creation_input_cost_per1k": 0.00625,
         "output_cost_per1k": 0.025,
     },

--- a/defog/llm/providers/anthropic_provider.py
+++ b/defog/llm/providers/anthropic_provider.py
@@ -578,29 +578,36 @@ class AnthropicProvider(BaseLLMProvider):
         # opus-4-1, opus-4-5, opus-4-6, haiku-4-5, etc.), "3-7" catches
         # Claude 3.7 Sonnet. Using "-4" instead of "-4-" so that
         # "claude-sonnet-4" (no date suffix) is also matched.
-        supports_thinking = "3-7" in model or "-4" in model
+        supports_thinking = "3-7" in model or "-4" in model or "-5" in model
         # Claude 4.6+ models use adaptive thinking (type: "adaptive") with
         # effort via output_config, replacing the deprecated budget_tokens
         # param. Update this tuple when new models add adaptive support.
         supports_adaptive = any(
             p in model
-            for p in ("opus-4-6", "opus-4-7", "opus-4-8", "sonnet-4-6", "fable")
+            for p in (
+                "opus-4-6",
+                "opus-4-7",
+                "opus-4-8",
+                "opus-5",
+                "sonnet-4-6",
+                "fable",
+            )
         )
         # effort: "max" is only available on Opus and Fable models. Sending it
         # to Sonnet returns an API error.
         supports_max_effort = any(
-            p in model for p in ("opus-4-6", "opus-4-7", "opus-4-8", "fable")
+            p in model for p in ("opus-4-6", "opus-4-7", "opus-4-8", "opus-5", "fable")
         )
         # effort: "xhigh" is only available on Opus 4.7, Opus 4.8, and Fable.
         # Sending it to any other model returns an API error.
         supports_xhigh_effort = any(
-            p in model for p in ("opus-4-7", "opus-4-8", "fable")
+            p in model for p in ("opus-4-7", "opus-4-8", "opus-5", "fable")
         )
         # Opus and Fable models require adaptive thinking always on. For other
         # adaptive models (e.g. Sonnet 4.6), only enable it when
         # reasoning_effort is explicitly requested.
         requires_adaptive = any(
-            p in model for p in ("opus-4-6", "opus-4-7", "opus-4-8", "fable")
+            p in model for p in ("opus-4-6", "opus-4-7", "opus-4-8", "opus-5", "fable")
         )
         use_adaptive = requires_adaptive or (
             supports_adaptive and reasoning_effort is not None
@@ -615,21 +622,32 @@ class AnthropicProvider(BaseLLMProvider):
             }
             temperature = 1.0
         elif reasoning_effort is not None and supports_thinking:
-            temperature = 1.0
             if reasoning_effort == "low":
+                temperature = 1.0
                 thinking = {
                     "type": "enabled",
                     "budget_tokens": 2048,
                 }
             elif reasoning_effort == "medium":
+                temperature = 1.0
                 thinking = {
                     "type": "enabled",
                     "budget_tokens": 4096,
                 }
             elif reasoning_effort in ("high", "max", "xhigh"):
+                temperature = 1.0
                 thinking = {
                     "type": "enabled",
                     "budget_tokens": 8192,
+                }
+            else:
+                # reasoning_effort == "none" (or an unrecognized level):
+                # previously fell through all branches and left `thinking`
+                # unbound, crashing any call that passed effort "none" to an
+                # Anthropic model (e.g. OpenAI-primary configs whose backup
+                # provider is Anthropic).
+                thinking = {
+                    "type": "disabled",
                 }
         else:
             thinking = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.7"
+version = "1.6.8"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Three things, found while wiring an OpenAI-primary / Anthropic-backup configuration:

**Bug:** passing `reasoning_effort="none"` to an Anthropic model crashed with `cannot access local variable 'thinking'` — the effort string enters the thinking-configuration branch (it is not `None`) but matches no case, leaving the variable unbound. Any `chat_async` call with an OpenAI primary and an Anthropic `backup_provider` hits this, because the effort string carries over to the backup. `"none"` now maps to thinking disabled.

**Pricing refresh** (all values from the official pricing pages):
- Add `claude-opus-5` (launched July 24, $5/$25 per MTok) to the cost table and the adaptive-thinking / effort-level capability checks; thinking detection now also matches Claude 5-generation model names.
- Add `claude-sonnet-5` at its introductory pricing, with a comment noting the September 1 change.
- Correct cache-read prices across the Claude 4.x family: the table carried 0.25× base input, the official rate is 0.1× (affects opus-4-1, opus-4-5 through 4-8, sonnet-4 through 4-6). Cost reports for cached Anthropic traffic were overstating cache-read spend 2.5×.

**Speech-to-text pricing:** add `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, and `gpt-4o-transcribe-diarize` so transcription pipelines can cost their calls through `CostCalculator` (input billed as audio tokens; per-minute estimates in the comment).

`ruff check`/`format` clean; `tests/test_anthropic_caching_pricing.py` passes; the effort-none path verified directly against `build_params`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)