### PR TITLE
Update GPT-5.6 Luna and Terra prices

### DIFF
--- a/defog/llm/cost/models.py
+++ b/defog/llm/cost/models.py
@@ -52,14 +52,14 @@ MODEL_COSTS = {
         "output_cost_per1k": 0.03,
     },
     "gpt-5.6-terra": {
-        "input_cost_per1k": 0.0025,
-        "cached_input_cost_per1k": 0.00025,
-        "output_cost_per1k": 0.015,
+        "input_cost_per1k": 0.002,
+        "cached_input_cost_per1k": 0.0002,
+        "output_cost_per1k": 0.012,
     },
     "gpt-5.6-luna": {
-        "input_cost_per1k": 0.001,
-        "cached_input_cost_per1k": 0.0001,
-        "output_cost_per1k": 0.006,
+        "input_cost_per1k": 0.0002,
+        "cached_input_cost_per1k": 0.00002,
+        "output_cost_per1k": 0.0012,
     },
     "gpt-5.5": {
         "input_cost_per1k": 0.005,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.10"
+version = "1.6.11"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_cost_calculator.py
+++ b/tests/test_cost_calculator.py
@@ -105,14 +105,16 @@ def test_gpt_5_5_pricing_matches_openai_rate_card():
 
 
 def test_gpt_5_6_pricing_matches_openai_rate_card():
-    # Per https://developers.openai.com/api/docs/pricing as of 2026-07-12.
+    # Per https://developers.openai.com/api/docs/pricing as of 2026-07-30.
     # Sol (and its gpt-5.6 alias): $5 / $0.50 cached / $30 per 1M tokens.
     assert _cost("gpt-5.6") == pytest.approx(3.5)
     assert _cost("gpt-5.6-sol", cached=1000) == pytest.approx(3.55)
-    # Terra: $2.50 / $0.25 cached / $15 per 1M tokens.
-    assert _cost("gpt-5.6-terra", cached=1000) == pytest.approx(1.775)
-    # Luna: $1 / $0.10 cached / $6 per 1M tokens.
-    assert _cost("gpt-5.6-luna", cached=1000) == pytest.approx(0.71)
+    # Terra: $2 / $0.20 cached / $12 per 1M tokens.
+    assert _cost("gpt-5.6-terra") == pytest.approx(1.4)
+    assert _cost("gpt-5.6-terra", cached=1000) == pytest.approx(1.42)
+    # Luna: $0.20 / $0.02 cached / $1.20 per 1M tokens.
+    assert _cost("gpt-5.6-luna") == pytest.approx(0.14)
+    assert _cost("gpt-5.6-luna", cached=1000) == pytest.approx(0.142)
 
 
 def test_is_model_supported():

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ wheels = [
 
 [[package]]
 name = "defog"
-version = "1.6.10"
+version = "1.6.11"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
OpenAI reduced the standard API prices for GPT-5.6 Luna and Terra on July 30, 2026. Defog still used the original launch prices, so `cost_in_cents` reported costs that were too high for these models.

This change updates the input, cached-input, and output rates from the official OpenAI price table. GPT-5.6 Sol and the `gpt-5.6` alias are unchanged. It also sets the package version to 1.6.11 for release.

Tests: `PYTHONPATH=. uv run python -m pytest tests/test_cost_calculator.py` (68 passed). Ruff and formatting checks also pass.