### PR TITLE
Add OpenAI Flex processing support

### DIFF
--- a/defog/llm/providers/openai_provider.py
+++ b/defog/llm/providers/openai_provider.py
@@ -132,6 +132,7 @@ class OpenAIProvider(BaseLLMProvider):
         response_format,
         tool_handler: ToolHandler,
         preview_max_tokens: Optional[int],
+        flex_processing: bool,
     ) -> Dict[str, Any]:
         """Build Responses API params to resume a paused run.
 
@@ -189,6 +190,7 @@ class OpenAIProvider(BaseLLMProvider):
             timeout=timeout,
             parallel_tool_calls=parallel_tool_calls,
             previous_response_id=previous_response_id,
+            flex_processing=flex_processing,
         )
         request_params["input"] = input_items
         instructions = "\n\n".join(p for p in instructions_parts if p.strip())
@@ -394,6 +396,7 @@ class OpenAIProvider(BaseLLMProvider):
         reasoning_effort: Optional[str] = None,
         parallel_tool_calls: bool = True,
         previous_response_id: Optional[str] = None,
+        flex_processing: bool = False,
         **kwargs,
     ) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
         """
@@ -421,6 +424,9 @@ class OpenAIProvider(BaseLLMProvider):
         # If a previous response id is provided, add it for continuation
         if previous_response_id:
             request_params["previous_response_id"] = previous_response_id
+
+        if flex_processing:
+            request_params["service_tier"] = "flex"
 
         if tools:
             function_specs = get_function_specs(tools, "openai")
@@ -913,6 +919,7 @@ class OpenAIProvider(BaseLLMProvider):
         previous_response_id: Optional[str] = None,
         tool_phase_complete_message: str = "exploration done, generating answer",
         resume_tool_results: Optional[Dict[str, Any]] = None,
+        flex_processing: bool = False,
         **kwargs,
     ) -> LLMResponse:
         """Execute a chat completion with OpenAI."""
@@ -963,6 +970,7 @@ class OpenAIProvider(BaseLLMProvider):
                 response_format,
                 tool_handler,
                 preview_max_tokens,
+                flex_processing,
             )
         else:
             request_params, messages = self.build_params(
@@ -979,6 +987,7 @@ class OpenAIProvider(BaseLLMProvider):
                 timeout=timeout,
                 parallel_tool_calls=parallel_tool_calls,
                 previous_response_id=previous_response_id,
+                flex_processing=flex_processing,
             )
 
         # Build a tool dict if needed

