### PR TITLE
Patch invalid structured-output fields instead of regenerating responses

### DIFF
--- a/defog/llm/providers/base.py
+++ b/defog/llm/providers/base.py
@@ -14,6 +14,10 @@ from ..memory.conversation_cache import (
     store_messages as store_cached_messages,
 )
 from ..tools import ToolHandler
+from ..structured_output_repair import (
+    deterministic_json_repair,
+    repair_structured_response,
+)
 import inspect
 
 
@@ -44,6 +48,7 @@ class LLMResponse:
     pending_tool_use: Optional[Dict[str, Any]] = None
     pause_payload: Optional[Any] = None
     messages: Optional[List[Dict[str, Any]]] = None
+    structured_output_repairs: Optional[Dict[str, Any]] = None
 
 
 class BaseLLMProvider(ABC):
@@ -204,6 +209,41 @@ class BaseLLMProvider(ABC):
             return response_format.model_validate(parsed)
 
         return parsed
+
+    _deterministic_json_repair = staticmethod(deterministic_json_repair)
+
+    async def _run_structured_repair_completion(
+        self, client: Any, request_params: Dict[str, Any]
+    ) -> Any:
+        """Run one OpenAI-compatible structured-output repair completion."""
+        return await client.chat.completions.create(**request_params)
+
+    async def _parse_with_repair(
+        self,
+        raw_content: str,
+        response_format: Any,
+        client: Any,
+        model: str,
+        request_params: Optional[Dict[str, Any]] = None,
+        extra_body: Optional[Dict[str, Any]] = None,
+        repair_metadata: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Shared schema-aware repair path for loose-JSON providers."""
+        request_options = {}
+        if extra_body:
+            request_options["extra_body"] = extra_body
+
+        return await repair_structured_response(
+            raw_content=raw_content,
+            response_format=response_format,
+            model=model,
+            create_completion=lambda params: self._run_structured_repair_completion(
+                client, params
+            ),
+            usage_calculator=self.calculate_token_usage,
+            metadata=repair_metadata,
+            request_options=request_options,
+        )
 
     def calculate_token_usage(
         self, response

--- a/defog/llm/providers/deepseek_provider.py
+++ b/defog/llm/providers/deepseek_provider.py
@@ -1,8 +1,6 @@
 from defog import config as defog_config
-import re
 import time
 import json
-import logging
 from copy import deepcopy
 from typing import Dict, List, Any, Optional, Callable, Tuple, Union
 
@@ -15,7 +13,6 @@ from ..utils_function_calling import get_function_specs, convert_tool_choice
 from ..image_utils import convert_to_openai_format
 from ..tools.handler import ToolHandler
 
-logger = logging.getLogger(__name__)
 
 DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
 
@@ -126,152 +123,6 @@ class DeepSeekProvider(BaseLLMProvider):
     # JSON repair helpers (json_object output is loose)
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _deterministic_json_repair(content: str) -> str:
-        """Apply deterministic fixes for common JSON issues from loose output.
-
-        Handles: markdown fences, Python literals (True/False/None),
-        JS constants (NaN/Infinity/undefined), trailing commas, comments,
-        single-quoted strings, and unbalanced brackets.
-        """
-        s = content.strip()
-
-        # Strip markdown code fences
-        if s.startswith("```"):
-            first_nl = s.find("\n")
-            s = s[first_nl + 1 :] if first_nl != -1 else s[3:]
-            if s.endswith("```"):
-                s = s[:-3]
-            s = s.strip()
-
-        # Remove single-line JS/Python comments (best effort)
-        s = re.sub(r"(?m)^\s*//[^\n]*$", "", s)
-        s = re.sub(r"//[^\n]*", "", s)
-        s = re.sub(r"/\*.*?\*/", "", s, flags=re.DOTALL)
-
-        # Replace Python/JS literals with JSON equivalents
-        s = re.sub(r"\bTrue\b", "true", s)
-        s = re.sub(r"\bFalse\b", "false", s)
-        s = re.sub(r"\bNone\b", "null", s)
-        s = re.sub(r"\bNaN\b", "null", s)
-        s = re.sub(r"\bundefined\b", "null", s)
-        s = re.sub(r"\bInfinity\b", "null", s)
-        s = re.sub(r"-\s*null\b", "null", s)  # fix -Infinity → -null → null
-
-        # Remove trailing commas before } or ]
-        s = re.sub(r",(\s*[}\]])", r"\1", s)
-
-        # Try single-quote → double-quote conversion if no double quotes present
-        # in the structural positions (keys/values). Best-effort heuristic.
-        if "'" in s and not re.search(r'(?<=[{\[,:])\s*"', s):
-            candidate = s.replace("'", '"')
-            try:
-                json.loads(candidate)
-                s = candidate
-            except json.JSONDecodeError:
-                pass  # didn't help, keep original
-
-        # Balance unclosed brackets using a character-level scan
-        open_braces = 0
-        open_brackets = 0
-        in_string = False
-        escape_next = False
-        for ch in s:
-            if escape_next:
-                escape_next = False
-                continue
-            if ch == "\\" and in_string:
-                escape_next = True
-                continue
-            if ch == '"':
-                in_string = not in_string
-                continue
-            if in_string:
-                continue
-            if ch == "{":
-                open_braces += 1
-            elif ch == "}":
-                open_braces -= 1
-            elif ch == "[":
-                open_brackets += 1
-            elif ch == "]":
-                open_brackets -= 1
-
-        # If we ended inside a string, close it
-        if in_string:
-            s += '"'
-
-        # If last non-whitespace is a colon, append null (truncated value)
-        stripped_tail = s.rstrip()
-        if stripped_tail and stripped_tail[-1] == ":":
-            s = stripped_tail + " null"
-        # If last non-whitespace is a comma, strip it
-        elif stripped_tail and stripped_tail[-1] == ",":
-            s = stripped_tail[:-1]
-
-        # Append missing closing brackets
-        if open_brackets > 0:
-            s += "]" * open_brackets
-        if open_braces > 0:
-            s += "}" * open_braces
-
-        # Final pass: remove any remaining trailing commas before closers
-        s = re.sub(r",(\s*[}\]])", r"\1", s)
-
-        return s
-
-    async def _llm_json_repair(
-        self,
-        broken_content: str,
-        response_format,
-        client,
-        model: str,
-        request_params: Dict[str, Any],
-    ) -> Any:
-        """Use a follow-on LLM call to fix broken JSON.
-
-        Appends the model's broken response as an assistant turn and adds a
-        user follow-up asking it to return valid JSON, preserving the full
-        conversation context.
-        """
-        schema = None
-        if hasattr(response_format, "model_json_schema"):
-            schema = response_format.model_json_schema()
-
-        schema_text = json.dumps(schema, indent=2) if schema else "Not available"
-
-        follow_up = (
-            "Your previous response was not valid JSON or did not match the "
-            "expected schema. Please return ONLY the corrected JSON — no "
-            "markdown fences, no explanations, no extra text.\n\n"
-            f"Expected JSON schema:\n{schema_text}"
-        )
-
-        logger.info("Attempting LLM-based JSON repair for model=%s", model)
-
-        messages = list(request_params.get("messages", []))
-        messages.append({"role": "assistant", "content": broken_content})
-        messages.append({"role": "user", "content": follow_up})
-
-        repair_params = {
-            "model": model,
-            "messages": messages,
-            "temperature": 0.0,
-            "max_tokens": 4096,
-        }
-        rf = self._build_response_format(response_format)
-        if rf:
-            repair_params["response_format"] = rf
-
-        response = await client.chat.completions.create(**repair_params)
-        if not hasattr(response, "choices") or not response.choices:
-            raise ProviderError(
-                self.get_provider_name(),
-                "No response from DeepSeek",
-            )
-        fixed_content = response.choices[0].message.content or ""
-        return self.parse_structured_response(fixed_content, response_format)
-
     async def _parse_with_repair(
         self,
         raw_content: str,
@@ -279,69 +130,16 @@ class DeepSeekProvider(BaseLLMProvider):
         client,
         model: str,
         request_params: Optional[Dict[str, Any]] = None,
+        repair_metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        """Parse structured response with deterministic repair and LLM fallback.
-
-        Sequence:
-        1. Try base parse_structured_response (markdown strip + json.loads + regex)
-        2. Apply deterministic fixes and re-parse
-        3. Make a follow-on LLM call to repair the JSON
-        4. Return original content if everything fails
-        """
-        if not response_format or not raw_content:
-            return raw_content
-
-        has_pydantic = hasattr(response_format, "model_validate")
-
-        def _is_parsed(result):
-            """True when the result is a parsed object, not raw text."""
-            if has_pydantic:
-                return not isinstance(result, str)
-            return isinstance(result, (dict, list))
-
-        # --- Step 1: standard parsing ---
-        try:
-            result = self.parse_structured_response(raw_content, response_format)
-            if _is_parsed(result):
-                return result
-        except Exception:
-            pass
-
-        # --- Step 2: deterministic repair ---
-        try:
-            repaired = self._deterministic_json_repair(raw_content)
-            result = self.parse_structured_response(repaired, response_format)
-            if _is_parsed(result):
-                logger.info("Deterministic JSON repair succeeded")
-                return result
-        except Exception:
-            pass
-
-        # --- Step 3: LLM-based repair ---
-        try:
-            result = await self._llm_json_repair(
-                raw_content,
-                response_format,
-                client,
-                model,
-                dict(request_params or {}),
-            )
-            if _is_parsed(result):
-                logger.info("LLM-based JSON repair succeeded")
-                return result
-        except Exception as e:
-            logger.warning("LLM-based JSON repair failed: %s", e)
-
-        # --- All repair attempts exhausted ---
-        logger.warning(
-            "All JSON repair attempts failed for structured output; "
-            "returning raw content"
+        return await super()._parse_with_repair(
+            raw_content,
+            response_format,
+            client,
+            model,
+            request_params,
+            repair_metadata=repair_metadata,
         )
-        return raw_content
-
-    # ------------------------------------------------------------------
-    # Request building
-    # ------------------------------------------------------------------
 
     def build_params(
         self,
@@ -439,6 +237,7 @@ class DeepSeekProvider(BaseLLMProvider):
         Optional[int],
         Optional[Dict[str, int]],
         str,
+        Optional[Dict[str, Any]],
     ]:
         """Process Chat Completions response, handling tool call chaining."""
         if tool_handler is None:
@@ -451,6 +250,7 @@ class DeepSeekProvider(BaseLLMProvider):
         total_input_tokens = 0
         total_cached_input_tokens = 0
         total_output_tokens = 0
+        repair_metadata: Dict[str, Any] = {}
         tool_calls_executed = False
 
         if tools:
@@ -664,6 +464,7 @@ class DeepSeekProvider(BaseLLMProvider):
                     client,
                     model,
                     final_params,
+                    repair_metadata=repair_metadata,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -684,6 +485,7 @@ class DeepSeekProvider(BaseLLMProvider):
                     client,
                     model,
                     request_params,
+                    repair_metadata=repair_metadata,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -698,6 +500,10 @@ class DeepSeekProvider(BaseLLMProvider):
             total_cached_input_tokens += cached_tokens
             total_output_tokens += output_tokens
 
+        total_input_tokens += repair_metadata.get("input_tokens", 0)
+        total_cached_input_tokens += repair_metadata.get("cached_input_tokens", 0)
+        total_output_tokens += repair_metadata.get("output_tokens", 0)
+
         return (
             content,
             tool_outputs,
@@ -706,6 +512,7 @@ class DeepSeekProvider(BaseLLMProvider):
             total_output_tokens,
             output_tokens_details,
             response.id or "",
+            repair_metadata or None,
         )
 
     # ------------------------------------------------------------------
@@ -807,6 +614,7 @@ class DeepSeekProvider(BaseLLMProvider):
                 output_tokens,
                 output_tokens_details,
                 response_id,
+                repair_metadata,
             ) = await self.process_response(
                 client=client,
                 response=response,
@@ -853,4 +661,5 @@ class DeepSeekProvider(BaseLLMProvider):
             cost_in_cents=cost,
             tool_outputs=tool_outputs,
             response_id=gen_response_id,
+            structured_output_repairs=repair_metadata,
         )

--- a/defog/llm/providers/openrouter_provider.py
+++ b/defog/llm/providers/openrouter_provider.py
@@ -1,8 +1,6 @@
 from defog import config as defog_config
-import re
 import time
 import json
-import logging
 from copy import deepcopy
 from typing import Dict, List, Any, Optional, Callable, Tuple, Union
 
@@ -15,7 +13,6 @@ from ..utils_function_calling import get_function_specs, convert_tool_choice
 from ..image_utils import convert_to_openai_format
 from ..tools.handler import ToolHandler
 
-logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
@@ -175,169 +172,6 @@ class OpenRouterProvider(BaseLLMProvider):
             "providers must be a list of strings or a provider routing dict"
         )
 
-    @staticmethod
-    def _deterministic_json_repair(content: str) -> str:
-        """Apply deterministic fixes for common JSON issues from open models.
-
-        Handles: markdown fences, Python literals (True/False/None),
-        JS constants (NaN/Infinity/undefined), trailing commas, comments,
-        single-quoted strings, and unbalanced brackets.
-        """
-        s = content.strip()
-
-        # Strip markdown code fences
-        if s.startswith("```"):
-            first_nl = s.find("\n")
-            s = s[first_nl + 1 :] if first_nl != -1 else s[3:]
-            if s.endswith("```"):
-                s = s[:-3]
-            s = s.strip()
-
-        # Remove single-line JS/Python comments (but not inside strings)
-        # Simplified: remove lines that start with // after optional whitespace
-        s = re.sub(r"(?m)^\s*//[^\n]*$", "", s)
-        # Remove trailing // comments after values (best effort — won't match
-        # comments inside strings, but covers the common case)
-        s = re.sub(r"//[^\n]*", "", s)
-        # Remove multi-line comments
-        s = re.sub(r"/\*.*?\*/", "", s, flags=re.DOTALL)
-
-        # Replace Python/JS literals with JSON equivalents
-        s = re.sub(r"\bTrue\b", "true", s)
-        s = re.sub(r"\bFalse\b", "false", s)
-        s = re.sub(r"\bNone\b", "null", s)
-        s = re.sub(r"\bNaN\b", "null", s)
-        s = re.sub(r"\bundefined\b", "null", s)
-        s = re.sub(r"\bInfinity\b", "null", s)
-        s = re.sub(r"-\s*null\b", "null", s)  # fix -Infinity → -null → null
-
-        # Remove trailing commas before } or ]
-        s = re.sub(r",(\s*[}\]])", r"\1", s)
-
-        # Try single-quote → double-quote conversion if no double quotes present
-        # in the structural positions (keys/values). This is a best-effort heuristic.
-        if "'" in s and not re.search(r'(?<=[{\[,:])\s*"', s):
-            # Likely single-quoted JSON — swap quotes
-            candidate = s.replace("'", '"')
-            try:
-                json.loads(candidate)
-                s = candidate
-            except json.JSONDecodeError:
-                pass  # didn't help, keep original
-
-        # Balance unclosed brackets using a proper character-level scan
-        open_braces = 0
-        open_brackets = 0
-        in_string = False
-        escape_next = False
-        for ch in s:
-            if escape_next:
-                escape_next = False
-                continue
-            if ch == "\\" and in_string:
-                escape_next = True
-                continue
-            if ch == '"':
-                in_string = not in_string
-                continue
-            if in_string:
-                continue
-            if ch == "{":
-                open_braces += 1
-            elif ch == "}":
-                open_braces -= 1
-            elif ch == "[":
-                open_brackets += 1
-            elif ch == "]":
-                open_brackets -= 1
-
-        # If we ended inside a string, close it
-        if in_string:
-            s += '"'
-
-        # If last non-whitespace is a colon, append null (truncated value)
-        stripped_tail = s.rstrip()
-        if stripped_tail and stripped_tail[-1] == ":":
-            s = stripped_tail + " null"
-        # If last non-whitespace is a comma, just strip it
-        # (a trailing comma before the closing bracket we're about to add)
-        elif stripped_tail and stripped_tail[-1] == ",":
-            s = stripped_tail[:-1]
-
-        # Append missing closing brackets
-        if open_brackets > 0:
-            s += "]" * open_brackets
-        if open_braces > 0:
-            s += "}" * open_braces
-
-        # Final pass: remove any remaining trailing commas before closers
-        # (can appear after bracket-balancing adds closers)
-        s = re.sub(r",(\s*[}\]])", r"\1", s)
-
-        return s
-
-    async def _llm_json_repair(
-        self,
-        broken_content: str,
-        response_format,
-        client,
-        model: str,
-        request_params: Dict[str, Any],
-    ) -> Any:
-        """Use a follow-on LLM call to fix broken JSON.
-
-        Appends the model's broken response as an assistant turn and adds a
-        user follow-up asking it to return valid JSON. This keeps the full
-        conversation context so the model understands what was originally
-        asked for.
-        """
-        schema = None
-        if hasattr(response_format, "model_json_schema"):
-            schema = response_format.model_json_schema()
-
-        schema_text = json.dumps(schema, indent=2) if schema else "Not available"
-
-        follow_up = (
-            "Your previous response was not valid JSON or did not match the "
-            "expected schema. Please return ONLY the corrected JSON — no "
-            "markdown fences, no explanations, no extra text.\n\n"
-            f"Expected JSON schema:\n{schema_text}"
-        )
-
-        logger.info(
-            "Attempting LLM-based JSON repair for model=%s",
-            model,
-        )
-
-        # Build the follow-up conversation: original messages + broken assistant
-        # turn + user correction request
-        messages = list(request_params.get("messages", []))
-        messages.append({"role": "assistant", "content": broken_content})
-        messages.append({"role": "user", "content": follow_up})
-
-        repair_params = {
-            "model": model,
-            "messages": messages,
-            "temperature": 0.0,
-            "max_tokens": 4096,
-        }
-        extra_body = request_params.get("extra_body")
-        if extra_body:
-            repair_params["extra_body"] = extra_body
-        # Ask for structured output if we can build a response_format
-        rf = self._build_response_format(response_format)
-        if rf:
-            repair_params["response_format"] = rf
-
-        response = await client.chat.completions.create(**repair_params)
-        if not hasattr(response, "choices") or not response.choices:
-            raise ProviderError(
-                self.get_provider_name(),
-                "No response from OpenRouter",
-            )
-        fixed_content = response.choices[0].message.content or ""
-        return self.parse_structured_response(fixed_content, response_format)
-
     async def _parse_with_repair(
         self,
         raw_content: str,
@@ -346,69 +180,17 @@ class OpenRouterProvider(BaseLLMProvider):
         model: str,
         request_params: Optional[Dict[str, Any]] = None,
         extra_body: Optional[Dict[str, Any]] = None,
+        repair_metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        """Parse structured response with deterministic repair and LLM fallback.
-
-        Sequence:
-        1. Try base parse_structured_response (markdown strip + json.loads + regex)
-        2. Apply deterministic fixes and re-parse
-        3. Make a follow-on LLM call to repair the JSON
-        4. Return original content if everything fails
-        """
-        if not response_format or not raw_content:
-            return raw_content
-
-        has_pydantic = hasattr(response_format, "model_validate")
-
-        def _is_parsed(result):
-            """True when the result is a successfully parsed object, not raw text."""
-            if has_pydantic:
-                return not isinstance(result, str)
-            # Without Pydantic, a parsed dict/list is success
-            return isinstance(result, (dict, list))
-
-        # --- Step 1: standard parsing ---
-        try:
-            result = self.parse_structured_response(raw_content, response_format)
-            if _is_parsed(result):
-                return result
-        except Exception:
-            pass
-
-        # --- Step 2: deterministic repair ---
-        try:
-            repaired = self._deterministic_json_repair(raw_content)
-            result = self.parse_structured_response(repaired, response_format)
-            if _is_parsed(result):
-                logger.info("Deterministic JSON repair succeeded")
-                return result
-        except Exception:
-            pass
-
-        # --- Step 3: LLM-based repair ---
-        try:
-            request_params_for_repair = dict(request_params or {})
-            if extra_body:
-                request_params_for_repair["extra_body"] = extra_body
-            result = await self._llm_json_repair(
-                raw_content,
-                response_format,
-                client,
-                model,
-                request_params_for_repair,
-            )
-            if _is_parsed(result):
-                logger.info("LLM-based JSON repair succeeded")
-                return result
-        except Exception as e:
-            logger.warning("LLM-based JSON repair failed: %s", e)
-
-        # --- All repair attempts exhausted ---
-        logger.warning(
-            "All JSON repair attempts failed for structured output; "
-            "returning raw content"
+        return await super()._parse_with_repair(
+            raw_content,
+            response_format,
+            client,
+            model,
+            request_params,
+            extra_body=extra_body,
+            repair_metadata=repair_metadata,
         )
-        return raw_content
 
     def build_params(
         self,
@@ -506,6 +288,8 @@ class OpenRouterProvider(BaseLLMProvider):
         Optional[int],
         Optional[Dict[str, int]],
         str,
+        Optional[float],
+        Optional[Dict[str, Any]],
     ]:
         """Process Chat Completions response, handling tool call chaining."""
         if tool_handler is None:
@@ -518,6 +302,7 @@ class OpenRouterProvider(BaseLLMProvider):
         total_input_tokens = 0
         total_cached_input_tokens = 0
         total_output_tokens = 0
+        repair_metadata: Dict[str, Any] = {}
         total_openrouter_cost = None
         tool_calls_executed = False
 
@@ -747,6 +532,7 @@ class OpenRouterProvider(BaseLLMProvider):
                     model,
                     request_params,
                     extra_body=extra_body,
+                    repair_metadata=repair_metadata,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -768,6 +554,7 @@ class OpenRouterProvider(BaseLLMProvider):
                     model,
                     request_params,
                     extra_body=extra_body,
+                    repair_metadata=repair_metadata,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -785,6 +572,10 @@ class OpenRouterProvider(BaseLLMProvider):
             if _cost is not None:
                 total_openrouter_cost = (total_openrouter_cost or 0) + _cost
 
+        total_input_tokens += repair_metadata.get("input_tokens", 0)
+        total_cached_input_tokens += repair_metadata.get("cached_input_tokens", 0)
+        total_output_tokens += repair_metadata.get("output_tokens", 0)
+
         return (
             content,
             tool_outputs,
@@ -794,6 +585,7 @@ class OpenRouterProvider(BaseLLMProvider):
             output_tokens_details,
             response.id or "",
             total_openrouter_cost,
+            repair_metadata or None,
         )
 
     async def execute_chat(
@@ -904,6 +696,7 @@ class OpenRouterProvider(BaseLLMProvider):
                 output_tokens_details,
                 response_id,
                 openrouter_cost,
+                repair_metadata,
             ) = await self.process_response(
                 client=client,
                 response=response,
@@ -939,6 +732,8 @@ class OpenRouterProvider(BaseLLMProvider):
         # Use OpenRouter-reported cost if available, fall back to local price table
         if openrouter_cost is not None:
             cost = round(openrouter_cost * 100, 6)  # Convert USD to cents
+            if repair_metadata and repair_metadata.get("cost_in_cents") is not None:
+                cost += repair_metadata["cost_in_cents"]
         else:
             cost = CostCalculator.calculate_cost(
                 model, input_tokens, output_tokens, cached_input_tokens
@@ -955,4 +750,5 @@ class OpenRouterProvider(BaseLLMProvider):
             cost_in_cents=cost,
             tool_outputs=tool_outputs,
             response_id=gen_response_id,
+            structured_output_repairs=repair_metadata,
         )

--- a/defog/llm/providers/zai_provider.py
+++ b/defog/llm/providers/zai_provider.py
@@ -1,8 +1,6 @@
 from defog import config as defog_config
-import re
 import time
 import json
-import logging
 from types import SimpleNamespace
 from copy import deepcopy
 from typing import Dict, List, Any, Optional, Callable, Tuple, Union
@@ -18,7 +16,6 @@ from ..utils_function_calling import get_function_specs, convert_tool_choice
 from ..image_utils import convert_to_openai_format
 from ..tools.handler import ToolHandler
 
-logger = logging.getLogger(__name__)
 
 ZAI_BASE_URL = "https://api.z.ai/api/paas/v4"
 
@@ -44,7 +41,9 @@ def _normalize_completion_response(data: Dict[str, Any]) -> Dict[str, Any]:
     usage = data["usage"] or {}
     usage.setdefault("prompt_tokens", 0)
     usage.setdefault("completion_tokens", 0)
-    usage.setdefault("total_tokens", usage["prompt_tokens"] + usage["completion_tokens"])
+    usage.setdefault(
+        "total_tokens", usage["prompt_tokens"] + usage["completion_tokens"]
+    )
     data["usage"] = usage
 
     for choice in data.get("choices") or []:
@@ -185,152 +184,6 @@ class ZAIProvider(BaseLLMProvider):
     # JSON repair helpers (json_object output is loose)
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _deterministic_json_repair(content: str) -> str:
-        """Apply deterministic fixes for common JSON issues from loose output.
-
-        Handles: markdown fences, Python literals (True/False/None),
-        JS constants (NaN/Infinity/undefined), trailing commas, comments,
-        single-quoted strings, and unbalanced brackets.
-        """
-        s = content.strip()
-
-        # Strip markdown code fences
-        if s.startswith("```"):
-            first_nl = s.find("\n")
-            s = s[first_nl + 1 :] if first_nl != -1 else s[3:]
-            if s.endswith("```"):
-                s = s[:-3]
-            s = s.strip()
-
-        # Remove single-line JS/Python comments (best effort)
-        s = re.sub(r"(?m)^\s*//[^\n]*$", "", s)
-        s = re.sub(r"//[^\n]*", "", s)
-        s = re.sub(r"/\*.*?\*/", "", s, flags=re.DOTALL)
-
-        # Replace Python/JS literals with JSON equivalents
-        s = re.sub(r"\bTrue\b", "true", s)
-        s = re.sub(r"\bFalse\b", "false", s)
-        s = re.sub(r"\bNone\b", "null", s)
-        s = re.sub(r"\bNaN\b", "null", s)
-        s = re.sub(r"\bundefined\b", "null", s)
-        s = re.sub(r"\bInfinity\b", "null", s)
-        s = re.sub(r"-\s*null\b", "null", s)  # fix -Infinity → -null → null
-
-        # Remove trailing commas before } or ]
-        s = re.sub(r",(\s*[}\]])", r"\1", s)
-
-        # Try single-quote → double-quote conversion if no double quotes present
-        # in the structural positions (keys/values). Best-effort heuristic.
-        if "'" in s and not re.search(r'(?<=[{\[,:])\s*"', s):
-            candidate = s.replace("'", '"')
-            try:
-                json.loads(candidate)
-                s = candidate
-            except json.JSONDecodeError:
-                pass  # didn't help, keep original
-
-        # Balance unclosed brackets using a character-level scan
-        open_braces = 0
-        open_brackets = 0
-        in_string = False
-        escape_next = False
-        for ch in s:
-            if escape_next:
-                escape_next = False
-                continue
-            if ch == "\\" and in_string:
-                escape_next = True
-                continue
-            if ch == '"':
-                in_string = not in_string
-                continue
-            if in_string:
-                continue
-            if ch == "{":
-                open_braces += 1
-            elif ch == "}":
-                open_braces -= 1
-            elif ch == "[":
-                open_brackets += 1
-            elif ch == "]":
-                open_brackets -= 1
-
-        # If we ended inside a string, close it
-        if in_string:
-            s += '"'
-
-        # If last non-whitespace is a colon, append null (truncated value)
-        stripped_tail = s.rstrip()
-        if stripped_tail and stripped_tail[-1] == ":":
-            s = stripped_tail + " null"
-        # If last non-whitespace is a comma, strip it
-        elif stripped_tail and stripped_tail[-1] == ",":
-            s = stripped_tail[:-1]
-
-        # Append missing closing brackets
-        if open_brackets > 0:
-            s += "]" * open_brackets
-        if open_braces > 0:
-            s += "}" * open_braces
-
-        # Final pass: remove any remaining trailing commas before closers
-        s = re.sub(r",(\s*[}\]])", r"\1", s)
-
-        return s
-
-    async def _llm_json_repair(
-        self,
-        broken_content: str,
-        response_format,
-        client,
-        model: str,
-        request_params: Dict[str, Any],
-    ) -> Any:
-        """Use a follow-on LLM call to fix broken JSON.
-
-        Appends the model's broken response as an assistant turn and adds a
-        user follow-up asking it to return valid JSON, preserving the full
-        conversation context.
-        """
-        schema = None
-        if hasattr(response_format, "model_json_schema"):
-            schema = response_format.model_json_schema()
-
-        schema_text = json.dumps(schema, indent=2) if schema else "Not available"
-
-        follow_up = (
-            "Your previous response was not valid JSON or did not match the "
-            "expected schema. Please return ONLY the corrected JSON — no "
-            "markdown fences, no explanations, no extra text.\n\n"
-            f"Expected JSON schema:\n{schema_text}"
-        )
-
-        logger.info("Attempting LLM-based JSON repair for model=%s", model)
-
-        messages = list(request_params.get("messages", []))
-        messages.append({"role": "assistant", "content": broken_content})
-        messages.append({"role": "user", "content": follow_up})
-
-        repair_params = {
-            "model": model,
-            "messages": messages,
-            "temperature": 0.0,
-            "max_tokens": 4096,
-        }
-        rf = self._build_response_format(response_format)
-        if rf:
-            repair_params["response_format"] = rf
-
-        response = await self._create_completion(client, repair_params)
-        if not hasattr(response, "choices") or not response.choices:
-            raise ProviderError(
-                self.get_provider_name(),
-                "No response from ZAI",
-            )
-        fixed_content = response.choices[0].message.content or ""
-        return self.parse_structured_response(fixed_content, response_format)
-
     async def _parse_with_repair(
         self,
         raw_content: str,
@@ -338,69 +191,16 @@ class ZAIProvider(BaseLLMProvider):
         client,
         model: str,
         request_params: Optional[Dict[str, Any]] = None,
+        repair_metadata: Optional[Dict[str, Any]] = None,
     ) -> Any:
-        """Parse structured response with deterministic repair and LLM fallback.
-
-        Sequence:
-        1. Try base parse_structured_response (markdown strip + json.loads + regex)
-        2. Apply deterministic fixes and re-parse
-        3. Make a follow-on LLM call to repair the JSON
-        4. Return original content if everything fails
-        """
-        if not response_format or not raw_content:
-            return raw_content
-
-        has_pydantic = hasattr(response_format, "model_validate")
-
-        def _is_parsed(result):
-            """True when the result is a parsed object, not raw text."""
-            if has_pydantic:
-                return not isinstance(result, str)
-            return isinstance(result, (dict, list))
-
-        # --- Step 1: standard parsing ---
-        try:
-            result = self.parse_structured_response(raw_content, response_format)
-            if _is_parsed(result):
-                return result
-        except Exception:
-            pass
-
-        # --- Step 2: deterministic repair ---
-        try:
-            repaired = self._deterministic_json_repair(raw_content)
-            result = self.parse_structured_response(repaired, response_format)
-            if _is_parsed(result):
-                logger.info("Deterministic JSON repair succeeded")
-                return result
-        except Exception:
-            pass
-
-        # --- Step 3: LLM-based repair ---
-        try:
-            result = await self._llm_json_repair(
-                raw_content,
-                response_format,
-                client,
-                model,
-                dict(request_params or {}),
-            )
-            if _is_parsed(result):
-                logger.info("LLM-based JSON repair succeeded")
-                return result
-        except Exception as e:
-            logger.warning("LLM-based JSON repair failed: %s", e)
-
-        # --- All repair attempts exhausted ---
-        logger.warning(
-            "All JSON repair attempts failed for structured output; "
-            "returning raw content"
+        return await super()._parse_with_repair(
+            raw_content,
+            response_format,
+            client,
+            model,
+            request_params,
+            repair_metadata=repair_metadata,
         )
-        return raw_content
-
-    # ------------------------------------------------------------------
-    # Request building
-    # ------------------------------------------------------------------
 
     def build_params(
         self,
@@ -501,6 +301,7 @@ class ZAIProvider(BaseLLMProvider):
         Optional[int],
         Optional[Dict[str, int]],
         str,
+        Optional[Dict[str, Any]],
     ]:
         """Process Chat Completions response, handling tool call chaining."""
         if tool_handler is None:
@@ -513,6 +314,7 @@ class ZAIProvider(BaseLLMProvider):
         total_input_tokens = 0
         total_cached_input_tokens = 0
         total_output_tokens = 0
+        repair_metadata: Dict[str, Any] = {}
         tool_calls_executed = False
 
         if tools:
@@ -726,6 +528,7 @@ class ZAIProvider(BaseLLMProvider):
                     client,
                     model,
                     final_params,
+                    repair_metadata=repair_metadata,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -746,6 +549,7 @@ class ZAIProvider(BaseLLMProvider):
                     client,
                     model,
                     request_params,
+                    repair_metadata=repair_metadata,
                 )
             else:
                 content = response.choices[0].message.content or ""
@@ -760,6 +564,10 @@ class ZAIProvider(BaseLLMProvider):
             total_cached_input_tokens += cached_tokens
             total_output_tokens += output_tokens
 
+        total_input_tokens += repair_metadata.get("input_tokens", 0)
+        total_cached_input_tokens += repair_metadata.get("cached_input_tokens", 0)
+        total_output_tokens += repair_metadata.get("output_tokens", 0)
+
         return (
             content,
             tool_outputs,
@@ -768,6 +576,7 @@ class ZAIProvider(BaseLLMProvider):
             total_output_tokens,
             output_tokens_details,
             response.id or "",
+            repair_metadata or None,
         )
 
     # ------------------------------------------------------------------
@@ -866,6 +675,7 @@ class ZAIProvider(BaseLLMProvider):
                 output_tokens,
                 output_tokens_details,
                 response_id,
+                repair_metadata,
             ) = await self.process_response(
                 client=client,
                 response=response,
@@ -915,4 +725,5 @@ class ZAIProvider(BaseLLMProvider):
             cost_in_cents=cost,
             tool_outputs=tool_outputs,
             response_id=gen_response_id,
+            structured_output_repairs=repair_metadata,
         )

--- a/defog/llm/structured_output_repair.py
+++ b/defog/llm/structured_output_repair.py
@@ -1,0 +1,513 @@
+"""Schema-aware repair for providers with loose JSON structured output.
+
+The pipeline separates syntax recovery, deterministic schema fixes, field-level
+model patches, and full-object fallback. Repair calls never receive the source
+conversation.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import re
+from typing import Any, Awaitable, Callable, Dict, Iterable, Optional, Sequence
+
+from pydantic import ValidationError
+
+from .cost import CostCalculator
+
+
+CompletionCall = Callable[[Dict[str, Any]], Awaitable[Any]]
+UsageCalculator = Callable[[Any], tuple[int, int, Optional[int], Any]]
+
+
+def deterministic_json_repair(content: str) -> str:
+    """Apply conservative syntax fixes to common loose-JSON output."""
+    value = content.strip()
+    if value.startswith("```"):
+        first_newline = value.find("\n")
+        value = value[first_newline + 1 :] if first_newline != -1 else value[3:]
+        if value.endswith("```"):
+            value = value[:-3]
+        value = value.strip()
+
+    value = re.sub(r"(?m)^\s*//[^\n]*$", "", value)
+    value = re.sub(r"//[^\n]*", "", value)
+    value = re.sub(r"/\*.*?\*/", "", value, flags=re.DOTALL)
+    for source, replacement in {
+        "True": "true",
+        "False": "false",
+        "None": "null",
+        "NaN": "null",
+        "undefined": "null",
+        "Infinity": "null",
+    }.items():
+        value = re.sub(rf"\b{source}\b", replacement, value)
+    value = re.sub(r"-\s*null\b", "null", value)
+    value = re.sub(r",(\s*[}\]])", r"\1", value)
+
+    if "'" in value and not re.search(r'(?<=[{\[,:])\s*"', value):
+        candidate = value.replace("'", '"')
+        try:
+            json.loads(candidate)
+            value = candidate
+        except json.JSONDecodeError:
+            pass
+
+    open_braces = open_brackets = 0
+    in_string = escape_next = False
+    for character in value:
+        if escape_next:
+            escape_next = False
+            continue
+        if character == "\\" and in_string:
+            escape_next = True
+            continue
+        if character == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if character == "{":
+            open_braces += 1
+        elif character == "}":
+            open_braces -= 1
+        elif character == "[":
+            open_brackets += 1
+        elif character == "]":
+            open_brackets -= 1
+
+    if in_string:
+        value += '"'
+    tail = value.rstrip()
+    if tail.endswith(":"):
+        value = tail + " null"
+    elif tail.endswith(","):
+        value = tail[:-1]
+    if open_brackets > 0:
+        value += "]" * open_brackets
+    if open_braces > 0:
+        value += "}" * open_braces
+    return re.sub(r",(\s*[}\]])", r"\1", value)
+
+
+def _json_candidates(content: str) -> Iterable[str]:
+    stripped = content.strip()
+    yield stripped
+    repaired = deterministic_json_repair(stripped)
+    if repaired != stripped:
+        yield repaired
+
+    decoder = json.JSONDecoder()
+    for index, character in enumerate(repaired):
+        if character not in "[{":
+            continue
+        try:
+            _, end = decoder.raw_decode(repaired[index:])
+        except json.JSONDecodeError:
+            continue
+        yield repaired[index : index + end]
+        break
+
+
+def _recover_json(content: str) -> tuple[Optional[Any], bool]:
+    original = content.strip()
+    seen = set()
+    for candidate in _json_candidates(content):
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            return json.loads(candidate), candidate != original
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return None, False
+
+
+def _json_pointer(location: Sequence[Any]) -> str:
+    escaped = (str(part).replace("~", "~0").replace("/", "~1") for part in location)
+    return "/" + "/".join(escaped)
+
+
+def _get_at_path(value: Any, location: Sequence[Any]) -> Any:
+    current = value
+    for part in location:
+        current = current[part]
+    return current
+
+
+def _set_at_path(value: Any, location: Sequence[Any], replacement: Any) -> bool:
+    if not location:
+        return False
+    try:
+        parent = _get_at_path(value, location[:-1])
+        part = location[-1]
+        if isinstance(parent, dict):
+            parent[part] = replacement
+        elif (
+            isinstance(parent, list)
+            and isinstance(part, int)
+            and 0 <= part < len(parent)
+        ):
+            parent[part] = replacement
+        else:
+            return False
+    except (KeyError, IndexError, TypeError):
+        return False
+    return True
+
+
+def _delete_at_path(value: Any, location: Sequence[Any]) -> bool:
+    if not location:
+        return False
+    try:
+        parent = _get_at_path(value, location[:-1])
+        part = location[-1]
+        if isinstance(parent, dict) and part in parent:
+            del parent[part]
+            return True
+        if (
+            isinstance(parent, list)
+            and isinstance(part, int)
+            and 0 <= part < len(parent)
+        ):
+            del parent[part]
+            return True
+    except (KeyError, IndexError, TypeError):
+        pass
+    return False
+
+
+def _validation_errors(error: ValidationError) -> list[Dict[str, Any]]:
+    return error.errors(include_url=False, include_context=False, include_input=True)
+
+
+def _apply_deterministic_schema_repairs(
+    candidate: Any, errors: Sequence[Dict[str, Any]]
+) -> int:
+    repaired = 0
+    for error in errors:
+        location = tuple(error.get("loc", ()))
+        if (
+            error.get("type") == "string_type"
+            and error.get("input") is None
+            and _set_at_path(candidate, location, "")
+        ):
+            repaired += 1
+        elif error.get("type") == "extra_forbidden" and _delete_at_path(
+            candidate, location
+        ):
+            repaired += 1
+    return repaired
+
+
+def _resolve_ref(schema: Any, root_schema: Dict[str, Any]) -> Any:
+    seen = set()
+    while isinstance(schema, dict) and "$ref" in schema:
+        reference = schema["$ref"]
+        if reference in seen or not reference.startswith("#/"):
+            break
+        seen.add(reference)
+        current: Any = root_schema
+        try:
+            for part in reference[2:].split("/"):
+                current = current[part.replace("~1", "/").replace("~0", "~")]
+        except (KeyError, TypeError):
+            break
+        schema = current
+    return schema
+
+
+def _schema_for_location(
+    root_schema: Dict[str, Any], location: Sequence[Any]
+) -> Dict[str, Any]:
+    current: Any = root_schema
+    for part in location:
+        current = _resolve_ref(current, root_schema)
+        if not isinstance(current, dict):
+            return {}
+        variants = current.get("anyOf") or current.get("oneOf")
+        if variants:
+            useful = [
+                _resolve_ref(option, root_schema)
+                for option in variants
+                if isinstance(option, dict) and option.get("type") != "null"
+            ]
+            if useful:
+                current = useful[0]
+        if isinstance(part, int):
+            current = current.get("items", {})
+        else:
+            properties = current.get("properties", {})
+            if part not in properties:
+                return {
+                    "additionalProperties": current.get("additionalProperties", True)
+                }
+            current = properties[part]
+    resolved = _resolve_ref(current, root_schema)
+    return copy.deepcopy(resolved) if isinstance(resolved, dict) else {}
+
+
+def _small_parent_context(candidate: Any, location: Sequence[Any]) -> Dict[str, Any]:
+    parent_location = tuple(location[:-1])
+    try:
+        parent = _get_at_path(candidate, parent_location)
+    except (KeyError, IndexError, TypeError):
+        parent = None
+    serialized = json.dumps(parent, ensure_ascii=False, default=str)
+    if len(serialized) > 6000 and location:
+        try:
+            current_value = _get_at_path(candidate, location)
+        except (KeyError, IndexError, TypeError):
+            current_value = None
+        parent = {str(location[-1]): current_value}
+    return {
+        "parent_path": _json_pointer(parent_location) if parent_location else "",
+        "value": parent,
+    }
+
+
+def _base_metadata(strategy: str, syntax_repaired: bool) -> Dict[str, Any]:
+    return {
+        "strategy": strategy,
+        "attempts": 0,
+        "deterministic_fields": 0,
+        "model_patched_fields": 0,
+        "input_tokens": 0,
+        "cached_input_tokens": 0,
+        "output_tokens": 0,
+        "cost_in_cents": 0.0,
+        "syntax_repaired": syntax_repaired,
+        "success": False,
+    }
+
+
+def _record_usage(
+    metadata: Dict[str, Any],
+    response: Any,
+    model: str,
+    usage_calculator: UsageCalculator,
+) -> None:
+    input_tokens, output_tokens, cached_tokens, _ = usage_calculator(response)
+    cached_tokens = cached_tokens or 0
+    metadata["input_tokens"] += input_tokens
+    metadata["output_tokens"] += output_tokens
+    metadata["cached_input_tokens"] += cached_tokens
+
+    usage = getattr(response, "usage", None)
+    reported_cost = getattr(usage, "cost", None) if usage else None
+    if reported_cost is not None:
+        repair_cost = reported_cost * 100
+        metadata["cost_source"] = "provider"
+    else:
+        repair_cost = CostCalculator.calculate_cost(
+            model, input_tokens, output_tokens, cached_tokens
+        )
+        if repair_cost is not None:
+            metadata.setdefault("cost_source", "local")
+    if repair_cost is None:
+        metadata["cost_in_cents"] = None
+    elif metadata["cost_in_cents"] is not None:
+        metadata["cost_in_cents"] += repair_cost
+
+
+def _completion_content(response: Any) -> str:
+    choices = getattr(response, "choices", None)
+    if not choices:
+        raise ValueError("repair call returned no choices")
+    return getattr(choices[0].message, "content", None) or ""
+
+
+def _repair_request(
+    *,
+    model: str,
+    payload: Dict[str, Any],
+    system_message: str,
+    max_tokens: int,
+    request_options: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": system_message},
+            {
+                "role": "user",
+                "content": json.dumps(payload, ensure_ascii=False, default=str),
+            },
+        ],
+        "temperature": 0.0,
+        "max_tokens": max_tokens,
+        "response_format": {"type": "json_object"},
+    }
+    if request_options:
+        params.update(request_options)
+    return params
+
+
+async def repair_structured_response(
+    *,
+    raw_content: str,
+    response_format: Any,
+    model: str,
+    create_completion: CompletionCall,
+    usage_calculator: UsageCalculator,
+    metadata: Optional[Dict[str, Any]] = None,
+    request_options: Optional[Dict[str, Any]] = None,
+) -> Any:
+    """Parse and repair a structured response with at most one model call."""
+    if not response_format or not raw_content:
+        return raw_content
+
+    parsed, syntax_repaired = _recover_json(raw_content)
+    has_pydantic = hasattr(response_format, "model_validate")
+    if parsed is None:
+        repair_metadata = _base_metadata("full_object", False)
+        repair_metadata["attempts"] = 1
+        schema = (
+            response_format.model_json_schema()
+            if hasattr(response_format, "model_json_schema")
+            else {}
+        )
+        params = _repair_request(
+            model=model,
+            payload={"broken_output": raw_content, "expected_schema": schema},
+            system_message=(
+                "Repair the broken output into one valid JSON object matching the "
+                "provided schema. Return JSON only. The source conversation is "
+                "intentionally unavailable; do not invent missing source facts."
+            ),
+            max_tokens=min(16384, max(1024, len(raw_content.encode()) // 3 + 512)),
+            request_options=request_options,
+        )
+        try:
+            response = await create_completion(params)
+            _record_usage(repair_metadata, response, model, usage_calculator)
+            repaired, _ = _recover_json(_completion_content(response))
+            if repaired is None:
+                raise ValueError("full-object repair returned invalid JSON")
+            result = (
+                response_format.model_validate(repaired) if has_pydantic else repaired
+            )
+            repair_metadata["success"] = True
+            if metadata is not None:
+                metadata.update(repair_metadata)
+            return result
+        except Exception:
+            if metadata is not None:
+                metadata.update(repair_metadata)
+            return raw_content
+
+    if not has_pydantic:
+        if syntax_repaired and metadata is not None:
+            repair_metadata = _base_metadata("deterministic", True)
+            repair_metadata["success"] = True
+            metadata.update(repair_metadata)
+        return parsed
+
+    try:
+        result = response_format.model_validate(parsed)
+        if syntax_repaired and metadata is not None:
+            repair_metadata = _base_metadata("deterministic", True)
+            repair_metadata["success"] = True
+            metadata.update(repair_metadata)
+        return result
+    except ValidationError as initial_error:
+        candidate = copy.deepcopy(parsed)
+        repair_metadata = _base_metadata("field_patch", syntax_repaired)
+        repair_metadata["deterministic_fields"] = _apply_deterministic_schema_repairs(
+            candidate, _validation_errors(initial_error)
+        )
+
+    try:
+        result = response_format.model_validate(candidate)
+        repair_metadata["strategy"] = "deterministic"
+        repair_metadata["success"] = True
+        if metadata is not None:
+            metadata.update(repair_metadata)
+        return result
+    except ValidationError as unresolved_error:
+        unresolved = _validation_errors(unresolved_error)
+
+    locations: Dict[str, tuple[Any, ...]] = {}
+    for error in unresolved:
+        location = tuple(error.get("loc", ()))
+        if not location:
+            if metadata is not None:
+                metadata.update(repair_metadata)
+            return raw_content
+        locations.setdefault(_json_pointer(location), location)
+
+    schema = response_format.model_json_schema()
+    invalid_fields = [
+        {
+            "path": _json_pointer(tuple(error["loc"])),
+            "error": {"type": error.get("type", ""), "message": error.get("msg", "")},
+            "field_schema": _schema_for_location(schema, tuple(error["loc"])),
+            "context": _small_parent_context(candidate, tuple(error["loc"])),
+        }
+        for error in unresolved
+    ]
+    params = _repair_request(
+        model=model,
+        payload={
+            "invalid_fields": invalid_fields,
+            "response_contract": {
+                "repairs": [
+                    {
+                        "path": "one exact invalid_fields path",
+                        "value": "replacement JSON value",
+                    }
+                ]
+            },
+        },
+        system_message=(
+            "Patch only the listed invalid JSON fields. Return one JSON object "
+            'with a "repairs" array containing exactly one entry per unique '
+            'invalid path. Each entry must have "path" and the replacement '
+            '"value". Never return or alter an unlisted path.'
+        ),
+        max_tokens=min(4096, max(256, len(locations) * 192 + 128)),
+        request_options=request_options,
+    )
+    repair_metadata["attempts"] = 1
+    try:
+        response = await create_completion(params)
+        _record_usage(repair_metadata, response, model, usage_calculator)
+        patch_object, _ = _recover_json(_completion_content(response))
+        repairs = (
+            patch_object.get("repairs") if isinstance(patch_object, dict) else None
+        )
+        if not isinstance(repairs, list):
+            raise ValueError("field repair did not return a repairs array")
+
+        received_paths = []
+        for repair in repairs:
+            if (
+                not isinstance(repair, dict)
+                or "path" not in repair
+                or "value" not in repair
+            ):
+                raise ValueError("invalid repair entry")
+            path = repair["path"]
+            if path not in locations:
+                raise ValueError("repair returned a path outside the allow-list")
+            if path in received_paths:
+                raise ValueError("repair returned a duplicate path")
+            received_paths.append(path)
+        if set(received_paths) != set(locations):
+            raise ValueError("repair did not cover every invalid path")
+
+        patched = copy.deepcopy(candidate)
+        for repair in repairs:
+            if not _set_at_path(patched, locations[repair["path"]], repair["value"]):
+                raise ValueError("repair path could not be applied")
+        result = response_format.model_validate(patched)
+        repair_metadata["model_patched_fields"] = len(repairs)
+        repair_metadata["success"] = True
+        if metadata is not None:
+            metadata.update(repair_metadata)
+        return result
+    except Exception:
+        if metadata is not None:
+            metadata.update(repair_metadata)
+        return raw_content

--- a/docs/llm/structured-output.md
+++ b/docs/llm/structured-output.md
@@ -56,3 +56,40 @@ notes = response.parsed
 print(f"Meeting on {notes.date}")
 print(f"Attendees: {', '.join(p.name for p in notes.attendees)}")
 
+### Repair behavior for loose JSON providers
+
+DeepSeek and ZAI support JSON-object mode but do not enforce the complete
+Pydantic schema at generation time. OpenRouter models can also occasionally
+return loose JSON. For these providers, Defog repairs structured output in this
+order:
+
+1. Normalize JSON syntax and apply safe local schema fixes, such as converting
+   `null` to `""` for string fields and removing keys forbidden by the model.
+2. If semantic validation errors remain, request patches only for the invalid
+   JSON-pointer paths. Valid fields and valid list items are not regenerated.
+3. If the output cannot be parsed at all, make one bounded full-object repair
+   call using the broken output and schema. The original source conversation is
+   not replayed.
+
+Repair calls are bounded to one attempt and fail closed: if a patch changes an
+unlisted path, omits an invalid path, or the assembled object still fails the
+original Pydantic validation, `response.content` contains the original raw
+string.
+
+When a repair was needed, `response.structured_output_repairs` contains audit
+metadata:
+
+```python
+repair = response.structured_output_repairs
+if repair:
+    print(repair["strategy"])  # deterministic, field_patch, or full_object
+    print(repair["attempts"])
+    print(repair["deterministic_fields"])
+    print(repair["model_patched_fields"])
+    print(repair["input_tokens"], repair["output_tokens"])
+    print(repair["cost_in_cents"], repair["success"])
+```
+
+Repair-call tokens and cost are included in the top-level `input_tokens`,
+`output_tokens`, and `cost_in_cents` totals. The telemetry fields report the
+repair portion separately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.8"
+version = "1.6.9"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_json_repair.py
+++ b/tests/test_json_repair.py
@@ -1,21 +1,13 @@
-"""Unit tests for the OpenRouter JSON repair pipeline.
-
-These tests exercise _deterministic_json_repair, _llm_json_repair, and
-_parse_with_repair without hitting any external API.
-"""
+"""Unit tests for shared schema-aware structured-output repair."""
 
 import json
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
+from defog.llm.providers.deepseek_provider import DeepSeekProvider
 from defog.llm.providers.openrouter_provider import OpenRouterProvider
-
-
-# ---------------------------------------------------------------------------
-# Test schemas
-# ---------------------------------------------------------------------------
 
 
 class SimpleOutput(BaseModel):
@@ -28,276 +20,388 @@ class NestedOutput(BaseModel):
     metadata: dict[str, int] = Field(default_factory=dict)
 
 
-# ---------------------------------------------------------------------------
-# Deterministic repair
-# ---------------------------------------------------------------------------
+class ExtractedItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    item_id: int
+    optional_text: str
+    required_text: str = Field(min_length=1)
+
+
+class ExtractionOutput(BaseModel):
+    items: list[ExtractedItem]
+    summary: str
 
 
 class TestDeterministicJsonRepair(unittest.TestCase):
     repair = staticmethod(OpenRouterProvider._deterministic_json_repair)
 
     def _roundtrip(self, broken: str) -> dict:
-        """Repair, then json.loads — raise on failure."""
         return json.loads(self.repair(broken))
 
-    # -- trailing commas ----------------------------------------------------
-
     def test_trailing_comma_object(self):
-        result = self._roundtrip('{"a": 1, "b": 2,}')
-        self.assertEqual(result, {"a": 1, "b": 2})
+        self.assertEqual(self._roundtrip('{"a": 1, "b": 2,}'), {"a": 1, "b": 2})
 
     def test_trailing_comma_array(self):
-        result = self._roundtrip('{"items": [1, 2, 3,]}')
-        self.assertEqual(result, {"items": [1, 2, 3]})
+        self.assertEqual(self._roundtrip('{"items": [1, 2, 3,]}'), {"items": [1, 2, 3]})
 
     def test_nested_trailing_commas(self):
-        result = self._roundtrip('{"a": {"b": 1,}, "c": [1,],}')
-        self.assertEqual(result, {"a": {"b": 1}, "c": [1]})
+        self.assertEqual(
+            self._roundtrip('{"a": {"b": 1,}, "c": [1,],}'),
+            {"a": {"b": 1}, "c": [1]},
+        )
 
-    # -- Python/JS literals -------------------------------------------------
+    def test_python_and_javascript_literals(self):
+        self.assertEqual(
+            self._roundtrip(
+                '{"yes": True, "no": False, "none": None, "nan": NaN, '
+                '"inf": Infinity, "neg_inf": -Infinity, "missing": undefined}'
+            ),
+            {
+                "yes": True,
+                "no": False,
+                "none": None,
+                "nan": None,
+                "inf": None,
+                "neg_inf": None,
+                "missing": None,
+            },
+        )
 
-    def test_python_true_false_none(self):
-        result = self._roundtrip('{"flag": True, "empty": None, "off": False}')
-        self.assertEqual(result, {"flag": True, "empty": None, "off": False})
+    def test_comments(self):
+        self.assertEqual(
+            self._roundtrip('// leading\n{"a": /* inline */ 1, // trailing\n"b": 2}'),
+            {"a": 1, "b": 2},
+        )
 
-    def test_nan_infinity(self):
-        result = self._roundtrip('{"a": NaN, "b": Infinity, "c": -Infinity}')
-        self.assertEqual(result, {"a": None, "b": None, "c": None})
-
-    def test_undefined(self):
-        result = self._roundtrip('{"a": undefined}')
-        self.assertEqual(result, {"a": None})
-
-    # -- comments -----------------------------------------------------------
-
-    def test_single_line_comment(self):
-        broken = '{\n  "a": 1, // this is a comment\n  "b": 2\n}'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"a": 1, "b": 2})
-
-    def test_leading_line_comment(self):
-        broken = '// comment\n{"a": 1}'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"a": 1})
-
-    def test_multiline_comment(self):
-        broken = '{"a": /* some comment */ 1}'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"a": 1})
-
-    # -- markdown fences ----------------------------------------------------
-
-    def test_markdown_json_fence(self):
-        broken = '```json\n{"a": 1}\n```'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"a": 1})
-
-    def test_markdown_plain_fence(self):
-        broken = '```\n{"a": 1}\n```'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"a": 1})
-
-    # -- single quotes ------------------------------------------------------
+    def test_markdown_fences(self):
+        self.assertEqual(self._roundtrip('```json\n{"a": 1}\n```'), {"a": 1})
+        self.assertEqual(self._roundtrip('```\n{"a": 1}\n```'), {"a": 1})
 
     def test_single_quoted_json(self):
