### PR TITLE
Close OpenAI async clients deterministically

### DIFF
--- a/defog/llm/citations.py
+++ b/defog/llm/citations.py
@@ -22,26 +22,25 @@ class CitationsResult(list):
 async def upload_document_to_openai_vector_store(document, store_id):
     from openai import AsyncOpenAI
 
-    client = AsyncOpenAI(api_key=config.get("OPENAI_API_KEY"))
+    async with AsyncOpenAI(api_key=config.get("OPENAI_API_KEY")) as client:
+        file_name = document["document_name"]
+        if not file_name.endswith(".txt"):
+            file_name = file_name + ".txt"
+        file_content = document["document_content"]
+        if isinstance(file_content, str):
+            # convert to bytes
+            file_content = file_content.encode("utf-8")
 
-    file_name = document["document_name"]
-    if not file_name.endswith(".txt"):
-        file_name = file_name + ".txt"
-    file_content = document["document_content"]
-    if isinstance(file_content, str):
-        # convert to bytes
-        file_content = file_content.encode("utf-8")
+        # first, upload the file to the vector store
+        file = await client.files.create(
+            file=(file_name, file_content), purpose="assistants"
+        )
 
-    # first, upload the file to the vector store
-    file = await client.files.create(
-        file=(file_name, file_content), purpose="assistants"
-    )
-
-    # then add it to the vector store
-    await client.vector_stores.files.create(
-        vector_store_id=store_id,
-        file_id=file.id,
-    )
+        # then add it to the vector store
+        await client.vector_stores.files.create(
+            vector_store_id=store_id,
+            file_id=file.id,
+        )
 
 
 async def citations_tool(
@@ -74,116 +73,121 @@ async def citations_tool(
         if provider in [LLMProvider.OPENAI, LLMProvider.OPENAI.value]:
             from openai import AsyncOpenAI
 
-            client = AsyncOpenAI(api_key=config.get("OPENAI_API_KEY"))
+            async with AsyncOpenAI(api_key=config.get("OPENAI_API_KEY")) as client:
+                # create an ephemeral vector store
+                store = await client.vector_stores.create()
+                store_id = store.id
 
-            # create an ephemeral vector store
-            store = await client.vector_stores.create()
-            store_id = store.id
+                # Upload all documents in parallel
+                tracker.update(10, "Uploading documents to vector store")
+                subtask_logger.log_subtask("Starting document uploads", "processing")
 
-            # Upload all documents in parallel
-            tracker.update(10, "Uploading documents to vector store")
-            subtask_logger.log_subtask("Starting document uploads", "processing")
-
-            upload_tasks = []
-            for idx, document in enumerate(documents, 1):
-                subtask_logger.log_document_upload(
-                    document["document_name"], idx, len(documents)
-                )
-                upload_tasks.append(
-                    upload_document_to_openai_vector_store(document, store_id)
-                )
-
-            await asyncio.gather(*upload_tasks)
-            tracker.update(40, "Documents uploaded")
-
-            # keep polling until the vector store is ready
-            is_ready = False
-            while not is_ready:
-                store = await client.vector_stores.files.list(vector_store_id=store_id)
-                total_completed = sum(
-                    1 for file in store.data if file.status == "completed"
-                )
-                is_ready = total_completed == len(documents)
-
-                # Update progress based on indexing status
-                progress = 40 + (total_completed / len(documents) * 40)  # 40-80% range
-                tracker.update(
-                    progress, f"Indexing {total_completed}/{len(documents)} files"
-                )
-                subtask_logger.log_vector_store_status(total_completed, len(documents))
-
-                if not is_ready:
-                    await asyncio.sleep(1)
-
-            # get the answer
-            tracker.update(80, "Generating citations")
-            subtask_logger.log_subtask("Querying with file search", "processing")
-            payload = {
-                "model": model,
-                "input": question,
-                "tools": [
-                    {
-                        "type": "file_search",
-                        "vector_store_ids": [store_id],
-                    }
-                ],
-                "tool_choice": "required",
-                "instructions": instructions,
-                "max_output_tokens": max_tokens,
-            }
-            if reasoning_effort:
-                payload["reasoning"] = {
-                    "effort": reasoning_effort,
-                    "summary": "auto",
-                }
-
-            response = await client.responses.create(**payload)
-
-            usage = getattr(response, "usage", None)
-            cost_in_cents = None
-            if usage:
-                input_tokens = getattr(usage, "input_tokens", 0) or 0
-                output_tokens = getattr(usage, "output_tokens", 0) or 0
-                cached_tokens = (
-                    getattr(
-                        getattr(usage, "input_tokens_details", None),
-                        "cached_tokens",
-                        0,
+                upload_tasks = []
+                for idx, document in enumerate(documents, 1):
+                    subtask_logger.log_document_upload(
+                        document["document_name"], idx, len(documents)
                     )
-                    or 0
-                )
-                cost_in_cents = CostCalculator.calculate_cost(
-                    model, input_tokens, output_tokens, cached_tokens
+                    upload_tasks.append(
+                        upload_document_to_openai_vector_store(document, store_id)
+                    )
+
+                await asyncio.gather(*upload_tasks)
+                tracker.update(40, "Documents uploaded")
+
+                # keep polling until the vector store is ready
+                is_ready = False
+                while not is_ready:
+                    store = await client.vector_stores.files.list(
+                        vector_store_id=store_id
+                    )
+                    total_completed = sum(
+                        1 for file in store.data if file.status == "completed"
+                    )
+                    is_ready = total_completed == len(documents)
+
+                    # Update progress based on indexing status
+                    progress = 40 + (
+                        total_completed / len(documents) * 40
+                    )  # 40-80% range
+                    tracker.update(
+                        progress, f"Indexing {total_completed}/{len(documents)} files"
+                    )
+                    subtask_logger.log_vector_store_status(
+                        total_completed, len(documents)
+                    )
+
+                    if not is_ready:
+                        await asyncio.sleep(1)
+
+                # get the answer
+                tracker.update(80, "Generating citations")
+                subtask_logger.log_subtask("Querying with file search", "processing")
+                payload = {
+                    "model": model,
+                    "input": question,
+                    "tools": [
+                        {
+                            "type": "file_search",
+                            "vector_store_ids": [store_id],
+                        }
+                    ],
+                    "tool_choice": "required",
+                    "instructions": instructions,
+                    "max_output_tokens": max_tokens,
+                }
+                if reasoning_effort:
+                    payload["reasoning"] = {
+                        "effort": reasoning_effort,
+                        "summary": "auto",
+                    }
+
+                response = await client.responses.create(**payload)
+
+                usage = getattr(response, "usage", None)
+                cost_in_cents = None
+                if usage:
+                    input_tokens = getattr(usage, "input_tokens", 0) or 0
+                    output_tokens = getattr(usage, "output_tokens", 0) or 0
+                    cached_tokens = (
+                        getattr(
+                            getattr(usage, "input_tokens_details", None),
+                            "cached_tokens",
+                            0,
+                        )
+                        or 0
+                    )
+                    cost_in_cents = CostCalculator.calculate_cost(
+                        model, input_tokens, output_tokens, cached_tokens
+                    )
+
+                # convert the response to a list of blocks
+                # similar to a subset of the Anthropic citations API
+                blocks = []
+                for part in response.output:
+                    if part.type == "message":
+                        contents = part.content
+                        for item in contents:
+                            if item.type == "output_text":
+                                blocks.append(
+                                    {
+                                        "text": item.text,
+                                        "type": "text",
+                                        "citations": [
+                                            {"document_title": i.filename}
+                                            for i in item.annotations
+                                        ],
+                                    }
+                                )
+                tracker.update(95, "Processing results")
+                subtask_logger.log_result_summary(
+                    "Citations",
+                    {
+                        "blocks_generated": len(blocks),
+                        "documents_processed": len(documents),
+                    },
                 )
 
-            # convert the response to a list of blocks
-            # similar to a subset of the Anthropic citations API
-            blocks = []
-            for part in response.output:
-                if part.type == "message":
-                    contents = part.content
-                    for item in contents:
-                        if item.type == "output_text":
-                            blocks.append(
-                                {
-                                    "text": item.text,
-                                    "type": "text",
-                                    "citations": [
-                                        {"document_title": i.filename}
-                                        for i in item.annotations
-                                    ],
-                                }
-                            )
-            tracker.update(95, "Processing results")
-            subtask_logger.log_result_summary(
-                "Citations",
-                {
-                    "blocks_generated": len(blocks),
-                    "documents_processed": len(documents),
-                },
-            )
-
-            return CitationsResult(blocks, cost_in_cents=cost_in_cents, usage=usage)
+                return CitationsResult(blocks, cost_in_cents=cost_in_cents, usage=usage)
 
         elif provider in [LLMProvider.ANTHROPIC, LLMProvider.ANTHROPIC.value]:
             from anthropic import AsyncAnthropic
@@ -237,9 +241,7 @@ async def citations_tool(
                 # Claude 4.6+ models support adaptive thinking, which
                 # replaces the deprecated budget_tokens approach.
                 _is_adaptive = (
-                    "opus-4-6" in model
-                    or "opus-4-7" in model
-                    or "sonnet-4-6" in model
+                    "opus-4-6" in model or "opus-4-7" in model or "sonnet-4-6" in model
                 )
                 if _is_adaptive:
                     payload["thinking"] = {"type": "adaptive"}

--- a/defog/llm/code_interp.py
+++ b/defog/llm/code_interp.py
@@ -46,57 +46,56 @@ async def code_interpreter_tool(
                 ResponseOutputMessage,
             )
 
-            client = AsyncOpenAI(api_key=config.get("OPENAI_API_KEY"))
+            async with AsyncOpenAI(api_key=config.get("OPENAI_API_KEY")) as client:
+                if csv_string:
+                    tracker.update(20, "Uploading data file")
+                    subtask_logger.log_subtask("Uploading CSV to OpenAI", "processing")
+                    file = await client.files.create(
+                        file=csv_file,
+                        purpose="user_data",
+                    )
 
-            if csv_string:
-                tracker.update(20, "Uploading data file")
-                subtask_logger.log_subtask("Uploading CSV to OpenAI", "processing")
-                file = await client.files.create(
-                    file=csv_file,
-                    purpose="user_data",
+                tracker.update(40, "Running code interpreter")
+                subtask_logger.log_code_execution("python")
+                response = await client.responses.create(
+                    model=model,
+                    tools=[
+                        {
+                            "type": "code_interpreter",
+                            "container": {
+                                "type": "auto",
+                                "file_ids": [file.id] if csv_string else [],
+                            },
+                        }
+                    ],
+                    tool_choice="required",
+                    input=[
+                        {
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": question}],
+                        }
+                    ],
+                    instructions=instructions,
+                )
+                tracker.update(80, "Processing results")
+                subtask_logger.log_subtask("Extracting code and output", "processing")
+
+                code = ""
+                output_text = ""
+
+                for chunk in response.output:
+                    if isinstance(chunk, ResponseCodeInterpreterToolCall):
+                        code += chunk.code
+                    elif isinstance(chunk, ResponseOutputMessage):
+                        for content in chunk.content:
+                            output_text += content.text
+
+                subtask_logger.log_result_summary(
+                    "Code Execution",
+                    {"code_length": len(code), "output_length": len(output_text)},
                 )
 
-            tracker.update(40, "Running code interpreter")
-            subtask_logger.log_code_execution("python")
-            response = await client.responses.create(
-                model=model,
-                tools=[
-                    {
-                        "type": "code_interpreter",
-                        "container": {
-                            "type": "auto",
-                            "file_ids": [file.id] if csv_string else [],
-                        },
-                    }
-                ],
-                tool_choice="required",
-                input=[
-                    {
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": question}],
-                    }
-                ],
-                instructions=instructions,
-            )
-            tracker.update(80, "Processing results")
-            subtask_logger.log_subtask("Extracting code and output", "processing")
-
-            code = ""
-            output_text = ""
-
-            for chunk in response.output:
-                if isinstance(chunk, ResponseCodeInterpreterToolCall):
-                    code += chunk.code
-                elif isinstance(chunk, ResponseOutputMessage):
-                    for content in chunk.content:
-                        output_text += content.text
-
-            subtask_logger.log_result_summary(
-                "Code Execution",
-                {"code_length": len(code), "output_length": len(output_text)},
-            )
-
-            return {"code": code, "output": output_text}
+                return {"code": code, "output": output_text}
         elif provider in [LLMProvider.ANTHROPIC, LLMProvider.ANTHROPIC.value]:
             from anthropic import AsyncAnthropic
 

--- a/defog/llm/pdf_processor.py
+++ b/defog/llm/pdf_processor.py
@@ -420,11 +420,22 @@ class OpenAIPDFProcessor(BasePDFProcessor):
         """Initialize OpenAI PDF processor with API client."""
         super().__init__(provider, model, temperature)
 
-        # Initialize OpenAI client
-        self.client = openai.AsyncOpenAI(
-            api_key=api_key or defog_config.get("OPENAI_API_KEY"),
-            base_url=base_url or "https://api.openai.com/v1/",
-        )
+        self._client_kwargs = {
+            "api_key": api_key or defog_config.get("OPENAI_API_KEY"),
+            "base_url": base_url or "https://api.openai.com/v1/",
+        }
+        self.client = None
+
+    async def analyze_pdf(
+        self, url: str, task: str, response_format: Optional[Type[BaseModel]] = None
+    ) -> PDFAnalysisResult:
+        """Analyze a PDF while deterministically managing the OpenAI client."""
+        async with openai.AsyncOpenAI(**self._client_kwargs) as client:
+            self.client = client
+            try:
+                return await super().analyze_pdf(url, task, response_format)
+            finally:
+                self.client = None
 
     async def _create_api_input(
         self,

--- a/defog/llm/providers/deepseek_provider.py
+++ b/defog/llm/providers/deepseek_provider.py
@@ -573,12 +573,6 @@ class DeepSeekProvider(BaseLLMProvider):
             messages, previous_response_id, conversation_cache
         )
 
-        # Create OpenAI client pointed at DeepSeek
-        client = AsyncOpenAI(
-            base_url=self.base_url,
-            api_key=self.api_key,
-        )
-
         # Filter tools by budget
         tools = self.filter_tools_by_budget(tools, tool_handler)
 
@@ -604,34 +598,40 @@ class DeepSeekProvider(BaseLLMProvider):
             tool_dict = tool_handler.build_tool_dict(tools)
 
         try:
-            response = await client.chat.completions.create(**request_params)
+            # Close the underlying HTTPX connection pool deterministically,
+            # including when the request is cancelled or processing raises.
+            async with AsyncOpenAI(
+                base_url=self.base_url,
+                api_key=self.api_key,
+            ) as client:
+                response = await client.chat.completions.create(**request_params)
 
-            (
-                content,
-                tool_outputs,
-                input_tokens,
-                cached_input_tokens,
-                output_tokens,
-                output_tokens_details,
-                response_id,
-                repair_metadata,
-            ) = await self.process_response(
-                client=client,
-                response=response,
-                request_params=request_params,
-                tools=tools,
-                tool_dict=tool_dict,
-                response_format=response_format,
-                model=model,
-                post_tool_function=post_tool_function,
-                post_response_hook=post_response_hook,
-                tool_handler=tool_handler,
-                parallel_tool_calls=parallel_tool_calls,
-                return_tool_outputs_only=return_tool_outputs_only,
-                tool_sample_functions=sample_functions,
-                tool_result_preview_max_tokens=preview_max_tokens,
-                tool_phase_complete_message=tool_phase_complete_message,
-            )
+                (
+                    content,
+                    tool_outputs,
+                    input_tokens,
+                    cached_input_tokens,
+                    output_tokens,
+                    output_tokens_details,
+                    response_id,
+                    repair_metadata,
+                ) = await self.process_response(
+                    client=client,
+                    response=response,
+                    request_params=request_params,
+                    tools=tools,
+                    tool_dict=tool_dict,
+                    response_format=response_format,
+                    model=model,
+                    post_tool_function=post_tool_function,
+                    post_response_hook=post_response_hook,
+                    tool_handler=tool_handler,
+                    parallel_tool_calls=parallel_tool_calls,
+                    return_tool_outputs_only=return_tool_outputs_only,
+                    tool_sample_functions=sample_functions,
+                    tool_result_preview_max_tokens=preview_max_tokens,
+                    tool_phase_complete_message=tool_phase_complete_message,
+                )
         except (ProviderError, ToolError):
             raise
         except Exception as e:

--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -940,7 +940,6 @@ class OpenAIProvider(BaseLLMProvider):
             self.validate_pre_model_call_hook(pre_model_call_hook)
 
         t = time.time()
-        client_openai = AsyncOpenAI(base_url=self.base_url, api_key=self.api_key)
 
         # Filter tools based on budget before building params
         tools = self.filter_tools_by_budget(tools, tool_handler)
@@ -988,50 +987,55 @@ class OpenAIProvider(BaseLLMProvider):
             tool_dict = tool_handler.build_tool_dict(tools)
 
         try:
-            # Use Responses API
-            await self._apply_pre_model_call_hook(
-                request_params,
-                model,
-                pre_model_call_hook,
-                checkpoint_kind="initial_request",
-            )
-            if response_format and not tools:
-                response = await client_openai.responses.parse(
-                    **request_params,
-                    text_format=response_format,
+            # Close the underlying HTTPX connection pool deterministically,
+            # including when the request is cancelled or processing raises.
+            async with AsyncOpenAI(
+                base_url=self.base_url, api_key=self.api_key
+            ) as client_openai:
+                # Use Responses API
+                await self._apply_pre_model_call_hook(
+                    request_params,
+                    model,
+                    pre_model_call_hook,
+                    checkpoint_kind="initial_request",
                 )
-            else:
-                response = await client_openai.responses.create(**request_params)
+                if response_format and not tools:
+                    response = await client_openai.responses.parse(
+                        **request_params,
+                        text_format=response_format,
+                    )
+                else:
+                    response = await client_openai.responses.create(**request_params)
 
-            request_params["previous_response_id"] = response.id
-            request_params["input"] = []
+                request_params["previous_response_id"] = response.id
+                request_params["input"] = []
 
-            (
-                content,
-                tool_outputs,
-                input_tokens,
-                cached_input_tokens,
-                output_tokens,
-                completion_token_details,
-                response_id,
-            ) = await self.process_response(
-                client=client_openai,
-                response=response,
-                request_params=request_params,
-                tools=tools,
-                tool_dict=tool_dict,
-                response_format=response_format,
-                model=model,
-                post_tool_function=post_tool_function,
-                post_response_hook=post_response_hook,
-                pre_model_call_hook=pre_model_call_hook,
-                tool_handler=tool_handler,
-                parallel_tool_calls=parallel_tool_calls,
-                return_tool_outputs_only=return_tool_outputs_only,
-                tool_sample_functions=sample_functions,
-                tool_result_preview_max_tokens=preview_max_tokens,
-                tool_phase_complete_message=tool_phase_complete_message,
-            )
+                (
+                    content,
+                    tool_outputs,
+                    input_tokens,
+                    cached_input_tokens,
+                    output_tokens,
+                    completion_token_details,
+                    response_id,
+                ) = await self.process_response(
+                    client=client_openai,
+                    response=response,
+                    request_params=request_params,
+                    tools=tools,
+                    tool_dict=tool_dict,
+                    response_format=response_format,
+                    model=model,
+                    post_tool_function=post_tool_function,
+                    post_response_hook=post_response_hook,
+                    pre_model_call_hook=pre_model_call_hook,
+                    tool_handler=tool_handler,
+                    parallel_tool_calls=parallel_tool_calls,
+                    return_tool_outputs_only=return_tool_outputs_only,
+                    tool_sample_functions=sample_functions,
+                    tool_result_preview_max_tokens=preview_max_tokens,
+                    tool_phase_complete_message=tool_phase_complete_message,
+                )
         except PauseToolExecution as pause:
             # A tool suspended the loop; return a paused LLMResponse. The caller
             # persists response.messages + response.response_id and resumes via

--- a/defog/llm/providers/openrouter_provider.py
+++ b/defog/llm/providers/openrouter_provider.py
@@ -643,15 +643,6 @@ class OpenRouterProvider(BaseLLMProvider):
             messages, previous_response_id, conversation_cache
         )
 
-        # Create OpenAI client pointed at OpenRouter
-        client = AsyncOpenAI(
-            base_url=self.base_url,
-            api_key=self.api_key,
-            default_headers={
-                "X-Title": "defog",
-            },
-        )
-
         # Filter tools by budget
         tools = self.filter_tools_by_budget(tools, tool_handler)
 
@@ -678,43 +669,52 @@ class OpenRouterProvider(BaseLLMProvider):
             tool_dict = tool_handler.build_tool_dict(tools)
 
         try:
-            # Separate extra_body from regular params for the API call
-            extra_body = request_params.pop("extra_body", None)
+            # Close the underlying HTTPX connection pool deterministically,
+            # including when the request is cancelled or processing raises.
+            async with AsyncOpenAI(
+                base_url=self.base_url,
+                api_key=self.api_key,
+                default_headers={
+                    "X-Title": "defog",
+                },
+            ) as client:
+                # Separate extra_body from regular params for the API call
+                extra_body = request_params.pop("extra_body", None)
 
-            create_kwargs = {**request_params}
-            if extra_body:
-                create_kwargs["extra_body"] = extra_body
+                create_kwargs = {**request_params}
+                if extra_body:
+                    create_kwargs["extra_body"] = extra_body
 
-            response = await client.chat.completions.create(**create_kwargs)
+                response = await client.chat.completions.create(**create_kwargs)
 
-            (
-                content,
-                tool_outputs,
-                input_tokens,
-                cached_input_tokens,
-                output_tokens,
-                output_tokens_details,
-                response_id,
-                openrouter_cost,
-                repair_metadata,
-            ) = await self.process_response(
-                client=client,
-                response=response,
-                request_params=request_params,
-                tools=tools,
-                tool_dict=tool_dict,
-                response_format=response_format,
-                model=model,
-                post_tool_function=post_tool_function,
-                post_response_hook=post_response_hook,
-                tool_handler=tool_handler,
-                parallel_tool_calls=parallel_tool_calls,
-                return_tool_outputs_only=return_tool_outputs_only,
-                tool_sample_functions=sample_functions,
-                tool_result_preview_max_tokens=preview_max_tokens,
-                tool_phase_complete_message=tool_phase_complete_message,
-                extra_body=extra_body,
-            )
+                (
+                    content,
+                    tool_outputs,
+                    input_tokens,
+                    cached_input_tokens,
+                    output_tokens,
+                    output_tokens_details,
+                    response_id,
+                    openrouter_cost,
+                    repair_metadata,
+                ) = await self.process_response(
+                    client=client,
+                    response=response,
+                    request_params=request_params,
+                    tools=tools,
+                    tool_dict=tool_dict,
+                    response_format=response_format,
+                    model=model,
+                    post_tool_function=post_tool_function,
+                    post_response_hook=post_response_hook,
+                    tool_handler=tool_handler,
+                    parallel_tool_calls=parallel_tool_calls,
+                    return_tool_outputs_only=return_tool_outputs_only,
+                    tool_sample_functions=sample_functions,
+                    tool_result_preview_max_tokens=preview_max_tokens,
+                    tool_phase_complete_message=tool_phase_complete_message,
+                    extra_body=extra_body,
+                )
         except (ProviderError, ToolError):
             raise
         except Exception as e:

--- a/defog/llm/web_search.py
+++ b/defog/llm/web_search.py
@@ -59,80 +59,81 @@ async def web_search_tool(
         if provider in [LLMProvider.OPENAI, LLMProvider.OPENAI.value]:
             from openai import AsyncOpenAI
 
-            client = AsyncOpenAI(api_key=config.get("OPENAI_API_KEY"))
+            async with AsyncOpenAI(api_key=config.get("OPENAI_API_KEY")) as client:
+                tracker.update(20, "Initiating web search")
+                subtask_logger.log_search_status(question)
 
-            tracker.update(20, "Initiating web search")
-            subtask_logger.log_search_status(question)
+                # Build request parameters
+                request_params = {
+                    "model": model,
+                    "tools": [{"type": "web_search"}],
+                    "tool_choice": "required",
+                    "input": question,
+                    "max_output_tokens": max_tokens,
+                }
 
-            # Build request parameters
-            request_params = {
-                "model": model,
-                "tools": [{"type": "web_search"}],
-                "tool_choice": "required",
-                "input": question,
-                "max_output_tokens": max_tokens,
-            }
-
-            # Add structured output format if provided
-            if response_format:
-                schema = response_format.model_json_schema()
-                request_params["text"] = {
-                    "format": {
-                        "type": "json_schema",
-                        "name": schema.get("title", response_format.__name__),
-                        "schema": schema | {"additionalProperties": False},
+                # Add structured output format if provided
+                if response_format:
+                    schema = response_format.model_json_schema()
+                    request_params["text"] = {
+                        "format": {
+                            "type": "json_schema",
+                            "name": schema.get("title", response_format.__name__),
+                            "schema": schema | {"additionalProperties": False},
+                        }
                     }
+
+                # Add reasoning effort for o-series and gpt-5 models
+                if reasoning_effort and (
+                    model.startswith("o") or model.startswith("gpt-5")
+                ):
+                    request_params["reasoning"] = {
+                        "effort": reasoning_effort,
+                        "summary": "auto",
+                    }
+
+                response = await client.responses.create(**request_params)
+                tracker.update(80, "Processing search results")
+                subtask_logger.log_subtask(
+                    "Extracting citations and content", "processing"
+                )
+
+                usage = {
+                    "input_tokens": response.usage.input_tokens,
+                    "output_tokens": response.usage.output_tokens,
                 }
+                output_text = response.output_text
+                websites_cited = []
+                for output in response.output:
+                    if hasattr(output, "content") and output.content:
+                        for content in output.content:
+                            if content.annotations:
+                                for annotation in content.annotations:
+                                    websites_cited.append(
+                                        {
+                                            "url": annotation.url,
+                                            "title": annotation.title,
+                                        }
+                                    )
 
-            # Add reasoning effort for o-series and gpt-5 models
-            if reasoning_effort and (
-                model.startswith("o") or model.startswith("gpt-5")
-            ):
-                request_params["reasoning"] = {
-                    "effort": reasoning_effort,
-                    "summary": "auto",
+                subtask_logger.log_result_summary(
+                    "Web Search",
+                    {
+                        "websites_found": len(websites_cited),
+                        "tokens_used": usage["input_tokens"] + usage["output_tokens"],
+                    },
+                )
+
+                # Parse structured output if response_format provided
+                search_results = output_text
+                if response_format and output_text:
+                    search_results = response_format.model_validate_json(output_text)
+
+                return {
+                    "usage": usage,
+                    "search_results": search_results,
+                    "websites_cited": websites_cited,
                 }
-
-            response = await client.responses.create(**request_params)
-            tracker.update(80, "Processing search results")
-            subtask_logger.log_subtask("Extracting citations and content", "processing")
-
-            usage = {
-                "input_tokens": response.usage.input_tokens,
-                "output_tokens": response.usage.output_tokens,
-            }
-            output_text = response.output_text
-            websites_cited = []
-            for output in response.output:
-                if hasattr(output, "content") and output.content:
-                    for content in output.content:
-                        if content.annotations:
-                            for annotation in content.annotations:
-                                websites_cited.append(
-                                    {
-                                        "url": annotation.url,
-                                        "title": annotation.title,
-                                    }
-                                )
-
-            subtask_logger.log_result_summary(
-                "Web Search",
-                {
-                    "websites_found": len(websites_cited),
-                    "tokens_used": usage["input_tokens"] + usage["output_tokens"],
-                },
-            )
-
-            # Parse structured output if response_format provided
-            search_results = output_text
-            if response_format and output_text:
-                search_results = response_format.model_validate_json(output_text)
-
-            return {
-                "usage": usage,
-                "search_results": search_results,
-                "websites_cited": websites_cited,
-            }
 
         elif provider in [LLMProvider.ANTHROPIC, LLMProvider.ANTHROPIC.value]:
             import json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.9"
+version = "1.6.10"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_openai_client_lifecycle.py
+++ b/tests/test_openai_client_lifecycle.py
@@ -1,0 +1,143 @@
+"""Regression tests for deterministic OpenAI SDK client cleanup."""
+
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from defog.llm.exceptions import ProviderError
+from defog.llm.pdf_processor import BasePDFProcessor, OpenAIPDFProcessor
+from defog.llm.providers.deepseek_provider import DeepSeekProvider
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _is_async_openai_call(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    if isinstance(node.func, ast.Name):
+        return node.func.id == "AsyncOpenAI"
+    return isinstance(node.func, ast.Attribute) and node.func.attr == "AsyncOpenAI"
+
+
+def test_all_async_openai_clients_are_context_managed():
+    """Prevent new SDK clients from relying on garbage collection for cleanup."""
+    unmanaged_calls = []
+
+    for path in (PROJECT_ROOT / "defog").rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        managed_calls = {
+            id(item.context_expr)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncWith)
+            for item in node.items
+            if _is_async_openai_call(item.context_expr)
+        }
+
+        for node in ast.walk(tree):
+            if _is_async_openai_call(node) and id(node) not in managed_calls:
+                unmanaged_calls.append(
+                    f"{path.relative_to(PROJECT_ROOT)}:{node.lineno}"
+                )
+
+    assert not unmanaged_calls, (
+        "AsyncOpenAI clients must be created with `async with`: "
+        + ", ".join(unmanaged_calls)
+    )
+
+
+class _FakeAsyncOpenAI:
+    instances = []
+    response = object()
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.entered = False
+        self.exited = False
+        self.chat = SimpleNamespace(
+            completions=SimpleNamespace(
+                create=AsyncMock(return_value=self.response),
+            )
+        )
+        self.instances.append(self)
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        self.exited = True
+
+
+def _make_deepseek_provider(monkeypatch, process_response):
+    import openai
+
+    _FakeAsyncOpenAI.instances.clear()
+    monkeypatch.setattr(openai, "AsyncOpenAI", _FakeAsyncOpenAI)
+
+    provider = DeepSeekProvider(api_key="sk-test")
+    provider.process_response = process_response
+    provider.persist_conversation_history = AsyncMock()
+    return provider
+
+
+@pytest.mark.asyncio
+async def test_deepseek_closes_client_after_success(monkeypatch):
+    provider = _make_deepseek_provider(
+        monkeypatch,
+        AsyncMock(return_value=("ok", [], 1, 0, 1, None, "response-id", None)),
+    )
+
+    response = await provider.execute_chat(
+        messages=[{"role": "user", "content": "hello"}],
+        model="deepseek-v4-pro",
+    )
+
+    assert response.content == "ok"
+    assert len(_FakeAsyncOpenAI.instances) == 1
+    assert _FakeAsyncOpenAI.instances[0].entered
+    assert _FakeAsyncOpenAI.instances[0].exited
+
+
+@pytest.mark.asyncio
+async def test_deepseek_closes_client_after_failure(monkeypatch):
+    provider = _make_deepseek_provider(
+        monkeypatch,
+        AsyncMock(side_effect=RuntimeError("processing failed")),
+    )
+
+    with pytest.raises(ProviderError, match="processing failed"):
+        await provider.execute_chat(
+            messages=[{"role": "user", "content": "hello"}],
+            model="deepseek-v4-pro",
+        )
+
+    assert len(_FakeAsyncOpenAI.instances) == 1
+    assert _FakeAsyncOpenAI.instances[0].entered
+    assert _FakeAsyncOpenAI.instances[0].exited
+
+
+@pytest.mark.asyncio
+async def test_openai_pdf_processor_closes_client_after_analysis(monkeypatch):
+    import openai
+
+    expected = object()
+    analyze_pdf = AsyncMock(return_value=expected)
+    monkeypatch.setattr(BasePDFProcessor, "analyze_pdf", analyze_pdf)
+    monkeypatch.setattr(openai, "AsyncOpenAI", _FakeAsyncOpenAI)
+    _FakeAsyncOpenAI.instances.clear()
+
+    processor = OpenAIPDFProcessor(api_key="sk-test")
+    result = await processor.analyze_pdf("https://example.com/file.pdf", "summarize")
+
+    assert result is expected
+    analyze_pdf.assert_awaited_once_with(
+        "https://example.com/file.pdf", "summarize", None
+    )
+    assert processor.client is None
+    assert len(_FakeAsyncOpenAI.instances) == 1
+    assert _FakeAsyncOpenAI.instances[0].entered
+    assert _FakeAsyncOpenAI.instances[0].exited

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.6.7"
+version = "1.6.10"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- manage every repository-owned AsyncOpenAI client with an async context manager
- cover OpenAI, OpenRouter, DeepSeek, citations, web search, code interpreter, and PDF processing
- add regression tests for DeepSeek success/failure cleanup, PDF cleanup, and package-wide client ownership

## Testing

- 4 lifecycle tests passed
- 33 targeted tests passed; 23 skipped
- Ruff lint, format, compileall, and git diff checks passed
- Broader suite excluding three pre-existing collection blockers: 396 passed, 136 skipped, 1 xfailed; remaining failures require unavailable API credentials or are unrelated existing failures

## Existing suite blockers

- duckdb and Pillow are not installed in the current environment
- tests/test_pdf_processor.py imports a module-level analyze_pdf function that is absent on main