--- a/defog/llm/utils.py
+++ b/defog/llm/utils.py
@@ -126,6 +126,7 @@ async def chat_async(
     task_budget: Optional[Union[int, Dict[str, Any]]] = None,
     conversation_cache: Optional[ConversationCache] = None,
     resume_tool_results: Optional[Dict[str, Any]] = None,
+    flex_processing: bool = False,
 ) -> LLMResponse:
     """
     Execute a chat completion with explicit provider parameter.
@@ -143,6 +144,8 @@ async def chat_async(
         backup_model: Fallback model to use on retry
         backup_provider: Fallback provider to use on retry
         reasoning_effort: Reasoning effort level (o1/o3 models only)
+        flex_processing: OpenAI only. When True, use OpenAI's lower-cost,
+            higher-latency Flex processing tier.
         tools: List of tools the model can call
         tool_choice: Tool calling behavior ("auto", "required", function name)
         max_retries: Maximum number of retry attempts
@@ -230,6 +233,9 @@ async def chat_async(
 
     if providers is not None and _provider_value(provider) != "openrouter":
         raise ValueError("providers is only supported when provider is 'openrouter'.")
+
+    if flex_processing and _provider_value(provider) != "openai":
+        raise ValueError("flex_processing is only supported when provider is 'openai'.")
 
     # Human-in-the-loop resume is only wired for anthropic and openai.
     if resume_tool_results is not None:
@@ -406,6 +412,8 @@ async def chat_async(
                 "conversation_cache": conversation_cache,
                 "resume_tool_results": resume_tool_results,
             }
+            if flex_processing and _provider_value(current_provider) == "openai":
+                execute_kwargs["flex_processing"] = True
             if (
                 providers is not None
                 and _provider_value(current_provider) == "openrouter"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -250,11 +250,13 @@ async def chat_async(
     previous_response_id: Optional[str] = None,
     strict_tools: bool = True,
     task_budget: Optional[Union[int, Dict[str, Any]]] = None,
+    flex_processing: bool = False,
 ) -> LLMResponse
 ```
 
 - `base_url`: Custom base URL for the provider's API endpoint (e.g. for proxies or self-hosted models). Overrides the default URL for the primary provider. Can also be set via environment variables (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, etc.) or through `LLMConfig`.
 - `providers`: OpenRouter-only upstream provider routing. Pass a list such as `["azure"]` to restrict routing to those providers (`provider.only`), or a full routing dict such as `{"order": ["deepinfra/turbo"], "allow_fallbacks": False}`.
+- `flex_processing`: OpenAI-only. Set to `True` to send requests using OpenAI's lower-cost, higher-latency Flex processing tier. The default `False` leaves the service tier unset.
 - `tool_result_preview_max_tokens`: Optional token budget for the tool output preview that is sent back to the LLM. Full tool outputs are still stored on the response object.
 - `tool_sample_functions`: Optional mapping of tool name to a callable (or a single callable) that returns a sampled version of the tool output before it is passed back to the LLM.
 - `strict_tools`: When `True` (default), Anthropic uses constrained decoding to enforce tool parameter schemas (`strict: true`). Set to `False` to skip constrained decoding for lower latency with tool-heavy agents. Only affects the Anthropic provider.

--- a/docs/llm/core-chat-functions.md
+++ b/docs/llm/core-chat-functions.md
@@ -111,10 +111,11 @@ response = await chat_async(
 # OpenAI
 response = await chat_async(
     provider=LLMProvider.OPENAI,
-    model="gpt-4o",
+    model="gpt-5-mini",
     messages=messages,
     tools=[my_function],
-    tool_choice="auto"
+    tool_choice="auto",
+    flex_processing=True,  # Lower cost; requests may take longer
 )
 
 # Anthropic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "defog"
-version = "1.6.11"
+version = "1.6.12"
 description = "Defog is a Python library that helps you generate data queries from natural language questions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_openai_flex_processing.py
+++ b/tests/test_openai_flex_processing.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from defog.llm.config import LLMConfig
+from defog.llm.providers.base import LLMResponse
+from defog.llm.providers.openai_provider import OpenAIProvider
+from defog.llm.utils import chat_async
+
+
+def test_build_params_enables_flex_service_tier():
+    provider = OpenAIProvider(api_key="sk-test")
+
+    request_params, _ = provider.build_params(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="gpt-5-mini",
+        flex_processing=True,
+    )
+
+    assert request_params["service_tier"] == "flex"
+
+
+def test_build_params_omits_service_tier_by_default():
+    provider = OpenAIProvider(api_key="sk-test")
+
+    request_params, _ = provider.build_params(
+        messages=[{"role": "user", "content": "Hello"}],
+        model="gpt-5-mini",
+    )
+
+    assert "service_tier" not in request_params
+
+
+@pytest.mark.asyncio
+async def test_chat_async_forwards_flex_processing(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    async def fake_execute_chat(self, **kwargs):
+        captured.update(kwargs)
+        return LLMResponse(
+            content="ok",
+            model=kwargs["model"],
+            time=0.0,
+            input_tokens=1,
+            output_tokens=1,
+        )
+
+    monkeypatch.setattr(OpenAIProvider, "execute_chat", fake_execute_chat)
+
+    response = await chat_async(
+        provider="openai",
+        model="gpt-5-mini",
+        messages=[{"role": "user", "content": "Hello"}],
+        flex_processing=True,
+        config=LLMConfig(api_keys={"openai": "sk-test"}),
+        max_retries=1,
+    )
+
+    assert response.content == "ok"
+    assert captured["flex_processing"] is True
+
+
+@pytest.mark.asyncio
+async def test_chat_async_rejects_flex_processing_for_non_openai_provider():
+    with pytest.raises(ValueError, match="only supported.*openai"):
+        await chat_async(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            messages=[{"role": "user", "content": "Hello"}],
+            flex_processing=True,
+        )


### PR DESCRIPTION
## Summary

- add an OpenAI-only flex_processing option to chat_async
- map Flex requests to service_tier=flex across initial, tool-chaining, and resume flows
- reject Flex processing for non-OpenAI providers
- document the option and add focused unit coverage
- bump the package version to 1.6.12

## Validation

- 27 passed, 3 skipped in the focused provider regression suite
- Ruff checks passed
- uv build produced and verified the 1.6.12 wheel and source distribution