-        broken = "{'name': 'hello', 'value': 42}"
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"name": "hello", "value": 42})
+        self.assertEqual(
+            self._roundtrip("{'name': 'hello', 'value': 42}"),
+            {"name": "hello", "value": 42},
+        )
 
-    # -- unbalanced brackets ------------------------------------------------
-
-    def test_missing_closing_brace(self):
-        broken = '{"name": "test", "value": 1'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"name": "test", "value": 1})
-
-    def test_missing_closing_bracket(self):
-        broken = '{"items": ["a", "b"'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"items": ["a", "b"]})
-
-    def test_missing_multiple_closers(self):
-        broken = '{"items": ["a", "b"'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"items": ["a", "b"]})
-
-    # -- truncated content --------------------------------------------------
-
-    def test_trailing_colon(self):
-        broken = '{"name": "test", "value":'
-        repaired = self.repair(broken)
-        result = json.loads(repaired)
-        self.assertEqual(result["name"], "test")
-        self.assertIsNone(result["value"])
-
-    def test_trailing_comma_incomplete(self):
-        broken = '{"name": "test","value": 1,'
-        repaired = self.repair(broken)
-        result = json.loads(repaired)
-        self.assertEqual(result, {"name": "test", "value": 1})
-
-    # -- unclosed string ----------------------------------------------------
-
-    def test_unclosed_string(self):
-        broken = '{"name": "test'
-        repaired = self.repair(broken)
-        result = json.loads(repaired)
-        self.assertEqual(result["name"], "test")
-
-    # -- combined issues ----------------------------------------------------
-
-    def test_combined_issues(self):
-        broken = '```json\n{"flag": True, "val": NaN, "items": [1, 2,]}\n```'
-        result = self._roundtrip(broken)
-        self.assertEqual(result, {"flag": True, "val": None, "items": [1, 2]})
-
-    # -- already valid JSON -------------------------------------------------
-
-    def test_valid_json_passthrough(self):
-        valid = '{"name": "test", "value": 42}'
-        result = self._roundtrip(valid)
-        self.assertEqual(result, {"name": "test", "value": 42})
+    def test_unbalanced_and_truncated_json(self):
+        self.assertEqual(self._roundtrip('{"items": ["a", "b"'), {"items": ["a", "b"]})
+        self.assertEqual(
+            self._roundtrip('{"name": "test", "value":'),
+            {"name": "test", "value": None},
+        )
+        self.assertEqual(self._roundtrip('{"name": "test'), {"name": "test"})
 
 
-# ---------------------------------------------------------------------------
-# _parse_with_repair  (mocked LLM)
-# ---------------------------------------------------------------------------
-
-
-class TestParseWithRepair(unittest.IsolatedAsyncioTestCase):
+class TestSchemaAwareRepair(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.provider = OpenRouterProvider.__new__(OpenRouterProvider)
-        # Minimal init for the base class methods we need
-        self.provider.api_key = "test"
-        self.provider.base_url = "http://test"
-        self.provider.config = None
-        self.provider.tool_handler = None
-
+        self.provider = DeepSeekProvider(api_key="test")
         self.mock_client = MagicMock()
+        self.mock_client.chat.completions.create = AsyncMock()
 
-    async def test_valid_json_no_repair(self):
-        """Valid JSON should parse on the first try — no repair needed."""
+    @staticmethod
+    def _completion(
+        content: str,
+        *,
+        prompt_tokens: int = 0,
+        completion_tokens: int = 0,
+        response_id: str = "repair-id",
+        cost: float | None = None,
+    ) -> MagicMock:
+        usage = MagicMock()
+        usage.prompt_tokens = prompt_tokens
+        usage.completion_tokens = completion_tokens
+        usage.prompt_tokens_details = None
+        usage.completion_tokens_details = None
+        if cost is not None:
+            usage.cost = cost
+        else:
+            del usage.cost
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content=content))]
+        response.usage = usage
+        response.id = response_id
+        return response
+
+    async def _parse(
+        self,
+        raw: str,
+        schema=ExtractionOutput,
+        *,
+        metadata=None,
+        request_params=None,
+    ):
+        return await self.provider._parse_with_repair(
+            raw,
+            schema,
+            self.mock_client,
+            "deepseek-v4-flash",
+            request_params or {"messages": []},
+            repair_metadata=metadata,
+        )
+
+    async def test_valid_json_needs_no_repair(self):
         raw = '{"name": "alice", "value": 10}'
-        result = await self.provider._parse_with_repair(
-            raw, SimpleOutput, self.mock_client, "test-model"
+        result = await self._parse(raw, SimpleOutput)
+        self.assertEqual(result, SimpleOutput(name="alice", value=10))
+        self.mock_client.chat.completions.create.assert_not_awaited()
+
+    async def test_null_string_and_forbidden_extra_are_repaired_locally(self):
+        raw = json.dumps(
+            {
+                "items": [
+                    {
+                        "item_id": 1,
+                        "optional_text": None,
+                        "required_text": "already valid",
+                        "review_span_ids": [7],
+                    },
+                    {
+                        "item_id": 2,
+                        "optional_text": "unchanged",
+                        "required_text": "also valid",
+                    },
+                ],
+                "summary": "keep me",
+            }
         )
-        self.assertIsInstance(result, SimpleOutput)
-        self.assertEqual(result.name, "alice")
-        self.assertEqual(result.value, 10)
+        metadata = {}
 
-    async def test_deterministic_repair_fixes_trailing_comma(self):
-        """Trailing comma should be fixed deterministically."""
-        raw = '{"name": "bob", "value": 5,}'
-        result = await self.provider._parse_with_repair(
-            raw, SimpleOutput, self.mock_client, "test-model"
+        result = await self._parse(raw, metadata=metadata)
+
+        self.assertEqual(result.items[0].optional_text, "")
+        self.assertEqual(result.items[0].required_text, "already valid")
+        self.assertEqual(
+            result.items[1].model_dump(),
+            {
+                "item_id": 2,
+                "optional_text": "unchanged",
+                "required_text": "also valid",
+            },
         )
-        self.assertIsInstance(result, SimpleOutput)
-        self.assertEqual(result.name, "bob")
-        self.assertEqual(result.value, 5)
+        self.assertEqual(result.summary, "keep me")
+        self.assertEqual(metadata["strategy"], "deterministic")
+        self.assertEqual(metadata["deterministic_fields"], 2)
+        self.assertEqual(metadata["attempts"], 0)
+        self.mock_client.chat.completions.create.assert_not_awaited()
 
-    async def test_deterministic_repair_fixes_python_literals(self):
-        """Python True/False/None should be fixed deterministically."""
-        raw = '{"name": "charlie", "value": 7, "flag": True}'
-        # True is not valid JSON — deterministic repair converts to true
-        # SimpleOutput ignores extra fields, so this should parse fine
-        result = await self.provider._parse_with_repair(
-            raw, SimpleOutput, self.mock_client, "test-model"
+    async def test_truncated_nested_json_is_recovered_then_schema_repaired(self):
+        raw = (
+            '{"items": [{"item_id": 1, "optional_text": null, '
+            '"required_text": "valid"}], "summary": "complete"'
         )
-        self.assertIsInstance(result, SimpleOutput)
-        self.assertEqual(result.name, "charlie")
-        self.assertEqual(result.value, 7)
+        metadata = {}
 
-    async def test_llm_repair_called_when_deterministic_fails(self):
-        """When deterministic repair can't fix it, the LLM fallback fires."""
-        # Completely garbled content that deterministic repair can't fix
-        raw = "The answer is name=alice and value=10, here you go!"
+        result = await self._parse(raw, metadata=metadata)
 
-        # Mock the LLM repair response
-        mock_response = MagicMock()
-        mock_response.choices = [
-            MagicMock(message=MagicMock(content='{"name": "alice", "value": 10}'))
-        ]
-        self.mock_client.chat = MagicMock()
-        self.mock_client.chat.completions = MagicMock()
-        self.mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+        self.assertIsInstance(result, ExtractionOutput)
+        self.assertEqual(result.items[0].optional_text, "")
+        self.assertTrue(metadata["syntax_repaired"])
+        self.assertEqual(metadata["strategy"], "deterministic")
+        self.mock_client.chat.completions.create.assert_not_awaited()
 
-        result = await self.provider._parse_with_repair(
-            raw,
-            SimpleOutput,
-            self.mock_client,
-            "test-model",
-            {"messages": [{"role": "user", "content": "give me data"}]},
+    async def test_field_patch_sends_only_invalid_records_and_preserves_valid_data(
+        self,
+    ):
+        original = {
+            "items": [
+                {"item_id": 1, "optional_text": None, "required_text": ""},
+                {
+                    "item_id": 2,
+                    "optional_text": "valid optional",
+                    "required_text": "valid required",
+                },
+                {"item_id": 3, "optional_text": "valid", "required_text": ""},
+            ],
+            "summary": "immutable summary",
+        }
+        self.mock_client.chat.completions.create.return_value = self._completion(
+            json.dumps(
+                {
+                    "repairs": [
+                        {"path": "/items/0/required_text", "value": "first fixed"},
+                        {"path": "/items/2/required_text", "value": "third fixed"},
+                    ]
+                }
+            ),
+            prompt_tokens=31,
+            completion_tokens=9,
         )
-        self.assertIsInstance(result, SimpleOutput)
-        self.assertEqual(result.name, "alice")
-        self.assertEqual(result.value, 10)
+        metadata = {}
+        secret_source = "SOURCE TRANSCRIPT THAT MUST NOT BE REPLAYED"
 
-        # Verify the LLM was called
-        self.mock_client.chat.completions.create.assert_called_once()
-
-    async def test_llm_repair_uses_conversation_context(self):
-        """The LLM repair call should include original messages as context."""
-        raw = "totally broken json!!!"
-        original_messages = [
-            {"role": "system", "content": "You are helpful."},
-            {"role": "user", "content": "Return structured data."},
-        ]
-
-        mock_response = MagicMock()
-        mock_response.choices = [
-            MagicMock(message=MagicMock(content='{"name": "fixed", "value": 1}'))
-        ]
-        self.mock_client.chat = MagicMock()
-        self.mock_client.chat.completions = MagicMock()
-        self.mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-
-        await self.provider._parse_with_repair(
-            raw,
-            SimpleOutput,
-            self.mock_client,
-            "test-model",
-            {"messages": original_messages},
+        result = await self._parse(
+            json.dumps(original),
+            metadata=metadata,
+            request_params={"messages": [{"role": "user", "content": secret_source}]},
         )
 
-        # Check that the repair call included the original messages +
-        # the broken assistant turn + the user follow-up
-        call_args = self.mock_client.chat.completions.create.call_args
-        messages_sent = call_args.kwargs.get("messages", call_args[1].get("messages"))
-        self.assertEqual(messages_sent[0]["role"], "system")
-        self.assertEqual(messages_sent[1]["role"], "user")
-        self.assertEqual(messages_sent[2]["role"], "assistant")
-        self.assertEqual(messages_sent[2]["content"], raw)
-        self.assertEqual(messages_sent[3]["role"], "user")
-        self.assertIn("schema", messages_sent[3]["content"].lower())
+        self.assertIsInstance(result, ExtractionOutput)
+        self.assertEqual(result.items[0].optional_text, "")
+        self.assertEqual(result.items[0].required_text, "first fixed")
+        self.assertEqual(result.items[1].model_dump(), original["items"][1])
+        self.assertEqual(result.items[2].required_text, "third fixed")
+        self.assertEqual(result.summary, original["summary"])
 
-    async def test_returns_raw_when_all_repair_fails(self):
-        """When even LLM repair fails, raw content is returned."""
-        raw = "completely unparseable garbage"
-
-        # LLM also returns garbage
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content="still broken"))]
-        self.mock_client.chat = MagicMock()
-        self.mock_client.chat.completions = MagicMock()
-        self.mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
-
-        result = await self.provider._parse_with_repair(
-            raw,
-            SimpleOutput,
-            self.mock_client,
-            "test-model",
-            {"messages": []},
+        call = self.mock_client.chat.completions.create.await_args.kwargs
+        self.assertEqual(len(call["messages"]), 2)
+        serialized_request = json.dumps(call["messages"])
+        self.assertNotIn(secret_source, serialized_request)
+        payload = json.loads(call["messages"][1]["content"])
+        self.assertEqual(
+            {field["path"] for field in payload["invalid_fields"]},
+            {"/items/0/required_text", "/items/2/required_text"},
         )
-        # Should return the original raw content
+        self.assertNotIn("immutable summary", serialized_request)
+        self.assertNotIn('"item_id": 2', serialized_request)
+        self.assertLess(call["max_tokens"], 4096)
+        self.assertEqual(metadata["strategy"], "field_patch")
+        self.assertEqual(metadata["attempts"], 1)
+        self.assertEqual(metadata["deterministic_fields"], 1)
+        self.assertEqual(metadata["model_patched_fields"], 2)
+        self.assertEqual(metadata["input_tokens"], 31)
+        self.assertEqual(metadata["output_tokens"], 9)
+        self.assertTrue(metadata["success"])
+
+    async def test_patch_for_non_error_path_rejects_entire_repair(self):
+        raw = json.dumps(
+            {
+                "items": [
+                    {"item_id": 1, "optional_text": "valid", "required_text": ""},
+                    {"item_id": 2, "optional_text": "valid", "required_text": "valid"},
+                ],
+                "summary": "unchanged",
+            }
+        )
+        self.mock_client.chat.completions.create.return_value = self._completion(
+            '{"repairs": [{"path": "/items/1/required_text", "value": "tampered"}]}',
+            prompt_tokens=5,
+            completion_tokens=4,
+        )
+        metadata = {}
+
+        result = await self._parse(raw, metadata=metadata)
+
         self.assertEqual(result, raw)
+        self.assertFalse(metadata["success"])
+        self.assertEqual(metadata["model_patched_fields"], 0)
+        self.assertEqual(metadata["input_tokens"], 5)
+        self.assertEqual(metadata["output_tokens"], 4)
+        self.mock_client.chat.completions.create.assert_awaited_once()
 
-    async def test_no_repair_when_no_response_format(self):
-        """With no response_format, raw content is returned as-is."""
-        raw = "just a plain string"
-        result = await self.provider._parse_with_repair(
-            raw, None, self.mock_client, "test-model"
+    async def test_incomplete_patch_set_fails_closed(self):
+        raw = json.dumps(
+            {
+                "items": [
+                    {"item_id": 1, "optional_text": "ok", "required_text": ""},
+                    {"item_id": 2, "optional_text": "ok", "required_text": ""},
+                ],
+                "summary": "unchanged",
+            }
         )
+        self.mock_client.chat.completions.create.return_value = self._completion(
+            '{"repairs": [{"path": "/items/0/required_text", "value": "fixed"}]}'
+        )
+
+        result = await self._parse(raw)
+
         self.assertEqual(result, raw)
+        self.mock_client.chat.completions.create.assert_awaited_once()
+
+    async def test_unparseable_json_uses_isolated_full_object_fallback(self):
+        raw = "unparseable output " * 900
+        self.mock_client.chat.completions.create.return_value = self._completion(
+            '{"name": "recovered", "value": 42}',
+            prompt_tokens=41,
+            completion_tokens=11,
+        )
+        metadata = {}
+        secret_source = "PRIVATE ORIGINAL SOURCE"
+
+        result = await self._parse(
+            raw,
+            SimpleOutput,
+            metadata=metadata,
+            request_params={"messages": [{"role": "user", "content": secret_source}]},
+        )
+
+        self.assertEqual(result, SimpleOutput(name="recovered", value=42))
+        call = self.mock_client.chat.completions.create.await_args.kwargs
+        serialized_request = json.dumps(call["messages"])
+        self.assertNotIn(secret_source, serialized_request)
+        self.assertIn(raw, serialized_request)
+        self.assertGreater(call["max_tokens"], 4096)
+        self.assertLessEqual(call["max_tokens"], 16384)
+        self.assertEqual(metadata["strategy"], "full_object")
+        self.assertEqual(metadata["attempts"], 1)
+        self.assertEqual(metadata["input_tokens"], 41)
+        self.assertEqual(metadata["output_tokens"], 11)
+        self.assertTrue(metadata["success"])
+
+    async def test_repair_call_failure_is_bounded_and_fails_closed(self):
+        raw = json.dumps(
+            {
+                "items": [
+                    {"item_id": 1, "optional_text": "valid", "required_text": ""}
+                ],
+                "summary": "unchanged",
+            }
+        )
+        self.mock_client.chat.completions.create.side_effect = RuntimeError(
+            "provider down"
+        )
+        metadata = {}
+
+        result = await self._parse(raw, metadata=metadata)
+
+        self.assertEqual(result, raw)
+        self.assertEqual(metadata["attempts"], 1)
+        self.assertFalse(metadata["success"])
+        self.mock_client.chat.completions.create.assert_awaited_once()
+
+    async def test_no_response_format_returns_raw_without_call(self):
+        result = await self._parse("plain text", None)
+        self.assertEqual(result, "plain text")
+        self.mock_client.chat.completions.create.assert_not_awaited()
+
+    async def test_process_response_aggregates_repair_usage_and_telemetry(self):
+        raw = json.dumps(
+            {
+                "items": [
+                    {"item_id": 1, "optional_text": "valid", "required_text": ""}
+                ],
+                "summary": "unchanged",
+            }
+        )
+        initial = self._completion(
+            raw, prompt_tokens=100, completion_tokens=20, response_id="initial-id"
+        )
+        self.mock_client.chat.completions.create.return_value = self._completion(
+            '{"repairs": [{"path": "/items/0/required_text", "value": "fixed"}]}',
+            prompt_tokens=7,
+            completion_tokens=3,
+        )
+
+        processed = await self.provider.process_response(
+            client=self.mock_client,
+            response=initial,
+            request_params={"messages": [{"role": "user", "content": "source"}]},
+            tools=None,
+            tool_dict={},
+            response_format=ExtractionOutput,
+            model="deepseek-v4-flash",
+        )
+
+        content, _, input_tokens, cached_tokens, output_tokens, _, _, telemetry = (
+            processed
+        )
+        self.assertIsInstance(content, ExtractionOutput)
+        self.assertEqual(input_tokens, 107)
+        self.assertEqual(cached_tokens, 0)
+        self.assertEqual(output_tokens, 23)
+        self.assertEqual(telemetry["input_tokens"], 7)
+        self.assertEqual(telemetry["output_tokens"], 3)
+        self.assertGreater(telemetry["cost_in_cents"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_openrouter_choices_validation.py
+++ b/tests/test_openrouter_choices_validation.py
@@ -1,13 +1,12 @@
 """Unit tests for OpenRouter response.choices validation (issue #261).
 
-Verifies that process_response and _llm_json_repair raise ProviderError
-when OpenRouter returns choices=None on follow-up API calls, instead of
-crashing with a TypeError.
+Verifies that process_response raises ProviderError for required follow-up calls
+and structured repair fails closed when a bounded repair call has no choices.
 """
 
 import json
 import unittest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from pydantic import BaseModel
 
@@ -248,26 +247,27 @@ class TestStructuredOutputFinalCallValidation(unittest.IsolatedAsyncioTestCase):
 # ---------------------------------------------------------------------------
 
 
-class TestLlmJsonRepairValidation(unittest.IsolatedAsyncioTestCase):
-    """_llm_json_repair makes an API call to fix broken JSON. If that call
-    returns choices=None, it must raise ProviderError."""
-
-    async def test_repair_choices_none_raises_provider_error(self):
+class TestStructuredRepairValidation(unittest.IsolatedAsyncioTestCase):
+    async def test_repair_choices_none_fails_closed(self):
         provider = OpenRouterProvider(api_key="test-key")
-
+        raw = '{"answer": "hello", "score": }'
         bad_response = _make_response(choices_present=False)
         client = AsyncMock()
         client.chat.completions.create = AsyncMock(return_value=bad_response)
+        metadata = {}
 
-        with self.assertRaises(ProviderError) as ctx:
-            await provider._llm_json_repair(
-                broken_content='{"answer": "hello", "score": }',
-                response_format=StructuredOutput,
-                client=client,
-                model="test-model",
-                request_params={"messages": []},
-            )
-        self.assertIn("No response from OpenRouter", str(ctx.exception))
+        result = await provider._parse_with_repair(
+            raw_content=raw,
+            response_format=StructuredOutput,
+            client=client,
+            model="test-model",
+            request_params={"messages": []},
+            repair_metadata=metadata,
+        )
+
+        self.assertEqual(result, raw)
+        self.assertEqual(metadata["attempts"], 1)
+        self.assertFalse(metadata["success"])
 
 
 # ---------------------------------------------------------------------------
@@ -342,7 +342,7 @@ class TestValidResponsesStillWork(unittest.IsolatedAsyncioTestCase):
         content = result[0]
         self.assertEqual(content, "The sum is 8")
 
-    async def test_llm_json_repair_with_valid_response(self):
+    async def test_structured_repair_with_valid_response(self):
         provider = OpenRouterProvider(api_key="test-key")
 
         good_json = json.dumps({"answer": "fixed", "score": 99})
@@ -350,8 +350,8 @@ class TestValidResponsesStillWork(unittest.IsolatedAsyncioTestCase):
         client = AsyncMock()
         client.chat.completions.create = AsyncMock(return_value=good_response)
 
-        result = await provider._llm_json_repair(
-            broken_content='{"answer": "hello", "score": }',
+        result = await provider._parse_with_repair(
+            raw_content='{"answer": "hello", "score": }',
             response_format=StructuredOutput,
             client=client,
             model="test-model",

--- a/tests/test_openrouter_provider_routing.py
+++ b/tests/test_openrouter_provider_routing.py
@@ -2,11 +2,16 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from pydantic import BaseModel
 
 from defog.llm.config import LLMConfig
 from defog.llm.providers.base import LLMResponse
 from defog.llm.providers.openrouter_provider import OpenRouterProvider
 from defog.llm.utils import chat_async
+
+
+class RoutingRepairOutput(BaseModel):
+    value: str
 
 
 def test_build_params_providers_list_maps_to_only():
@@ -92,11 +97,20 @@ async def test_chat_async_rejects_providers_for_non_openrouter():
 
 
 @pytest.mark.asyncio
-async def test_llm_json_repair_forwards_provider_extra_body():
+async def test_structured_repair_forwards_provider_extra_body():
     provider = OpenRouterProvider(api_key="sk-test")
     extra_body = {"provider": {"only": ["azure"]}}
     response = SimpleNamespace(
-        choices=[SimpleNamespace(message=SimpleNamespace(content="fixed"))]
+        choices=[
+            SimpleNamespace(message=SimpleNamespace(content='{"value": "fixed"}'))
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=1,
+            completion_tokens=1,
+            prompt_tokens_details=None,
+            completion_tokens_details=None,
+            cost=None,
+        ),
     )
     client = SimpleNamespace(
         chat=SimpleNamespace(
@@ -104,13 +118,14 @@ async def test_llm_json_repair_forwards_provider_extra_body():
         )
     )
 
-    result = await provider._llm_json_repair(
-        broken_content="broken",
-        response_format=None,
+    result = await provider._parse_with_repair(
+        raw_content="broken",
+        response_format=RoutingRepairOutput,
         client=client,
         model="openai/gpt-5-mini",
-        request_params={"messages": [], "extra_body": extra_body},
+        request_params={"messages": []},
+        extra_body=extra_body,
     )
 
-    assert result == "fixed"
+    assert result == RoutingRepairOutput(value="fixed")
     assert client.chat.completions.create.call_args.kwargs["extra_body"] == extra_body


### PR DESCRIPTION
## Summary

- add a shared schema-aware structured-output repair pipeline for DeepSeek, OpenRouter, and ZAI
- preserve parsed objects and use Pydantic error locations for deterministic null-string and forbidden-extra fixes
- request bounded, allow-listed field patches containing only invalid paths, relevant subschemas, and small parent contexts
- isolate unparseable JSON fallback from the original source conversation
- aggregate repair tokens and cost into LLMResponse totals and expose structured_output_repairs telemetry
- bump the package version to 1.6.9 and document repair behavior

## Safety properties

- valid fields and list items are never patched
- unlisted, duplicate, or incomplete patch paths fail closed
- the assembled object is revalidated with the original Pydantic model
- repair calls are bounded to one attempt
- source prompts are never replayed during repair

## Tests

- 51 affected tests passed, 19 live-API tests skipped, and 6 subtests passed
- coverage includes nested lists, multiple invalid fields, forbidden extras, invalid patch paths, incomplete patches, truncated and unparseable JSON, provider failure, prompt isolation, output limits, and usage/cost aggregation
- broader suite attempt reached 392 passed and 136 skipped; remaining failures are unrelated baseline issues from missing optional dependencies, a stale PDF test import, absent API keys, and existing async/config tests
- Ruff checks pass for every changed Python file
- wheel and source archive pass Twine validation

## Release

Published defog 1.6.9 to PyPI before opening this PR:
https://pypi.org/project/defog/1.6.9/

Closes #291